### PR TITLE
AGR-2254 Set track_total_hits to true for ES searches

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/SearchDAO.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/SearchDAO.java
@@ -68,6 +68,7 @@ public class SearchDAO extends ESDAO {
         searchSourceBuilder.query(query);
         searchSourceBuilder.size(limit);
         searchSourceBuilder.from(offset);
+        searchSourceBuilder.trackTotalHits(true);
 
         if(sort != null && sort.equals("alphabetical")) {
             searchSourceBuilder.sort("name.keyword", SortOrder.ASC);


### PR DESCRIPTION
There was a breaking change in ES that limits reported hits to 10,000 without setting track_total_hits to true. 