### PR TITLE
Agr 1297 - only include biological process, cellular component and molecular function terms in GO index

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/GoRepository.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/GoRepository.java
@@ -16,7 +16,7 @@ public class GoRepository extends Neo4jRepository<GOTerm> {
     }
 
     public List<String> getAllGoKeys() {
-        String query = "MATCH (g:GOTerm) RETURN distinct g.primaryKey";
+        String query = "MATCH (g:GOTerm) WHERE g.type in ['biological_process','cellular_component','molecular_function'] RETURN distinct g.primaryKey";
         Result r = queryForResult(query);
         Iterator<Map<String, Object>> i = r.iterator();
 


### PR DESCRIPTION
(which excluded the empty string and "other" that showed up in 2.0)