### PR TITLE
Agr 940 1.7 fix

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/translators/document/GeneTranslator.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/translators/document/GeneTranslator.java
@@ -75,13 +75,16 @@ public class GeneTranslator extends EntityDocumentTranslator<Gene, GeneDocument>
                 terms.add(term);
             }
         }
+
         geneDocument.setBiologicalProcess(collectGoTermNames(goTerms.get("biological_process")));
         geneDocument.setCellularComponent(collectGoTermNames(goTerms.get("cellular_component")));
         geneDocument.setMolecularFunction(collectGoTermNames(goTerms.get("molecular_function")));
 
-        geneDocument.setBiologicalProcessWithParents(collectGoTermParentNames(goTerms.get("biological_process")));
-        geneDocument.setCellularComponentWithParents(collectGoTermParentNames(goTerms.get("cellular_component")));
-        geneDocument.setMolecularFunctionWithParents(collectGoTermParentNames(goTerms.get("molecular_function")));
+        Set<GOTerm> allParentTerms = gene.getGoParentTerms();
+
+        geneDocument.setBiologicalProcessWithParents(collectGoTermParentNames(allParentTerms,"biological_process"));
+        geneDocument.setCellularComponentWithParents(collectGoTermParentNames(allParentTerms,"cellular_component"));
+        geneDocument.setMolecularFunctionWithParents(collectGoTermParentNames(allParentTerms,"molecular_function"));
 
         // This code is duplicated in Gene and Feature should be pulled out into its own translator
         ArrayList<String> secondaryIds = new ArrayList<>();
@@ -227,10 +230,9 @@ public class GeneTranslator extends EntityDocumentTranslator<Gene, GeneDocument>
                 .stream().map(GOTerm::getName).collect(Collectors.toList());
     }
 
-    protected List<String> collectGoTermParentNames(Set<GOTerm> terms) {
+    protected List<String> collectGoTermParentNames(Set<GOTerm> terms, String subset) {
         return CollectionUtils.emptyIfNull(terms).stream()
-                .map(GOTerm::getParentTerms)
-                .flatMap(Set::stream)
+                .filter(term -> term.getType().equals(subset))
                 .map(GOTerm::getName)
                 .collect(Collectors.toList());
     }

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/GOTerm.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/GOTerm.java
@@ -43,9 +43,9 @@ public class GOTerm extends Ontology {
     public Set<GOTerm> getParentTerms() {
         Set<GOTerm> parentTerms = new HashSet<>();
 
-        isAParents.stream().forEach(parent -> { parentTerms.addAll(parent.getIsAParents());});
-        partOfParents.stream().forEach(parent -> {parentTerms.addAll(parent.getPartOfParents());});
-
+        isAParents.stream().forEach(parent -> { parentTerms.addAll(parent.getParentTerms());});
+        partOfParents.stream().forEach(parent -> {parentTerms.addAll(parent.getParentTerms());});
+                
         parentTerms.add(this);
 
         return parentTerms;


### PR DESCRIPTION
Collected parent terms into one bucket first, then split up into the individual GO namespaces