### PR TITLE
AGR-1925 download format

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
@@ -347,7 +347,7 @@ public class GeneController implements GeneRESTInterface {
         JsonResultResponse<InteractionGeneJoin> interactions = geneService.getInteractions(id, pagination);
 
         Response.ResponseBuilder responseBuilder = Response.ok(interactionTanslator.getAllRows(interactions.getResults()));
-        APIServiceHelper.setDownloadHeader(id, EntityType.GENE, EntityType.INTERACTION, responseBuilder);
+        APIServiceHelper.setDownloadHeader(id, EntityType.GENE, EntityType.INTERACTION, joinType.getName(), responseBuilder);
         return responseBuilder.build();
     }
 

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
@@ -5,6 +5,7 @@ import lombok.extern.log4j.Log4j2;
 import org.alliancegenome.api.entity.AlleleVariantSequence;
 import org.alliancegenome.api.entity.DiseaseRibbonSummary;
 import org.alliancegenome.api.entity.ExpressionSummary;
+import org.alliancegenome.api.entity.JoinTypeValue;
 import org.alliancegenome.api.rest.interfaces.GeneRESTInterface;
 import org.alliancegenome.api.service.*;
 import org.alliancegenome.api.service.helper.APIServiceHelper;
@@ -259,7 +260,7 @@ public class GeneController implements GeneRESTInterface {
     @Override
     public JsonResultResponse<InteractionGeneJoin> getInteractions(String id, Integer limit, Integer page, String sortBy, String asc,
                                                                    String moleculeType,
-                                                                   String joinType,
+                                                                   JoinTypeValue joinType,
                                                                    String interactorGeneSymbol,
                                                                    String interactorSpecies,
                                                                    String interactorMoleculeType,
@@ -276,7 +277,7 @@ public class GeneController implements GeneRESTInterface {
         long startTime = System.currentTimeMillis();
         Pagination pagination = new Pagination(page, limit, sortBy, asc, new InteractionColumnFieldMapping());
         pagination.addFieldFilter(FieldFilter.MOLECULE_TYPE, moleculeType);
-        pagination.addFieldFilter(FieldFilter.JOIN_TYPE, joinType);
+        pagination.addFieldFilter(FieldFilter.JOIN_TYPE, joinType.getName());
         pagination.addFieldFilter(FieldFilter.INTERACTOR_GENE_SYMBOL, interactorGeneSymbol);
         pagination.addFieldFilter(FieldFilter.INTERACTOR_SPECIES, interactorSpecies);
         pagination.addFieldFilter(FieldFilter.INTERACTOR_MOLECULE_TYPE, interactorMoleculeType);
@@ -313,7 +314,7 @@ public class GeneController implements GeneRESTInterface {
     @Override
     public Response getInteractionsDownload(String id, String sortBy, String asc,
                                             String moleculeType,
-                                            String joinType,
+                                            JoinTypeValue joinType,
                                             String interactorGeneSymbol,
                                             String interactorSpecies,
                                             String interactorMoleculeType,
@@ -329,7 +330,7 @@ public class GeneController implements GeneRESTInterface {
                                             ) {
         Pagination pagination = new Pagination(1, Integer.MAX_VALUE, sortBy, asc);
         pagination.addFieldFilter(FieldFilter.MOLECULE_TYPE, moleculeType);
-        pagination.addFieldFilter(FieldFilter.JOIN_TYPE, joinType);
+        pagination.addFieldFilter(FieldFilter.JOIN_TYPE, joinType.getName());
         pagination.addFieldFilter(FieldFilter.INTERACTOR_GENE_SYMBOL, interactorGeneSymbol);
         pagination.addFieldFilter(FieldFilter.INTERACTOR_SPECIES, interactorSpecies);
         pagination.addFieldFilter(FieldFilter.INTERACTOR_MOLECULE_TYPE, interactorMoleculeType);
@@ -763,6 +764,5 @@ public class GeneController implements GeneRESTInterface {
         APIServiceHelper.setDownloadHeader(geneId, EntityType.GENE, EntityType.ALLELE, responseBuilder);
         return responseBuilder.build();
     }
-
 
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/entity/JoinTypeValue.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/entity/JoinTypeValue.java
@@ -1,0 +1,15 @@
+package org.alliancegenome.api.entity;
+
+public enum  JoinTypeValue {
+	genetic_interaction("genetic_interaction"), 
+	molecular_interaction("molecular_interaction"),
+	;
+	private String name="molecular_interaction";
+	
+	JoinTypeValue(String name) {
+        this.name = name;
+    }
+	public String getName() {
+        return name;
+    }
+}

--- a/agr_api/src/main/java/org/alliancegenome/api/entity/JoinTypeValue.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/entity/JoinTypeValue.java
@@ -1,15 +1,15 @@
 package org.alliancegenome.api.entity;
 
 public enum  JoinTypeValue {
-	genetic_interaction("genetic_interaction"), 
-	molecular_interaction("molecular_interaction"),
-	;
-	private String name="molecular_interaction";
-	
-	JoinTypeValue(String name) {
+    genetic_interaction("genetic_interaction"), 
+    molecular_interaction("molecular_interaction"),
+    ;
+    private String name="molecular_interaction";
+    
+    JoinTypeValue(String name) {
         this.name = name;
     }
-	public String getName() {
+    public String getName() {
         return name;
     }
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/GeneRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/GeneRESTInterface.java
@@ -436,8 +436,8 @@ public interface GeneRESTInterface {
             @QueryParam("asc") String asc,
             @Parameter(in = ParameterIn.QUERY, name = "filter.moleculeType")
             @QueryParam("filter.moleculeType") String moleculeType,
-            @Parameter(in = ParameterIn.QUERY, name = "filter.joinType")
-            @QueryParam("filter.joinType") String joinType,
+            @Parameter(in = ParameterIn.QUERY, name = "filter.joinType", description=" molecylar_interaction or genetic_interaction", required = true  )
+            @QueryParam("filter.joinType") JoinTypeValue joinType,
             @Parameter(in = ParameterIn.QUERY, name = "filter.interactorGeneSymbol", description = "Gene symbol")
             @QueryParam("filter.interactorGeneSymbol") String interactorGeneSymbol,
             @Parameter(in = ParameterIn.QUERY, name = "filter.interactorSpecies", description = "Species")
@@ -481,8 +481,8 @@ public interface GeneRESTInterface {
             @QueryParam("asc") String asc,
             @Parameter(in = ParameterIn.QUERY, name = "filter.moleculeType", description = "molecule type")
             @QueryParam("filter.moleculeType") String moleculeType,
-            @Parameter(in = ParameterIn.QUERY, name = "filter.joinType")
-            @QueryParam("filter.joinType") String joinType,
+            @Parameter(in = ParameterIn.QUERY, name = "filter.joinType",  description=" molecylar_interaction or genetic_interaction", required = true)
+            @QueryParam("filter.joinType")  JoinTypeValue joinType,
             @Parameter(in = ParameterIn.QUERY, name = "filter.interactorGeneSymbol", description = "gene symbol")
             @QueryParam("filter.interactorGeneSymbol") String interactorGeneSymbol,
             @Parameter(in = ParameterIn.QUERY, name = "filter.interactorSpecies", description = "species")

--- a/agr_api/src/main/java/org/alliancegenome/api/service/GeneService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/GeneService.java
@@ -70,12 +70,12 @@ public class GeneService {
         response.addAnnotationSummarySupplementalData(getInteractionSummary(id));
         if (interactions == null)
             return response;
-        FilterService<InteractionGeneJoin> filterService = new FilterService<>(new InteractionAnnotationFiltering());
-        ColumnFieldMapping<InteractionGeneJoin> mapping = new InteractionColumnFieldMapping();
-        List<InteractionGeneJoin> interactionAnnotationList = geneCacheRepo.getInteractions(id);
-        response.addDistinctFieldValueSupplementalData(filterService.getDistinctFieldValues(interactionAnnotationList,
-                mapping.getSingleValuedFieldColumns(Table.INTERACTION), mapping));        
-        //response.addDistinctFieldValueSupplementalData(interactions.getDistinctFieldValueMap());
+        //FilterService<InteractionGeneJoin> filterService = new FilterService<>(new InteractionAnnotationFiltering());
+        //ColumnFieldMapping<InteractionGeneJoin> mapping = new InteractionColumnFieldMapping();
+        //List<InteractionGeneJoin> interactionAnnotationList = geneCacheRepo.getInteractions(id);
+        //response.addDistinctFieldValueSupplementalData(filterService.getDistinctFieldValues(interactionAnnotationList,
+        //        mapping.getSingleValuedFieldColumns(Table.INTERACTION), mapping));        
+        response.addDistinctFieldValueSupplementalData(interactions.getDistinctFieldValueMap());
         response.setResults(interactions.getResult());
         response.setTotal(interactions.getTotalNumber());
         return response;

--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/APIServiceHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/APIServiceHelper.java
@@ -13,7 +13,7 @@ public class APIServiceHelper {
 
     private APIServiceHelper() {} // All Static Methods
     
-    public static String getFileName(String title, String id, EntityType collectionType) {
+    public static String getFileName(String title, String id, EntityType collectionType, String extra) {
         String fileName = title;
         fileName += "-";
         fileName += id;
@@ -21,6 +21,10 @@ public class APIServiceHelper {
         // make the entity name plural
         fileName += collectionType.toString().toLowerCase() + "s";
         fileName += "-";
+        if(extra != null && extra.length() > 0) {
+            fileName += extra;
+            fileName += "-";
+        }
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         fileName += dateFormat.format(new Date());
         fileName += ".tsv";
@@ -28,8 +32,12 @@ public class APIServiceHelper {
     }
 
     public static void setDownloadHeader(String id, EntityType type, EntityType collectionType, Response.ResponseBuilder responseBuilder) {
+        setDownloadHeader(id, type, collectionType, "", responseBuilder);
+    }
+    
+    public static void setDownloadHeader(String id, EntityType type, EntityType collectionType, String extraFileName, Response.ResponseBuilder responseBuilder) {
         String title = getEntityName(id, type);
-        String fileName = APIServiceHelper.getFileName(title, id, collectionType);
+        String fileName = APIServiceHelper.getFileName(title, id, collectionType, extraFileName);
         responseBuilder.header("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
         responseBuilder.type(MediaType.TEXT_PLAIN_TYPE);
     }

--- a/agr_cacher/src/main/java/org/alliancegenome/cacher/cachers/InteractionCacher.java
+++ b/agr_cacher/src/main/java/org/alliancegenome/cacher/cachers/InteractionCacher.java
@@ -95,8 +95,8 @@ public class InteractionCacher extends Cacher {
         newJoin.setPublication(join.getPublication());
         newJoin.setSourceDatabase(join.getSourceDatabase());
         newJoin.setId(join.getId());
-        newJoin.setAlleleA(join.getAlleleA());
-        newJoin.setAlleleB(join.getAlleleB());
+        newJoin.setAlleleA(join.getAlleleB());
+        newJoin.setAlleleB(join.getAlleleA());
         newJoin.setPhenotypes(join.getPhenotypes());
         return newJoin;
     }

--- a/agr_java_core/src/main/java/org/alliancegenome/api/entity/JoinTypeValue.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/api/entity/JoinTypeValue.java
@@ -1,0 +1,15 @@
+package org.alliancegenome.api.entity;
+
+public enum JoinTypeValue {
+	genetic_interaction("genetic_interaction"), 
+	molecular_interaction("molecular_interaction"),
+	;
+	private String name="molecular_interaction";
+	
+	JoinTypeValue(String name) {
+        this.name = name;
+    }
+	public String getName() {
+        return name;
+    }
+}

--- a/agr_java_core/src/main/java/org/alliancegenome/api/entity/JoinTypeValue.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/api/entity/JoinTypeValue.java
@@ -1,15 +1,15 @@
 package org.alliancegenome.api.entity;
 
 public enum JoinTypeValue {
-	genetic_interaction("genetic_interaction"), 
-	molecular_interaction("molecular_interaction"),
-	;
-	private String name="molecular_interaction";
-	
-	JoinTypeValue(String name) {
+    genetic_interaction("genetic_interaction"), 
+    molecular_interaction("molecular_interaction"),
+    ;
+    private String name="molecular_interaction";
+    
+    JoinTypeValue(String name) {
         this.name = name;
     }
-	public String getName() {
+    public String getName() {
         return name;
     }
 }

--- a/agr_java_core/src/main/java/org/alliancegenome/cache/repository/InteractionCacheRepository.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/cache/repository/InteractionCacheRepository.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 
+import org.alliancegenome.api.entity.JoinTypeValue;
 import org.alliancegenome.api.service.*;
 import org.alliancegenome.cache.*;
 import org.alliancegenome.cache.repository.helper.*;
@@ -31,13 +32,12 @@ public class InteractionCacheRepository {
             return null;
 
         PaginationResult<InteractionGeneJoin> result = new PaginationResult<>();
-
-        FilterService<InteractionGeneJoin> filterService = new FilterService<>(new InteractionAnnotationFiltering());
-        ColumnFieldMapping<InteractionGeneJoin> mapping = new InteractionColumnFieldMapping();
-        result.setDistinctFieldValueMap(filterService.getDistinctFieldValues(interactionAnnotationList, mapping.getSingleValuedFieldColumns(Table.INTERACTION), mapping));
-
         //filtering
         List<InteractionGeneJoin> filteredInteractionAnnotationList = filterInteractionAnnotations(interactionAnnotationList, pagination.getFieldFilterValueMap(), true);
+        //set Distinct Field Value based on filtered list
+        FilterService<InteractionGeneJoin> filterService = new FilterService<>(new InteractionAnnotationFiltering());
+        ColumnFieldMapping<InteractionGeneJoin> mapping = new InteractionColumnFieldMapping();
+        result.setDistinctFieldValueMap(filterService.getDistinctFieldValues(filteredInteractionAnnotationList, mapping.getSingleValuedFieldColumns(Table.INTERACTION), mapping));
 
         if (!filteredInteractionAnnotationList.isEmpty()) {
             result.setTotalNumber(filteredInteractionAnnotationList.size());
@@ -45,6 +45,7 @@ public class InteractionCacheRepository {
         }
         return result;
     }
+    
 
     private List<InteractionGeneJoin> getSortedAndPaginatedInteractionAnnotations(Pagination pagination,
                                                                                   List<InteractionGeneJoin> filteredInteractionAnnotationList) {

--- a/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/InteractionToTdfTranslator.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/InteractionToTdfTranslator.java
@@ -46,7 +46,7 @@ public class InteractionToTdfTranslator {
         headerJoiner.add("Phenotype or trait");
         }
         else {
-        	headerJoiner.add("Focus gene molecule type ID");
+            headerJoiner.add("Focus gene molecule type ID");
             headerJoiner.add("Focus gene molecule type");
             headerJoiner.add("Interaction type");
             headerJoiner.add("Focus gene experimental role ID");

--- a/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/InteractionToTdfTranslator.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/InteractionToTdfTranslator.java
@@ -12,9 +12,9 @@ public class InteractionToTdfTranslator {
         StringBuilder builder = new StringBuilder();
         StringJoiner headerJoiner = new StringJoiner("\t");
         if (annotations.get(0).getJoinType().equalsIgnoreCase(JoinTypeValue.genetic_interaction.getName())) {
-        //headerJoiner.add("Focus gene molecule type ID");
-        //headerJoiner.add("Focus gene molecule type");
-        headerJoiner.add("Interaction type");
+        headerJoiner.add("Focus gene molecule type ID");
+        headerJoiner.add("Focus gene molecule type");
+        //headerJoiner.add("Interaction type");
         headerJoiner.add("Focus gene experimental role ID");
         headerJoiner.add("Focus gene experimental role");
         
@@ -23,32 +23,32 @@ public class InteractionToTdfTranslator {
         headerJoiner.add("Interactor species ID");
         headerJoiner.add("Interactor species");
         
-        //headerJoiner.add("Interactor molecule type ID");
-        //headerJoiner.add("Interactor molecule type");
+        headerJoiner.add("Interactor molecule type ID");
+        headerJoiner.add("Interactor molecule type");
         headerJoiner.add("Interactor experimental role ID");
         headerJoiner.add("Interactor experimental role");
         
         headerJoiner.add("Interaction type ID");
         headerJoiner.add("Interaction type");
         
-        headerJoiner.add("Detection method IDs");
-        headerJoiner.add("Detection methods");
+        //headerJoiner.add("Detection method IDs");
+        //headerJoiner.add("Detection methods");
         
         headerJoiner.add("Source ID");
         headerJoiner.add("Source DB ID");
         headerJoiner.add("Source DB");
-        headerJoiner.add("Aggregation DB ID");
-        headerJoiner.add("Aggregation DB");
+        //headerJoiner.add("Aggregation DB ID");
+        //headerJoiner.add("Aggregation DB");
         headerJoiner.add("Reference");
         //new column from genetic interaction
-        headerJoiner.add("genetic perturbation A");
-        headerJoiner.add("genetic perturbation B");
+        headerJoiner.add("Genetic perturbation A");
+        headerJoiner.add("Genetic perturbation B");
         headerJoiner.add("Phenotype or trait");
         }
         else {
             headerJoiner.add("Focus gene molecule type ID");
             headerJoiner.add("Focus gene molecule type");
-            headerJoiner.add("Interaction type");
+            //headerJoiner.add("Interaction type");
             headerJoiner.add("Focus gene experimental role ID");
             headerJoiner.add("Focus gene experimental role");
             
@@ -75,8 +75,8 @@ public class InteractionToTdfTranslator {
             headerJoiner.add("Aggregation DB");
             headerJoiner.add("Reference");
             //new column from genetic interaction
-            //headerJoiner.add("genetic perturbation A");
-            //headerJoiner.add("genetic perturbation B");
+            //headerJoiner.add("Genetic perturbation A");
+            //headerJoiner.add("Genetic perturbation B");
             //headerJoiner.add("Phenotype or trait");
         }
 
@@ -85,11 +85,9 @@ public class InteractionToTdfTranslator {
 
         annotations.forEach(interactionGeneJoin -> {
             StringJoiner joiner = new StringJoiner("\t");
-            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName()))
             joiner.add(interactionGeneJoin.getInteractorAType().getPrimaryKey());
-            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName()))
             joiner.add(interactionGeneJoin.getInteractorAType().getLabel());
-            joiner.add(interactionGeneJoin.getJoinType());
+            //joiner.add(interactionGeneJoin.getJoinType());
             joiner.add(interactionGeneJoin.getInteractorARole().getPrimaryKey());
             joiner.add(interactionGeneJoin.getInteractorARole().getLabel());
             
@@ -97,9 +95,8 @@ public class InteractionToTdfTranslator {
             joiner.add(interactionGeneJoin.getGeneB().getSymbol());
             joiner.add(interactionGeneJoin.getGeneB().getSpecies().getPrimaryKey());
             joiner.add(interactionGeneJoin.getGeneB().getSpecies().getName());
-            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName()))
             joiner.add(interactionGeneJoin.getInteractorBType().getPrimaryKey());
-            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName()))
+
             joiner.add(interactionGeneJoin.getInteractorBType().getLabel());
             joiner.add(interactionGeneJoin.getInteractorBRole().getPrimaryKey());
             joiner.add(interactionGeneJoin.getInteractorBRole().getLabel());
@@ -108,23 +105,24 @@ public class InteractionToTdfTranslator {
             joiner.add(interactionGeneJoin.getInteractionType().getLabel());
             
             // add list of detectionMethods Ids
-            String detectionMethodIds = "";
-            if (interactionGeneJoin.getDetectionsMethods() != null) {
+            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName())) {
+              String detectionMethodIds = "";
+              if (interactionGeneJoin.getDetectionsMethods() != null) {
                 StringJoiner methodJoiner = new StringJoiner(",");
                 interactionGeneJoin.getDetectionsMethods().forEach(method -> methodJoiner.add(method.getPrimaryKey()));
                 detectionMethodIds = methodJoiner.toString();
-            }
-            joiner.add(detectionMethodIds);
+              }
+              joiner.add(detectionMethodIds);
             
-            // add list of detectionMethods Labels
-            String detectionMethods = "";
-            if (interactionGeneJoin.getDetectionsMethods() != null) {
+              // add list of detectionMethods Labels
+              String detectionMethods = "";
+              if (interactionGeneJoin.getDetectionsMethods() != null) {
                 StringJoiner methodJoiner = new StringJoiner(",");
                 interactionGeneJoin.getDetectionsMethods().forEach(method -> methodJoiner.add(method.getLabel()));
                 detectionMethods = methodJoiner.toString();
+              }
+              joiner.add(detectionMethods);
             }
-            joiner.add(detectionMethods);
-
             // add list of detectionMethods Labels
             String sourceIds = "";
             if (interactionGeneJoin.getCrossReferences() != null) {
@@ -144,42 +142,45 @@ public class InteractionToTdfTranslator {
                 joiner.add(sourceDatabaseID);
                 joiner.add(sourceDatabase);
             }
-            
-            
-            if (interactionGeneJoin.getAggregationDatabase() !=null) {//maybe null here
+            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName())) {
+             String aggregationDatabaseID="";
+             String aggregationDatabase="";
+             if (interactionGeneJoin.getAggregationDatabase() !=null) {//maybe null here
               joiner.add(interactionGeneJoin.getAggregationDatabase().getPrimaryKey());
               joiner.add(interactionGeneJoin.getAggregationDatabase().getLabel());
+             }
+             else {
+            	joiner.add(aggregationDatabaseID);
+            	joiner.add(aggregationDatabase);
+             }
             }
-            
             if (interactionGeneJoin.getPublication()!=null)
              joiner.add(interactionGeneJoin.getPublication().getPubId());
             else 
                 joiner.add(""); 
             //genetic perturbation alleleA
-            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.genetic_interaction.getName()))
-            if (interactionGeneJoin.getAlleleA()!=null) {
-                joiner.add(interactionGeneJoin.getAlleleA().getPrimaryKey());
-            }
-            else {
-                joiner.add("");
-            }
-            //genetic perturbation, alleleB
-            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.genetic_interaction.getName()))
-            if (interactionGeneJoin.getAlleleB()!=null) {
-                joiner.add(interactionGeneJoin.getAlleleB().getPrimaryKey());
-            }
-            else {
-                joiner.add("");
-            }
-            //phenotypes
-            String phenotypeIds = "";
             if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.genetic_interaction.getName())) {
-             if (interactionGeneJoin.getPhenotypes() != null) {
+              if (interactionGeneJoin.getAlleleA()!=null) {
+                joiner.add(interactionGeneJoin.getAlleleA().getSymbol());
+              }
+              else {
+                joiner.add("");
+              }
+            //genetic perturbation, alleleB
+              if (interactionGeneJoin.getAlleleB()!=null) {
+                joiner.add(interactionGeneJoin.getAlleleB().getSymbol());
+              }
+              else {
+                joiner.add("");
+              }
+              //phenotypes
+              String phenotypeIds = "";
+              if (interactionGeneJoin.getPhenotypes() != null) {
                 StringJoiner phenotypeJoiner = new StringJoiner(",");
                 interactionGeneJoin.getPhenotypes().forEach(phenotype -> phenotypeJoiner.add(phenotype.getPrimaryKey()));
                 phenotypeIds = phenotypeJoiner.toString();
-             }
-             joiner.add(phenotypeIds);
+              }
+               joiner.add(phenotypeIds);
             }
             builder.append(joiner.toString());
             builder.append(ConfigHelper.getJavaLineSeparator());

--- a/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/InteractionToTdfTranslator.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/InteractionToTdfTranslator.java
@@ -4,15 +4,16 @@ import java.util.*;
 
 import org.alliancegenome.core.config.ConfigHelper;
 import org.alliancegenome.neo4j.entity.node.InteractionGeneJoin;
+import org.alliancegenome.api.entity.JoinTypeValue;
 
 public class InteractionToTdfTranslator {
 
     public String getAllRows(List<InteractionGeneJoin> annotations) {
         StringBuilder builder = new StringBuilder();
         StringJoiner headerJoiner = new StringJoiner("\t");
-
-        headerJoiner.add("Focus gene molecule type ID");
-        headerJoiner.add("Focus gene molecule type");
+        if (annotations.get(0).getJoinType().equalsIgnoreCase(JoinTypeValue.genetic_interaction.getName())) {
+        //headerJoiner.add("Focus gene molecule type ID");
+        //headerJoiner.add("Focus gene molecule type");
         headerJoiner.add("Interaction type");
         headerJoiner.add("Focus gene experimental role ID");
         headerJoiner.add("Focus gene experimental role");
@@ -22,8 +23,8 @@ public class InteractionToTdfTranslator {
         headerJoiner.add("Interactor species ID");
         headerJoiner.add("Interactor species");
         
-        headerJoiner.add("Interactor molecule type ID");
-        headerJoiner.add("Interactor molecule type");
+        //headerJoiner.add("Interactor molecule type ID");
+        //headerJoiner.add("Interactor molecule type");
         headerJoiner.add("Interactor experimental role ID");
         headerJoiner.add("Interactor experimental role");
         
@@ -43,14 +44,50 @@ public class InteractionToTdfTranslator {
         headerJoiner.add("genetic perturbation A");
         headerJoiner.add("genetic perturbation B");
         headerJoiner.add("Phenotype or trait");
+        }
+        else {
+        	headerJoiner.add("Focus gene molecule type ID");
+            headerJoiner.add("Focus gene molecule type");
+            headerJoiner.add("Interaction type");
+            headerJoiner.add("Focus gene experimental role ID");
+            headerJoiner.add("Focus gene experimental role");
+            
+            headerJoiner.add("Interactor gene ID");
+            headerJoiner.add("Interactor gene");
+            headerJoiner.add("Interactor species ID");
+            headerJoiner.add("Interactor species");
+            
+            headerJoiner.add("Interactor molecule type ID");
+            headerJoiner.add("Interactor molecule type");
+            headerJoiner.add("Interactor experimental role ID");
+            headerJoiner.add("Interactor experimental role");
+            
+            headerJoiner.add("Interaction type ID");
+            headerJoiner.add("Interaction type");
+            
+            headerJoiner.add("Detection method IDs");
+            headerJoiner.add("Detection methods");
+            
+            headerJoiner.add("Source ID");
+            headerJoiner.add("Source DB ID");
+            headerJoiner.add("Source DB");
+            headerJoiner.add("Aggregation DB ID");
+            headerJoiner.add("Aggregation DB");
+            headerJoiner.add("Reference");
+            //new column from genetic interaction
+            //headerJoiner.add("genetic perturbation A");
+            //headerJoiner.add("genetic perturbation B");
+            //headerJoiner.add("Phenotype or trait");
+        }
 
         builder.append(headerJoiner.toString());
         builder.append(ConfigHelper.getJavaLineSeparator());
 
         annotations.forEach(interactionGeneJoin -> {
             StringJoiner joiner = new StringJoiner("\t");
-
+            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName()))
             joiner.add(interactionGeneJoin.getInteractorAType().getPrimaryKey());
+            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName()))
             joiner.add(interactionGeneJoin.getInteractorAType().getLabel());
             joiner.add(interactionGeneJoin.getJoinType());
             joiner.add(interactionGeneJoin.getInteractorARole().getPrimaryKey());
@@ -60,8 +97,9 @@ public class InteractionToTdfTranslator {
             joiner.add(interactionGeneJoin.getGeneB().getSymbol());
             joiner.add(interactionGeneJoin.getGeneB().getSpecies().getPrimaryKey());
             joiner.add(interactionGeneJoin.getGeneB().getSpecies().getName());
-            
+            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName()))
             joiner.add(interactionGeneJoin.getInteractorBType().getPrimaryKey());
+            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.molecular_interaction.getName()))
             joiner.add(interactionGeneJoin.getInteractorBType().getLabel());
             joiner.add(interactionGeneJoin.getInteractorBRole().getPrimaryKey());
             joiner.add(interactionGeneJoin.getInteractorBRole().getLabel());
@@ -118,6 +156,7 @@ public class InteractionToTdfTranslator {
             else 
                 joiner.add(""); 
             //genetic perturbation alleleA
+            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.genetic_interaction.getName()))
             if (interactionGeneJoin.getAlleleA()!=null) {
                 joiner.add(interactionGeneJoin.getAlleleA().getPrimaryKey());
             }
@@ -125,6 +164,7 @@ public class InteractionToTdfTranslator {
                 joiner.add("");
             }
             //genetic perturbation, alleleB
+            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.genetic_interaction.getName()))
             if (interactionGeneJoin.getAlleleB()!=null) {
                 joiner.add(interactionGeneJoin.getAlleleB().getPrimaryKey());
             }
@@ -133,13 +173,14 @@ public class InteractionToTdfTranslator {
             }
             //phenotypes
             String phenotypeIds = "";
-            if (interactionGeneJoin.getPhenotypes() != null) {
+            if (interactionGeneJoin.getJoinType().equalsIgnoreCase(JoinTypeValue.genetic_interaction.getName())) {
+             if (interactionGeneJoin.getPhenotypes() != null) {
                 StringJoiner phenotypeJoiner = new StringJoiner(",");
                 interactionGeneJoin.getPhenotypes().forEach(phenotype -> phenotypeJoiner.add(phenotype.getPrimaryKey()));
                 phenotypeIds = phenotypeJoiner.toString();
+             }
+             joiner.add(phenotypeIds);
             }
-            joiner.add(phenotypeIds);
-
             builder.append(joiner.toString());
             builder.append(ConfigHelper.getJavaLineSeparator());
         });


### PR DESCRIPTION
with those fix: 1. change molecular/genetic download file name and format see  AGR-2616
2. change the distinct value for filter so it will separate values from molecuar/genetic interaction, see  AGR-2617
3. change the way for alleleA/alleleB to attach to new InteractionGeneJoin in InteractionCacher.java (we discussed this issue before), see  AGR-2620
4. set the join type of interaction as pulldown menu and as required.  here same package org.alliancegenome.api.entity exists in two different project: agr_api and agr_cacher, here class org.alliancegenome.api.entity.JoinTypeValue must exist in those two places, not sure if easy way to solve it or not.