### PR TITLE
AGR-2842 added species to TranscriptLevelConsequence

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
@@ -99,6 +99,7 @@ public class AlleleVariantSequenceConverter {
             avsDoc.setVariant(variant);
             if (htpConsequences != null) {
                 for (TranscriptLevelConsequence c : htpConsequences) {
+                    c.getAssociatedGene().setSpecies(species);
                     if(!transcriptsProcessed.contains(c.getTranscriptID())) {
                         transcriptsProcessed.add(c.getTranscriptID());
                         if(first) {
@@ -111,11 +112,8 @@ public class AlleleVariantSequenceConverter {
                         //    s.setConsequence(c);
                         /****************SearchbleDocument Fields***************/
                         if(c.getAssociatedGene().getSymbol()!=null && !c.getAssociatedGene().getSymbol().equals("")){
-                            c.getAssociatedGene().setSpecies(species);
                             genes.add(c.getAssociatedGene().getNameKey());
                         }
-
-
                     }
                 }
             }

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
@@ -70,7 +70,7 @@ public class AlleleVariantSequenceConverter {
             boolean first=true;
             Set<String> molecularConsequences = new HashSet<>();
             Set<String> genes = new HashSet<>();
-            List<TranscriptLevelConsequence> htpConsequences = getConsequences(ctx, a.getBaseString(), header);
+            List<TranscriptLevelConsequence> htpConsequences = getConsequences(ctx, a.getBaseString(), header, species);
             String hgvsNomenclature = htpConsequences != null ? htpConsequences.stream()
                     .findFirst()
                     .map(TranscriptLevelConsequence::getHgvsVEPGeneNomenclature)
@@ -132,7 +132,7 @@ public class AlleleVariantSequenceConverter {
 
     
     
-    private List<TranscriptLevelConsequence> getConsequences(VariantContext ctx, String varNuc, String[] header) throws Exception {
+    private List<TranscriptLevelConsequence> getConsequences(VariantContext ctx, String varNuc, String[] header, Species species) throws Exception {
         List<TranscriptLevelConsequence> features = new ArrayList<>();
         List<String> alreadyAdded = new ArrayList<>();
         
@@ -142,7 +142,7 @@ public class AlleleVariantSequenceConverter {
 
                 if (header.length == infos.length) {
                     if (infos[0].equalsIgnoreCase(varNuc)) {
-                        TranscriptLevelConsequence feature = new TranscriptLevelConsequence(header, infos);
+                        TranscriptLevelConsequence feature = new TranscriptLevelConsequence(header, infos, species);
                         if(!alreadyAdded.contains(feature.getTranscriptID())) {
                             features.add(feature);
                             alreadyAdded.add(feature.getTranscriptID());

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
@@ -70,7 +70,7 @@ public class AlleleVariantSequenceConverter {
             boolean first=true;
             Set<String> molecularConsequences = new HashSet<>();
             Set<String> genes = new HashSet<>();
-            List<TranscriptLevelConsequence> htpConsequences = getConsequences(ctx, a.getBaseString(), header, species);
+            List<TranscriptLevelConsequence> htpConsequences = getConsequences(ctx, a.getBaseString(), header);
             String hgvsNomenclature = htpConsequences != null ? htpConsequences.stream()
                     .findFirst()
                     .map(TranscriptLevelConsequence::getHgvsVEPGeneNomenclature)
@@ -110,8 +110,11 @@ public class AlleleVariantSequenceConverter {
                         molecularConsequences.add(c.getTranscriptLevelConsequence());
                         //    s.setConsequence(c);
                         /****************SearchbleDocument Fields***************/
-                        if(c.getAssociatedGene().getSymbol()!=null && !c.getAssociatedGene().getSymbol().equals(""))
+                        if(c.getAssociatedGene().getSymbol()!=null && !c.getAssociatedGene().getSymbol().equals("")){
+                            c.getAssociatedGene().setSpecies(species);
                             genes.add(c.getAssociatedGene().getNameKey());
+                        }
+
 
                     }
                 }
@@ -132,7 +135,7 @@ public class AlleleVariantSequenceConverter {
 
     
     
-    private List<TranscriptLevelConsequence> getConsequences(VariantContext ctx, String varNuc, String[] header, Species species) throws Exception {
+    private List<TranscriptLevelConsequence> getConsequences(VariantContext ctx, String varNuc, String[] header) throws Exception {
         List<TranscriptLevelConsequence> features = new ArrayList<>();
         List<String> alreadyAdded = new ArrayList<>();
         
@@ -142,7 +145,7 @@ public class AlleleVariantSequenceConverter {
 
                 if (header.length == infos.length) {
                     if (infos[0].equalsIgnoreCase(varNuc)) {
-                        TranscriptLevelConsequence feature = new TranscriptLevelConsequence(header, infos, species);
+                        TranscriptLevelConsequence feature = new TranscriptLevelConsequence(header, infos);
                         if(!alreadyAdded.contains(feature.getTranscriptID())) {
                             features.add(feature);
                             alreadyAdded.add(feature.getTranscriptID());

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/TranscriptLevelConsequence.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/TranscriptLevelConsequence.java
@@ -156,7 +156,7 @@ public class TranscriptLevelConsequence extends Neo4jEntity {
 
     
     
-    public TranscriptLevelConsequence(String[] header, String[] infos, Species species) {
+    public TranscriptLevelConsequence(String[] header, String[] infos) {
 
         /* From MOD VCF File
         0  Allele: GGGG
@@ -206,7 +206,6 @@ public class TranscriptLevelConsequence extends Neo4jEntity {
         associatedGene = new Gene();
         associatedGene.setSymbol(infos[3]);
         associatedGene.setPrimaryKey(infos[4]);
-        associatedGene.setSpecies(species);
         
         transcriptID = infos[6];
         sequenceFeatureType = infos[7];

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/TranscriptLevelConsequence.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/TranscriptLevelConsequence.java
@@ -156,7 +156,7 @@ public class TranscriptLevelConsequence extends Neo4jEntity {
 
     
     
-    public TranscriptLevelConsequence(String[] header, String[] infos) {
+    public TranscriptLevelConsequence(String[] header, String[] infos, Species species) {
 
         /* From MOD VCF File
         0  Allele: GGGG
@@ -206,6 +206,7 @@ public class TranscriptLevelConsequence extends Neo4jEntity {
         associatedGene = new Gene();
         associatedGene.setSymbol(infos[3]);
         associatedGene.setPrimaryKey(infos[4]);
+        associatedGene.setSpecies(species);
         
         transcriptID = infos[6];
         sequenceFeatureType = infos[7];


### PR DESCRIPTION
After we changed line 114 in the AlleleVariantSequenceConverter to use getNameKey(), it still didn't appear to append the species abbreviation to the gene symbol on build. So I tried running the variant indexer with the debugger and noticed that species was always null within the getNameKey() method. 
	
In TranscriptLevelConsequence, setSpecies was never called on associatedGene and that the infos doesn't  contain species. So I passed down species from AlleleVariantSequenceConverter to TranscriptLevelConsequence