### PR TITLE
use regex for *RNA_gene, deboost pseudogenes to compensate for human boost

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -103,6 +103,8 @@ public class SearchService {
         functionList.add(documentHasDiseaseBoost());
         functionList.add(proteinCodingBoost());
         functionList.add(rnaBoost());
+        functionList.add(pseudogeneBoost());
+
 
         return functionList.toArray(new FunctionScoreQueryBuilder.FilterFunctionBuilder[functionList.size()]);
     }
@@ -119,6 +121,8 @@ public class SearchService {
         functionList.add(proteinCodingBoost());
 
         functionList.add(rnaBoost());
+
+        functionList.add(pseudogeneBoost());
 
         functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("name_key.keyword",q),
                 ScoreFunctionBuilders.weightFactorFunction(1000F)));
@@ -175,10 +179,14 @@ public class SearchService {
     }
 
     private FunctionScoreQueryBuilder.FilterFunctionBuilder rnaBoost() {
-        return new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("soTermName","ncRNA_gene"),
+        return new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("soTermName",".*RNA_gene"),
                 ScoreFunctionBuilders.weightFactorFunction(1.2F));
     }
 
+    private FunctionScoreQueryBuilder.FilterFunctionBuilder pseudogeneBoost() {
+        return new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("soTermName","pseudogene"),
+                ScoreFunctionBuilders.weightFactorFunction(0.5F));
+    }
 
     private FunctionScoreQueryBuilder.FilterFunctionBuilder humanSpeciesBoost() {
         return new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("species","Homo sapiens"),

--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -179,7 +179,7 @@ public class SearchService {
     }
 
     private FunctionScoreQueryBuilder.FilterFunctionBuilder rnaBoost() {
-        return new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("soTermName",".*RNA_gene"),
+        return new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("soTermName",".*RNA"),
                 ScoreFunctionBuilders.weightFactorFunction(1.2F));
     }
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -105,7 +105,6 @@ public class SearchService {
         functionList.add(rnaBoost());
         functionList.add(pseudogeneBoost());
 
-
         return functionList.toArray(new FunctionScoreQueryBuilder.FilterFunctionBuilder[functionList.size()]);
     }
 


### PR DESCRIPTION
For genes, human pseudogenes should rank below MOD non-pseudogenes, so "boosting" by 0.5X to counteract the 1.5X human boost.
Also, I'm suggesting use of `.*RNA` regex, which should catch almost all genes having biotype in the ncRNA_gene branch; I'm assuming this is possible.