### PR TITLE
SCRUM-3257

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
@@ -143,7 +143,8 @@ public class DiseaseESService {
 	}
 
 	private void generateFilter(BoolQueryBuilder bool, String filterName, String filterValue) {
-
+		filterValue = QueryParser.escape(filterValue);
+		filterValue = filterValue.replaceAll("'"," ");
 		if (filterValue.contains("|")) {
 			Log.info("Or Filter: " + filterName + " " + filterValue);
 			BoolQueryBuilder orClause = boolQuery();
@@ -158,7 +159,7 @@ public class DiseaseESService {
 			} else {
 				String[] elements = filterValue.split(" ");
 				BoolQueryBuilder andClause = boolQuery();
-				Arrays.stream(elements).forEach(element -> andClause.must(QueryBuilders.queryStringQuery("*" + QueryParser.escape(element) + "*").field(filterName)));
+				Arrays.stream(elements).forEach(element -> andClause.must(QueryBuilders.queryStringQuery("*" + element + "*").field(filterName)));
 				bool.must(andClause);
 			}
 		}

--- a/agr_java_core/src/main/java/org/alliancegenome/cache/CacheAlliance.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/cache/CacheAlliance.java
@@ -10,6 +10,7 @@ import org.alliancegenome.neo4j.entity.node.Allele;
 import org.alliancegenome.neo4j.entity.node.ECOTerm;
 import org.alliancegenome.neo4j.entity.node.InteractionGeneJoin;
 import org.alliancegenome.neo4j.view.HomologView;
+import org.alliancegenome.neo4j.view.ParalogBean;
 
 public enum CacheAlliance {
 
@@ -22,7 +23,7 @@ public enum CacheAlliance {
 	GENE_PHENOTYPE(PhenotypeAnnotation.class, (12584 * 100) + 956783), // min: 507 max: 956783 mean: 12584
 	GENE_INTERACTION(InteractionGeneJoin.class, (134649 * 100) + 20188384), // min: 3354 max: 20188384 mean: 134649
 	GENE_ORTHOLOGY(HomologView.class, (18912 * 100) + 2020141), // min: 905 max: 2020141 mean: 18912
-	GENE_PARALOGY(HomologView.class, (18912 * 100) + 2020141), // min: 905 max: 2020141 mean: 18912
+	GENE_PARALOGY(ParalogBean.class, (18912 * 100) + 2020141), // min: 905 max: 2020141 mean: 18912
 	GENE_PURE_AGM_PHENOTYPE(PrimaryAnnotatedEntity.class, 10_000_000), // Need to run the stats on this cache
 	GENE_ASSOCIATION_MODEL_GENE(PrimaryAnnotatedEntity.class, (4073 * 100) + 1468636), // min: 492 max: 1468636 mean: 4073
 	//GENE_ALLELE(),


### PR DESCRIPTION
replace single quote with white space. QueryParser.escape() method is not escaping the single quote.