### PR TITLE
Removed standard filter from classic_text field type

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/settings/SiteIndexSettings.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/settings/SiteIndexSettings.java
@@ -69,7 +69,7 @@ public class SiteIndexSettings extends Settings {
                          .startObject("classic_text")
                             .field("type","custom")
                             .field("tokenizer","classic")
-                            .array("filter", new String[]{"apostrophe","standard","lowercase"})
+                            .array("filter", new String[]{"apostrophe","lowercase"})
                          .endObject()
                         .startObject("letter_text")
                             .field("type","custom")


### PR DESCRIPTION
The standard filter didn't do anything, and throws an error in ES 7.x now that it's gone