### PR TITLE
SCRUM-2721: backend trick for Saccharomyces cerevisia

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
@@ -289,7 +289,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 		pagination.addFieldFilter(FieldFilter.ASSOCIATION_TYPE, associationType);
 
 		// TODO: remove when SC data is fixed:
-		if (species == "Saccharomyces cerevisiae") {
+		if (species.equals("Saccharomyces cerevisiae")) {
 			pagination.addFieldFilter(FieldFilter.SPECIES, "Saccharomyces cerevisiae S288C");
 		}
 		if (pagination.hasErrors()) {


### PR DESCRIPTION
When fixing the agr_ui for the SC and SC-S288C issue:

- When SC is selected in the dropdown filter, the UI refetch data with the argument `filter.species="Saccharomyces cerevisia"`.
- Can the Pagination support adding 2 filters: one for Saccharomyces cerevisiae" and other for "Saccharomyces cerevisiae S288C" ?