### PR TITLE
AGR-1899 Add support for finding features by hgvs name

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/QueryManipulationService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/QueryManipulationService.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class QueryManipulationService {
 
-    private static final String ESCAPE_CHARS = "[<>/\\[\\]()]";
+    private static final String ESCAPE_CHARS = "[/\\[\\]()]";
     private static final Pattern LUCENE_PATTERN = Pattern.compile(ESCAPE_CHARS);
     private static final String REPLACEMENT_STRING = "\\\\$0";
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -110,6 +110,7 @@ public class SearchService {
         for (String token : tokens) {
             MultiMatchQueryBuilder mmq = multiMatchQuery(token);
             searchHelper.getSearchFields().stream().forEach(mmq::field);
+            mmq.analyzer("keyword");
             mmq.fields(searchHelper.getBoostMap());
             mmq.queryName(token);
             functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(mmq, ScoreFunctionBuilders.weightFactorFunction(10.0F)));

--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
@@ -159,6 +159,9 @@ public class SearchHelper {
             add("molecularFunctionWithParents");
             add("phenotypeStatements");
             add("primaryKey");
+            add("relatedVariants");
+            add("relatedVariants.keyword");
+            add("relatedVariants.standardText");
             add("symbol");
             add("symbol.autocomplete");
             add("symbol.keyword");

--- a/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryMatchIntegrationSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryMatchIntegrationSpec.groovy
@@ -81,6 +81,12 @@ class QueryMatchIntegrationSpec extends AbstractSpec {
         "AGR-865"  | "MGI:5502315"             | "Rradtm1.1(KOMP)Vlcg"
         "AGR-865"  | "FB:FBal0151567"          | "rut[EP399]"
 
+        //variant hgvs names for alleles
+        "AGR-1899" | "MGI:5316784"               | "NC_000083.6:g.75273979T>A"
+        "AGR-1899" | "ZFIN:ZDB-ALT-161003-18649" | "NC_007116.7:g.23258951T>A"
+        "AGR-1899" | "RGD:13209000"              | "NC_005118.4:g.55252024_55252027del"
+        "AGR-1899" | "FB:FBal0000019"            | "NT_033777.3:g.7087759G>A"
+
         //diseasesViaExperiment found by allele and gene names
         "AGR-866"  | "DOID:11726"              | "tm1502"
         "AGR-866"  | "DOID:0050692"            | "mi289a"

--- a/agr_api/src/test/groovy/org/alliancegenome/api/tests/unit/QueryManipulationUnitSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/tests/unit/QueryManipulationUnitSpec.groovy
@@ -33,8 +33,8 @@ class QueryManipulationUnitSpec extends Specification {
         "__primaryKey:DOID:10314"             | "primaryKey:DOID\\:10314"
         "si:ch211-133d24.26p"                 | "si\\:ch211-133d24.26p"
         "en::ftz::Mmus\\En1"                  | "en\\:\\:ftz\\:\\:Mmus\\En1"
-        "Foxn1<sup>nu-StL</sup> (Mmu)"        | "Foxn1\\<sup\\>nu-StL\\<\\/sup\\> \\(Mmu\\)"
-        "Gt(ROSA)26Sor<sup>tm1(Pik3ca*H1047R)Egan</sup> (Mmu)" | "Gt\\(ROSA\\)26Sor\\<sup\\>tm1\\(Pik3ca*H1047R\\)Egan\\<\\/sup\\> \\(Mmu\\)"
+        "Foxn1<sup>nu-StL</sup> (Mmu)"        | "Foxn1<sup>nu-StL<\\/sup> \\(Mmu\\)"
+        "Gt(ROSA)26Sor<sup>tm1(Pik3ca*H1047R)Egan</sup> (Mmu)" | "Gt\\(ROSA\\)26Sor<sup>tm1\\(Pik3ca*H1047R\\)Egan<\\/sup> \\(Mmu\\)"
         "rut[EP399] (Dme)"                    | "rut\\[EP399\\] \\(Dme\\)"
     }
 

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/cache/IndexerCache.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/cache/IndexerCache.java
@@ -20,6 +20,7 @@ public class IndexerCache {
     protected Map<String, Set<String>> genes = new HashMap<>();
     protected Map<String, Set<String>> models = new HashMap<>();
     protected Map<String, Set<String>> phenotypeStatements = new HashMap<>();
+    protected Map<String, Set<String>> relatedVariants = new HashMap<>();
 
     protected void addCachedFields(SearchableItemDocument document) {
         String id = document.getPrimaryKey();
@@ -31,7 +32,7 @@ public class IndexerCache {
         document.setGenes(genes.get(id));
         document.setModels(models.get(id));
         document.setPhenotypeStatements(phenotypeStatements.get(id));
-
+        document.setRelatedVariants(relatedVariants.get(id));
     }
 
 }

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/document/SearchableItemDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/document/SearchableItemDocument.java
@@ -73,6 +73,7 @@ public class SearchableItemDocument extends ESDocument {
     Set<String> molecularFunctionWithParents = new HashSet<>();
     Set<String> parentDiseaseNames = new HashSet<>();
     Set<String> phenotypeStatements = new HashSet<>();
+    Set<String> relatedVariants = new HashSet<>();
     Set<String> secondaryIds = new HashSet<>();
     Set<String> strictOrthologySymbols = new HashSet<>();
     Set<String> soTermNameWithParents = new HashSet<>();

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
@@ -74,6 +74,7 @@ public class Mapping extends Builder {
                 .keyword()
                 .build();
         new FieldBuilder(builder, "primaryKey", "keyword").build();
+        new FieldBuilder(builder, "relatedVariants", "text").keyword().standardText().build();
         new FieldBuilder(builder, "symbol", "text").analyzer("symbols")
                 .autocomplete()
                 .htmlSmoosh()

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/AlleleIndexerRepository.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/AlleleIndexerRepository.java
@@ -63,6 +63,9 @@ public class AlleleIndexerRepository extends Neo4jRepository {
         log.info("Building allele -> phenotype statements map");
         alleleDocumentCache.setPhenotypeStatements(getPhenotypeStatementsMap(species));
 
+        log.info("Building allele -> variant name map");
+        alleleDocumentCache.setRelatedVariants(getRelatedVariants(species));
+
         log.info("Building allele -> variant types map");
         alleleDocumentCache.setVariantTypesMap(getVariantTypesMap(species));
 
@@ -128,6 +131,14 @@ public class AlleleIndexerRepository extends Neo4jRepository {
         query += " RETURN distinct a.primaryKey, phenotype.phenotypeStatement ";
 
         return getMapSetForQuery(query, "a.primaryKey", "phenotype.phenotypeStatement", getSpeciesParams(species));
+    }
+
+    public Map<String, Set<String>> getRelatedVariants(String species) {
+        String query = "MATCH (species:Species)--(:Gene)-[:IS_ALLELE_OF]-(a:Allele)--(v:Variant) ";
+        query += getSpeciesWhere(species);
+        query += " RETURN distinct a.primaryKey as id, v.hgvsNomenclature as value";
+
+        return getMapSetForQuery(query, getSpeciesParams(species));
     }
 
     public Map<String, Set<String>> getVariantTypesMap(String species) {


### PR DESCRIPTION
I had some trouble because it turned out that <> aren't chars that Lucene needs to have escaped, but we were escaping them. I also tweaked the part of our ES query that adds a 10x boost for each term matched so that it doesn't further tokenize the matches. I'm not yet 100% confident about what side effects that change might have, but I'll have another PR coming in behind this one with some test infrastructure tweaks and that's where I'll be able to see any problems.