### PR TITLE
load all DiseaseEntityJoin nodes into memory / cache

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/query/FieldFilter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/query/FieldFilter.java
@@ -20,6 +20,7 @@ public enum FieldFilter {
     PHENOTYPE("termName"),
     ASSOCIATION_TYPE("associationType"),
     ORTHOLOG("filter.orthologGene"),
+    EXPERIMENT("filter.experiment"),
     ORTHOLOG_SPECIES("filter.orthologGeneSpecies");
     private String name;
 

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/DiseaseAnnotation.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/DiseaseAnnotation.java
@@ -37,6 +37,7 @@ public class DiseaseAnnotation implements Comparable<DiseaseAnnotation> {
     private List<EvidenceCode> evidenceCodes;
     @JsonView({View.DiseaseAnnotation.class})
     private String associationType;
+    private int sortOrder;
     private List<DiseaseEntityJoin> diseaseEntityJoinSet;
 
     @JsonIgnore

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/DiseaseEntityJoin.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/DiseaseEntityJoin.java
@@ -29,6 +29,7 @@ public class DiseaseEntityJoin extends EntityJoin {
     // Make sure this is singular here
     // might turn into a collection i
     private String dataProvider;
+    private int sortOrder;
 
     public Source getSource() {
         SourceService service = new SourceService();

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/Species.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/Species.java
@@ -26,7 +26,8 @@ public class Species extends Neo4jEntity implements Comparable<Species> {
 
     @JsonView({View.Default.class})
     private String name;
-    
+    private int phylogeneticOrder;
+
     private String species;
     
     @Relationship(type = "CREATED_BY")


### PR DESCRIPTION
Since I could not find any way in Neo4j to write performant queries (sorting and the including child clause) always made queries in some way slow. In the last iteration I got a fairly fast retrieval for just 10 records, however, when retrieving 100 or even all for high-level terms (downloads) it was painfully slow. 
Solution: 

1. Get all DiseaseEntityJoin nodes into Java memory 

2. create a map for every disease ID containing all Disease Annotation including substructure

When a request for a given disease ID comes in I just have to get the list of annotations from the static map and return it.

Downside: The first request will take somewhere between 90 and 200 seconds to pre-load the map.
The total number of nodes is currently about 170K, which should not have a big memory imprint at this time.