### PR TITLE
remove illegal access warning from groovy by upgrading from 2.4.6 to 3.0.4

### DIFF
--- a/agr_api/pom.xml
+++ b/agr_api/pom.xml
@@ -114,7 +114,7 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>2.4.6</version>
+			<version>3.0.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/agr_api/pom.xml
+++ b/agr_api/pom.xml
@@ -26,19 +26,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>elastic</id>
-			<name>elasticsearch-releases</name>
-			<url>https://artifacts.elastic.co/maven</url>
-		</repository>
-		<repository>
-			<id>nexus</id>
-			<name>nexus</name>
-			<url>https://repository.jboss.org</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>commons-io</groupId>
@@ -114,8 +101,9 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>3.0.4</version>
+			<version>3.0.5</version>
 			<scope>test</scope>
+			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>org.spockframework</groupId>
@@ -194,7 +182,7 @@
 			<plugin>
 				<groupId>org.codehaus.gmavenplus</groupId>
 				<artifactId>gmavenplus-plugin</artifactId>
-				<version>1.0</version>
+				<version>1.9.1</version>
 				<executions>
 					<execution>
 						<goals>
@@ -202,7 +190,6 @@
 							<goal>addTestSources</goal>
 							<goal>generateStubs</goal>
 							<goal>compile</goal>
-							<goal>testCompile</goal>
 							<goal>removeStubs</goal>
 							<goal>removeTestStubs</goal>
 						</goals>

--- a/agr_cacher/pom.xml
+++ b/agr_cacher/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>2.4.6</version>
+			<version>3.0.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/agr_cacher/pom.xml
+++ b/agr_cacher/pom.xml
@@ -63,8 +63,9 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>3.0.4</version>
+			<version>3.0.5</version>
 			<scope>test</scope>
+			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>org.spockframework</groupId>

--- a/agr_elasticsearch_util/pom.xml
+++ b/agr_elasticsearch_util/pom.xml
@@ -19,14 +19,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>elastic</id>
-			<name>elasticsearch-releases</name>
-			<url>https://artifacts.elastic.co/maven</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.alliancegenome</groupId>

--- a/agr_indexer/pom.xml
+++ b/agr_indexer/pom.xml
@@ -33,8 +33,8 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>3.0.4</version>
-			<scope>test</scope>
+			<version>3.0.5</version>
+			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>org.spockframework</groupId>
@@ -64,14 +64,6 @@
 			<version>${jackson.version}</version>
 		</dependency>
 	</dependencies>
-
-	<repositories>
-		<repository>
-			<id>elastic</id>
-			<name>elasticsearch-releases</name>
-			<url>https://artifacts.elastic.co/maven</url>
-		</repository>
-	</repositories>
 
 	<build>
 		<finalName>${project.artifactId}</finalName>
@@ -115,7 +107,7 @@
 			<plugin>
 				<groupId>org.codehaus.gmavenplus</groupId>
 				<artifactId>gmavenplus-plugin</artifactId>
-				<version>1.0</version>
+				<version>1.9.1</version>
 				<executions>
 					<execution>
 						<goals>
@@ -123,7 +115,6 @@
 							<goal>addTestSources</goal>
 							<goal>generateStubs</goal>
 							<goal>compile</goal>
-							<goal>testCompile</goal>
 							<goal>removeStubs</goal>
 							<goal>removeTestStubs</goal>
 						</goals>
@@ -201,7 +192,7 @@
 									<pluginExecutionFilter>
 										<groupId>org.codehaus.gmavenplus</groupId>
 										<artifactId>gmavenplus-plugin</artifactId>
-										<versionRange>[1.0,)</versionRange>
+										<versionRange>[1.9,)</versionRange>
 										<goals>
 											<goal>addSources</goal>
 											<goal>addTestSources</goal>

--- a/agr_indexer/pom.xml
+++ b/agr_indexer/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>2.4.6</version>
+			<version>3.0.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/agr_intermine_data_extractor/pom.xml
+++ b/agr_intermine_data_extractor/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>2.4.6</version>
+			<version>3.0.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/agr_intermine_data_extractor/pom.xml
+++ b/agr_intermine_data_extractor/pom.xml
@@ -47,8 +47,9 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>3.0.4</version>
+			<version>3.0.5</version>
 			<scope>test</scope>
+			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>org.spockframework</groupId>
@@ -106,7 +107,7 @@
 			<plugin>
 				<groupId>org.codehaus.gmavenplus</groupId>
 				<artifactId>gmavenplus-plugin</artifactId>
-				<version>1.0</version>
+				<version>1.9.1</version>
 				<executions>
 					<execution>
 						<goals>
@@ -114,7 +115,6 @@
 							<goal>addTestSources</goal>
 							<goal>generateStubs</goal>
 							<goal>compile</goal>
-							<goal>testCompile</goal>
 							<goal>removeStubs</goal>
 							<goal>removeTestStubs</goal>
 						</goals>

--- a/agr_java_core/pom.xml
+++ b/agr_java_core/pom.xml
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>2.4.6</version>
+			<version>3.0.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/agr_java_core/pom.xml
+++ b/agr_java_core/pom.xml
@@ -17,12 +17,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jackson.version>2.11.1</jackson.version>
 	</properties>
-	<repositories>
-		<repository>
-			<id>elasticsearch-releases</id>
-			<url>https://artifacts.elastic.co/maven</url>
-		</repository>
-	</repositories>
 
 	<dependencies>
 		<dependency>
@@ -158,8 +152,9 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>3.0.4</version>
+			<version>3.0.5</version>
 			<scope>test</scope>
+         <type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>org.spockframework</groupId>

--- a/agr_schema_validation/pom.xml
+++ b/agr_schema_validation/pom.xml
@@ -19,14 +19,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>elastic</id>
-			<name>elasticsearch-releases</name>
-			<url>https://artifacts.elastic.co/maven</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,6 @@
 		<revision>3.2.0</revision>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>elasticsearch-releases</id>
-			<url>https://artifacts.elastic.co/maven</url>
-		</repository>
-	</repositories>
-
 	<build>
 		<pluginManagement>
 			<plugins>


### PR DESCRIPTION


WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass$3$1 (file:/Users/cmpich/.m2/repository/org/codehaus/groovy/groovy-all/2.4.6/groovy-all-2.4.6.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass$3$1