### PR TITLE
AGR-949  Increased boost on category:gene to 1.1

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -88,7 +88,7 @@ public class SearchService {
 
         //gene category boost
         functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("category","gene"),
-                ScoreFunctionBuilders.weightFactorFunction(1.0001F)));
+                ScoreFunctionBuilders.weightFactorFunction(1.1F)));
 
         functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("name_key.keyword",q),
                 ScoreFunctionBuilders.weightFactorFunction(1000F)));

--- a/agr_api/src/test/groovy/org/alliancegenome/api/AutocompleteIntegrationSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/AutocompleteIntegrationSpec.groovy
@@ -54,10 +54,12 @@ class AutocompleteIntegrationSpec extends Specification {
 
         then:
         results
-        results.size() > 2
+        results.size() > 4
         results.get(0).category == category
         results.get(1).category == category
         results.get(2).category == category
+        results.get(3).category == category
+        results.get(4).category == category
 
         where:
         category | query


### PR DESCRIPTION
 so that zebrafish a & b genes get bumped above alleles