### PR TITLE
Allele indexer refactored

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/cache/AlleleDocumentCache.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/cache/AlleleDocumentCache.java
@@ -26,7 +26,7 @@ public class AlleleDocumentCache extends IndexerCache {
         document.setConstructRegulatoryRegion(constructRegulatoryRegions.get(id));
 
         document.setAlleles(alleles.get(id));
-        Allele a = alleleMap.get(id);
+        Allele a = alleleVariantMap.get(id);
         if(a!=null) {
             if(diseases != null && diseases.get(id)!=null )
                 a.setDisease(diseases.get(id).size() > 0);

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/cache/IndexerCache.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/cache/IndexerCache.java
@@ -13,6 +13,8 @@ import lombok.*;
 public abstract class IndexerCache {
 
     protected Map<String, Variant> variantMap = new HashMap<>();
+    protected Map<String, Allele> alleleVariantMap = new HashMap<>();
+
     protected Map<String, Allele> alleleMap = new HashMap<>();
     protected Map<String, Set<String>> assays = new HashMap<>();
     protected Map<String, Set<String>> chromosomes = new HashMap<>();

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/AlleleRepository.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/AlleleRepository.java
@@ -440,7 +440,7 @@ public class AlleleRepository extends Neo4jRepository<Allele> {
     }
     public Map<String, Allele> getAllAlleleVariants() {
 
-        String query = "MATCH p1=(:Species)-[:FROM_SPECIES]-(a:Allele)";
+        String query = "MATCH p1=(:Species)-[:FROM_SPECIES]-(a:Allele)--(g:Gene)";
         query+= " OPTIONAL MATCH p=(a:Allele)<-[:VARIATION]-(variant:Variant)-[:ASSOCIATION]->(:TranscriptLevelConsequence)--(:Transcript)--(:SOTerm)";
         query += " OPTIONAL MATCH crossRef=(a:Allele)-[:CROSS_REFERENCE]->(c:CrossReference)";
         query += " OPTIONAL MATCH vari=(a:Allele)<-[:VARIATION]-(variant:Variant)-[:VARIATION_TYPE]->(soTerm:SOTerm)";

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/AlleleRepository.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/AlleleRepository.java
@@ -440,7 +440,7 @@ public class AlleleRepository extends Neo4jRepository<Allele> {
     }
     public Map<String, Allele> getAllAlleleVariants() {
 
-        String query = "MATCH p1=(:Species)-[:FROM_SPECIES]-(a:Allele)--(g:Gene)";
+        String query = "MATCH p1=(:Species)<-[:FROM_SPECIES]-(a:Allele)-[:IS_ALLELE_OF]->(g:Gene)";
         query+= " OPTIONAL MATCH p=(a:Allele)<-[:VARIATION]-(variant:Variant)-[:ASSOCIATION]->(:TranscriptLevelConsequence)--(:Transcript)--(:SOTerm)";
         query += " OPTIONAL MATCH crossRef=(a:Allele)-[:CROSS_REFERENCE]->(c:CrossReference)";
         query += " OPTIONAL MATCH vari=(a:Allele)<-[:VARIATION]-(variant:Variant)-[:VARIATION_TYPE]->(soTerm:SOTerm)";

--- a/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/indexer/AlleleIndexerRepository.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/neo4j/repository/indexer/AlleleIndexerRepository.java
@@ -22,7 +22,7 @@ public class AlleleIndexerRepository extends AlleleRepository {
 
         ExecutorService executor = Executors.newFixedThreadPool(20); // Run all at once
         
-   //     executor.execute(new GetAlleleMapThread());
+        executor.execute(new GetAlleleMapThread());
         executor.execute(new GetAlleleVariantsMapThread());
         executor.execute(new GetCrossReferencesThread());
         executor.execute(new GetConstructsThread());
@@ -60,7 +60,7 @@ public class AlleleIndexerRepository extends AlleleRepository {
         @Override
         public void run() {
             log.info("Fetching alleles objects");
-            cache.setAlleleMap(getAllAlleleVariants());
+            cache.setAlleleVariantMap(getAllAlleleVariants());
             log.info("Finished Fetching alleles objects");
         }
     }


### PR DESCRIPTION
@adamgibs the allele indexer is refactored to put a fix for indexing associated gene which is being used in the allele variant detail table, as well to also index transgenic alleles. See if it is working as expected and not missing any transgenic alleles, an issue  AGR-3023 which was recently resolved. 