### PR TITLE
AGR-2845 added gene synonyms and cross references to htp variants

### DIFF
--- a/agr_cacher/src/main/java/org/alliancegenome/cacher/cachers/HtpVariantCreation.java
+++ b/agr_cacher/src/main/java/org/alliancegenome/cacher/cachers/HtpVariantCreation.java
@@ -8,7 +8,6 @@ import org.alliancegenome.api.entity.AlleleVariantSequence;
 import org.alliancegenome.core.filedownload.model.DownloadableFile;
 import org.alliancegenome.core.variant.config.VariantConfigHelper;
 import org.alliancegenome.core.variant.converters.AlleleVariantSequenceConverter;
-import org.alliancegenome.es.index.site.cache.GeneDocumentCache;
 import org.alliancegenome.neo4j.entity.SpeciesType;
 import org.alliancegenome.neo4j.entity.node.TranscriptLevelConsequence;
 
@@ -55,7 +54,6 @@ public class HtpVariantCreation extends Thread {
 
         private final DownloadableFile df;
         private final AlleleVariantSequenceConverter converter = new AlleleVariantSequenceConverter();
-        GeneDocumentCache geneCache = new GeneDocumentCache();
         
         public VCFReader(DownloadableFile df) {
             this.df = df;
@@ -76,7 +74,7 @@ public class HtpVariantCreation extends Thread {
                     VariantContext vc = iter1.next();
 
 
-                    List<AlleleVariantSequence> docList = converter.convertContextToAlleleVariantSequence(vc, header, speciesType, geneCache);
+                    List<AlleleVariantSequence> docList = converter.convertContextToAlleleVariantSequence(vc, header, speciesType, null);
                         //for (AlleleVariantSequence doc : docList) {
                             //for (TranscriptLevelConsequence transcriptFeature : doc.getTranscriptLevelConsequences()) {
 

--- a/agr_cacher/src/main/java/org/alliancegenome/cacher/cachers/HtpVariantCreation.java
+++ b/agr_cacher/src/main/java/org/alliancegenome/cacher/cachers/HtpVariantCreation.java
@@ -8,6 +8,7 @@ import org.alliancegenome.api.entity.AlleleVariantSequence;
 import org.alliancegenome.core.filedownload.model.DownloadableFile;
 import org.alliancegenome.core.variant.config.VariantConfigHelper;
 import org.alliancegenome.core.variant.converters.AlleleVariantSequenceConverter;
+import org.alliancegenome.es.index.site.cache.GeneDocumentCache;
 import org.alliancegenome.neo4j.entity.SpeciesType;
 import org.alliancegenome.neo4j.entity.node.TranscriptLevelConsequence;
 
@@ -54,6 +55,7 @@ public class HtpVariantCreation extends Thread {
 
         private final DownloadableFile df;
         private final AlleleVariantSequenceConverter converter = new AlleleVariantSequenceConverter();
+        GeneDocumentCache geneCache = new GeneDocumentCache();
         
         public VCFReader(DownloadableFile df) {
             this.df = df;
@@ -73,7 +75,8 @@ public class HtpVariantCreation extends Thread {
                 while (iter1.hasNext()) {
                     VariantContext vc = iter1.next();
 
-                        List<AlleleVariantSequence> docList = converter.convertContextToAlleleVariantSequence(vc, header, speciesType);
+
+                    List<AlleleVariantSequence> docList = converter.convertContextToAlleleVariantSequence(vc, header, speciesType, geneCache);
                         //for (AlleleVariantSequence doc : docList) {
                             //for (TranscriptLevelConsequence transcriptFeature : doc.getTranscriptLevelConsequences()) {
 

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
@@ -6,10 +6,12 @@ import org.alliancegenome.api.entity.AlleleVariantSequence;
 import org.alliancegenome.es.index.site.cache.GeneDocumentCache;
 import org.alliancegenome.neo4j.entity.SpeciesType;
 import org.alliancegenome.neo4j.entity.node.*;
+import org.alliancegenome.neo4j.entity.relationship.GenomeLocation;
 
 import htsjdk.variant.variantcontext.VariantContext;
 import io.github.lukehutch.fastclasspathscanner.utils.Join;
 import org.alliancegenome.neo4j.entity.relationship.GenomeLocation;
+import org.apache.commons.lang3.StringUtils;
 
 public class AlleleVariantSequenceConverter {
     
@@ -49,20 +51,6 @@ public class AlleleVariantSequenceConverter {
             variant.setGenomicReferenceSequence(ctx.getReference().getBaseString());
             variant.setGenomicVariantSequence(a.getBaseString());
 
-            int endPos = 0;
-
-            if (ctx.isSNP()) {
-                endPos = ctx.getStart() + 1;
-            } // insertions
-            if (ctx.isSimpleInsertion()) {
-                endPos = ctx.getStart();
-                //  System.out.println("INSERTION");
-            } else if (ctx.isSimpleDeletion()) {
-                endPos = ctx.getStart() + refNuc.getDisplayString().length();
-                //  System.out.println("Deletion");
-            } else {
-                //   System.out.println("Unexpected var type");
-            }
             List<String> transcriptsProcessed=new ArrayList<>();
 
             AlleleVariantSequence avsDoc = new AlleleVariantSequence();
@@ -73,11 +61,11 @@ public class AlleleVariantSequenceConverter {
             location.setStart((long) ctx.getStart());
             location.setEnd((long) ctx.getEnd());
             Chromosome chromosome = new Chromosome();
-            chromosome.setPrimaryKey(ctx.getChr());
+            chromosome.setPrimaryKey(ctx.getContig());
             location.setChromosome(chromosome);
             variant.setLocation(location);
             variant.setNucleotideChange(a.getBaseString()); // variantDocument.setVarNuc(a.getBaseString());
-            boolean first=true;
+            boolean first = true;
             Set<String> molecularConsequences = new HashSet<>();
             Set<String> genes = new HashSet<>();
             List<TranscriptLevelConsequence> htpConsequences = getConsequences(ctx, a.getBaseString(), header);
@@ -88,15 +76,16 @@ public class AlleleVariantSequenceConverter {
 
             variant.setHgvsNomenclature(hgvsNomenclature);
             variant.setName(hgvsNomenclature);
-            if(ctx.getID()!=null && !ctx.getID().equals("") && !ctx.getID().equals(".")){
-                avsDoc.setPrimaryKey(ctx.getID());
-                avsDoc.setNameKey(ctx.getID());
-                avsDoc.setName(ctx.getID());
-                variant.setPrimaryKey(ctx.getID());
+            String ctxId = ctx.getID();
+            if(StringUtils.isNotEmpty(ctxId) && !ctxId.equals(".")) {
+                avsDoc.setPrimaryKey(ctxId);
+                avsDoc.setNameKey(ctxId);
+                avsDoc.setName(ctxId);
+                variant.setPrimaryKey(ctxId);
 
             } else{
                 //    if (hgvsNomenclature != null && hgvsNomenclature.length()<512) {
-                if (hgvsNomenclature != null && hgvsNomenclature.length()<100) {
+                if (hgvsNomenclature != null && hgvsNomenclature.length() < 100) {
                     variant.setPrimaryKey(hgvsNomenclature);
                     avsDoc.setPrimaryKey(hgvsNomenclature);
                     avsDoc.setNameKey(hgvsNomenclature);
@@ -126,21 +115,27 @@ public class AlleleVariantSequenceConverter {
 
 
                     c.getAssociatedGene().setSpecies(species);
-
-                    if(!transcriptsProcessed.contains(c.getTranscriptID())) {
-                        transcriptsProcessed.add(c.getTranscriptID());
+                    String transcriptID = c.getTranscript().getPrimaryKey();
+                    if(!transcriptsProcessed.contains(transcriptID)) {
+                        transcriptsProcessed.add(transcriptID);
                         if(first) {
                             first=false;
                             //    variant.setHgvsNomenclature(c.getHgvsVEPGeneNomenclature());
-                            c.getAssociatedGene().setSpecies(species);
+                            //c.getAssociatedGene().setSpecies(species);
                             variant.setGene(c.getAssociatedGene());
 
                         }
                         molecularConsequences.addAll(c.getTranscriptLevelConsequences());
                         //    s.setConsequence(c);
                         /****************SearchableDocument Fields***************/
-                        if(c.getAssociatedGene().getSymbol()!=null && !c.getAssociatedGene().getSymbol().equals("")){
-                            genes.add(c.getAssociatedGene().getNameKey());
+                        if(StringUtils.isNotEmpty(c.getAssociatedGene().getSymbol())) {
+                            // This is faster than calling getNakeKey on the gene
+                            StringBuffer buffer = new StringBuffer();
+                            buffer.append(c.getAssociatedGene().getSymbol());
+                            buffer.append(" (");
+                            buffer.append(speciesType.getAbbreviation());
+                            buffer.append(")");
+                            genes.add(buffer.toString());
                         }
                     }
                 }
@@ -163,7 +158,7 @@ public class AlleleVariantSequenceConverter {
     
     private List<TranscriptLevelConsequence> getConsequences(VariantContext ctx, String varNuc, String[] header) throws Exception {
         List<TranscriptLevelConsequence> features = new ArrayList<>();
-        List<String> alreadyAdded = new ArrayList<>();
+        HashSet<String> alreadyAdded = new HashSet<>();
         
         for (String s : ctx.getAttributeAsStringList("CSQ", "")) {
             if (s.length() > 0) {
@@ -171,10 +166,12 @@ public class AlleleVariantSequenceConverter {
 
                 if (header.length == infos.length) {
                     if (infos[0].equalsIgnoreCase(varNuc)) {
+
                         TranscriptLevelConsequence feature = new TranscriptLevelConsequence(header, infos);
-                        if(!alreadyAdded.contains(feature.getTranscriptID())) {
+                        String transcriptID = feature.getTranscript().getPrimaryKey();
+                        if(!alreadyAdded.contains(transcriptID)) {
                             features.add(feature);
-                            alreadyAdded.add(feature.getTranscriptID());
+                            alreadyAdded.add(transcriptID);
                         }
                     }
                 } else {

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleVariantSequenceConverter.java
@@ -110,18 +110,20 @@ public class AlleleVariantSequenceConverter {
             avsDoc.setVariant(variant);
             if (htpConsequences != null) {
                 for (TranscriptLevelConsequence c : htpConsequences) {
+                    if(geneCache != null){
+                        Set<String> synonymSet = geneCache.getSynonyms().get(c.getAssociatedGene().getPrimaryKey());
+                        Set<String> crossReferencesSet = geneCache.getCrossReferences().get(c.getAssociatedGene().getPrimaryKey());
+                        if(synonymSet != null){
+                            List<String> synonymList = new ArrayList<>(synonymSet);
+                            c.getAssociatedGene().setSynonymList(synonymList);
+                        }
 
-                    Set<String> synonymSet = geneCache.getSynonyms().get(c.getAssociatedGene().getPrimaryKey());
-                    Set<String> crossReferencesSet = geneCache.getCrossReferences().get(c.getAssociatedGene().getPrimaryKey());
-                    if(synonymSet != null){
-                        List<String> synonymList = new ArrayList<>(synonymSet);
-                        c.getAssociatedGene().setSynonymList(synonymList);
+                        if(crossReferencesSet != null){
+                            List<String> crossReferencesList = new ArrayList<>(crossReferencesSet);
+                            c.getAssociatedGene().setCrossReferencesList(crossReferencesList);
+                        }
                     }
 
-                    if(crossReferencesSet != null){
-                        List<String> crossReferencesList = new ArrayList<>(crossReferencesSet);
-                        c.getAssociatedGene().setCrossReferencesList(crossReferencesList);
-                    }
 
                     c.getAssociatedGene().setSpecies(species);
 

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/Gene.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/Gene.java
@@ -149,17 +149,4 @@ public class Gene extends GeneticEntity implements Comparable<Gene> {
     }
 
 
-    @JsonView(value = {View.AlleleVariantSequenceConverterForES.class})
-    @JsonProperty(value = "crossReferences")
-    public List<String> getCrossReferencesList() {
-        if (crossReferences != null) {
-            List<String> list = new ArrayList<>();
-            for (CrossReference crossReference : crossReferences) {
-                list.add(crossReference.getName());
-            }
-            return list;
-        } else {
-            return new ArrayList<>();
-        }
-    }
 }

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/Gene.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/Gene.java
@@ -2,6 +2,7 @@ package org.alliancegenome.neo4j.entity.node;
 
 import java.util.*;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.alliancegenome.es.util.DateConverter;
 import org.alliancegenome.neo4j.entity.relationship.*;
 import org.alliancegenome.neo4j.view.View;
@@ -145,5 +146,20 @@ public class Gene extends GeneticEntity implements Comparable<Gene> {
     @Override
     public int hashCode() {
         return Objects.hash(primaryKey);
+    }
+
+
+    @JsonView(value = {View.AlleleVariantSequenceConverterForES.class})
+    @JsonProperty(value = "crossReferences")
+    public List<String> getCrossReferencesList() {
+        if (crossReferences != null) {
+            List<String> list = new ArrayList<>();
+            for (CrossReference crossReference : crossReferences) {
+                list.add(crossReference.getName());
+            }
+            return list;
+        } else {
+            return new ArrayList<>();
+        }
     }
 }

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/GeneticEntity.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/GeneticEntity.java
@@ -54,15 +54,14 @@ public class GeneticEntity extends Neo4jEntity {
     @JsonView(value = {View.API.class, View.GeneAllelesAPI.class, View.GeneAlleleVariantSequenceAPI.class, View.AlleleVariantSequenceConverterForES.class})
     @JsonProperty(value = "synonyms")
     public List<String> getSynonymList() {
+        List<String> list = null;
         if (synonyms != null) {
-            List<String> list = new ArrayList<String>();
+            list = new ArrayList<String>();
             for (Synonym s : synonyms) {
                 list.add(s.getName());
             }
-            return list;
-        } else {
-            return new ArrayList<>();
         }
+        return list;
     }
 
     @JsonProperty(value = "synonyms")
@@ -78,8 +77,6 @@ public class GeneticEntity extends Neo4jEntity {
         }
     }
 
-
-
     @Relationship(type = "ALSO_KNOWN_AS")
     private List<SecondaryId> secondaryIds;
 
@@ -87,8 +84,9 @@ public class GeneticEntity extends Neo4jEntity {
     @JsonView(value = {View.API.class, View.AlleleVariantSequenceConverterForES.class})
     @JsonProperty(value = "secondaryIds")
     public List<String> getSecondaryIdsList() {
-        List<String> list = new ArrayList<>();
+        List<String> list = null;
         if (secondaryIds != null) {
+            list = new ArrayList<>();
             for (SecondaryId s : secondaryIds) {
                 list.add(s.getName());
             }
@@ -122,19 +120,14 @@ public class GeneticEntity extends Neo4jEntity {
 
 
 
-    public void setCrossReferenceMap(Map<String, Object> map) {
-        if (map == null)
-            return;
-        this.crossReferencesMap = map;
-    }
 
     @JsonView({View.API.class, View.AlleleVariantSequenceConverterForES.class})
     public Map<String, Object> getCrossReferenceMap() {
         if (crossReferencesMap != null)
             return crossReferencesMap;
-        crossReferencesMap = new HashMap<>();
 
         if (crossReferences != null) {
+            crossReferencesMap = new HashMap<>();
             List<CrossReference> othersList = new ArrayList<>();
             for (CrossReference cr : crossReferences) {
                 String typeName = crossReferenceType.getDisplayName();
@@ -154,12 +147,16 @@ public class GeneticEntity extends Neo4jEntity {
                         crossReferencesMap.put("other", othersList);
                     }
                 }
-
             }
         }
         return crossReferencesMap;
     }
 
+    public void setCrossReferenceMap(Map<String, Object> crossReferencesMap) {
+        if (crossReferencesMap == null)
+            return;
+        this.crossReferencesMap = crossReferencesMap;
+    }
 
     @JsonView(value = {View.AlleleVariantSequenceConverterForES.class})
     public List<String> getCrossReferencesList() {
@@ -173,7 +170,6 @@ public class GeneticEntity extends Neo4jEntity {
             return new ArrayList<>();
         }
     }
-
 
     public void setCrossReferencesList(List<String> list) {
         crossReferences = new ArrayList<>();
@@ -189,7 +185,7 @@ public class GeneticEntity extends Neo4jEntity {
 
 
     // ToDo: the primary URL should be an attribute on the entity node
-    @JsonView({View.GeneAllelesAPI.class, View.AlleleAPI.class, View.Default.class})
+    @JsonView({View.GeneAllelesAPI.class, View.AlleleAPI.class, View.Default.class,View.AlleleVariantSequenceConverterForES.class})
     @JsonProperty(value = "url")
     @JsonInclude(JsonInclude.Include.USE_DEFAULTS)
     public String getUrl() {

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/GeneticEntity.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/entity/node/GeneticEntity.java
@@ -78,6 +78,21 @@ public class GeneticEntity extends Neo4jEntity {
         }
     }
 
+
+
+    @JsonProperty(value = "crossReferencesList")
+    public void setCrossReferencesList(List<String> list) {
+        crossReferences = new ArrayList<CrossReference>();
+        if (CollectionUtils.isNotEmpty(list)) {
+            list.forEach(crRef -> {
+                CrossReference crossReference = new CrossReference();
+                crossReference.setName(crRef);
+                crossReferences.add(crossReference);
+            });
+            crossReferences.sort(Comparator.comparing(crossReference -> crossReference.getName().toLowerCase()));
+        }
+    }
+
     @Relationship(type = "ALSO_KNOWN_AS")
     private List<SecondaryId> secondaryIds;
 

--- a/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreation.java
+++ b/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreation.java
@@ -9,6 +9,7 @@ import org.alliancegenome.core.filedownload.model.*;
 import org.alliancegenome.core.util.StatsCollector;
 import org.alliancegenome.core.variant.config.VariantConfigHelper;
 import org.alliancegenome.core.variant.converters.AlleleVariantSequenceConverter;
+import org.alliancegenome.es.index.site.cache.GeneDocumentCache;
 import org.alliancegenome.es.util.*;
 import org.alliancegenome.neo4j.entity.SpeciesType;
 import org.alliancegenome.neo4j.view.View;
@@ -30,6 +31,7 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class SourceDocumentCreation extends Thread {
 
+    private final GeneDocumentCache geneCache;
     private DownloadSource source;
     private SpeciesType speciesType;
     private String[] header = null;
@@ -76,9 +78,10 @@ public class SourceDocumentCreation extends Thread {
     private StatsCollector statsCollector = new StatsCollector();
     private String message_header = "";
     
-    public SourceDocumentCreation(RestHighLevelClient client, DownloadSource source) {
+    public SourceDocumentCreation(RestHighLevelClient client, DownloadSource source, GeneDocumentCache geneCache) {
         this.client = client;
         this.source = source;
+        this.geneCache = geneCache;
         speciesType = SpeciesType.getTypeByID(source.getTaxonId());
         aVSConverter = new AlleleVariantSequenceConverter();
         if(indexing) client = EsClientFactory.getDefaultEsClient();
@@ -394,7 +397,7 @@ public class SourceDocumentCreation extends Thread {
 
                     for (VariantContext ctx : ctxList) {
                         try {
-                            List<AlleleVariantSequence> avsList = aVSConverter.convertContextToAlleleVariantSequence(ctx, header, speciesType);
+                            List<AlleleVariantSequence> avsList = aVSConverter.convertContextToAlleleVariantSequence(ctx, header, speciesType, geneCache);
 
                             for(AlleleVariantSequence sequence: avsList) {
                                 workBucket.add(sequence);

--- a/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreationManager.java
+++ b/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreationManager.java
@@ -4,6 +4,8 @@ import java.util.concurrent.*;
 
 import org.alliancegenome.core.filedownload.model.*;
 import org.alliancegenome.core.variant.config.VariantConfigHelper;
+import org.alliancegenome.es.index.site.cache.GeneDocumentCache;
+import org.alliancegenome.neo4j.repository.indexer.GeneIndexerRepository;
 import org.elasticsearch.client.RestHighLevelClient;
 
 import lombok.extern.log4j.Log4j2;
@@ -24,8 +26,12 @@ public class SourceDocumentCreationManager extends Thread {
         try {
 
             ExecutorService executor = Executors.newFixedThreadPool(VariantConfigHelper.getSourceDocumentCreatorThreads());
+
+            GeneIndexerRepository geneRepo = new GeneIndexerRepository();
+            GeneDocumentCache geneCache = geneRepo.getGeneDocumentCache();
+
             for(DownloadSource source: downloadSet.getDownloadFileSet()) {
-                SourceDocumentCreation creator = new SourceDocumentCreation(client, source);
+                SourceDocumentCreation creator = new SourceDocumentCreation(client, source, geneCache);
                 executor.execute(creator);
             }
 

--- a/agr_variant_indexer/src/test/java/org/alliancegenome/variant_indexer/TestSingleLineConvert.java
+++ b/agr_variant_indexer/src/test/java/org/alliancegenome/variant_indexer/TestSingleLineConvert.java
@@ -38,7 +38,7 @@ public class TestSingleLineConvert {
             try {
                 VariantContext vc = iter1.next();
                 //if(vc.getID().equals("rs55780505")) {
-                List<AlleleVariantSequence> docs = converter.convertContextToAlleleVariantSequence(vc, null, SpeciesType.HUMAN);
+                List<AlleleVariantSequence> docs = converter.convertContextToAlleleVariantSequence(vc, null, SpeciesType.HUMAN, null);
                 
                 for(AlleleVariantSequence doc: docs) {
                     String jsonDoc = mapper.writeValueAsString(doc);


### PR DESCRIPTION
This seems to work on my local machine, but I'm sure this is not the optimal way to do it. Feedback is definitely welcome. 

I instantiated `GeneDocumentCache` in `HtpVariantCreation` in order to avoid compilation errors. However, it's unclear to me what `HtpVariantCreation` is doing.

Added a `crossReferencesList` to `GeneticEntity` in order to have something similar to the synonyms list. I added its get method in `Gene` because I was running into a conflict with the `getCrossReferencesMap`  getter.