### PR TITLE
Removed host based sitemap

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/SiteMapController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/SiteMapController.java
@@ -1,17 +1,11 @@
 package org.alliancegenome.api.controller;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.ws.rs.core.UriInfo;
 
-import org.alliancegenome.api.model.xml.SiteMap;
-import org.alliancegenome.api.model.xml.SiteMapIndex;
-import org.alliancegenome.api.model.xml.XMLURL;
-import org.alliancegenome.api.model.xml.XMLURLSet;
+import org.alliancegenome.api.model.xml.*;
 import org.alliancegenome.api.rest.interfaces.SiteMapRESTInterface;
 import org.alliancegenome.cache.repository.SiteMapCacheManager;
 import org.alliancegenome.core.config.ConfigHelper;
@@ -25,26 +19,26 @@ public class SiteMapController implements SiteMapRESTInterface {
 	@Inject SiteMapCacheManager manager;
 
 	@Override
-	public SiteMapIndex getSiteMap(UriInfo uriInfo) {
+	public SiteMapIndex getSiteMap() {
 		
 		List<SiteMap> list = new ArrayList<SiteMap>();
 		
 		List<String> geneKeys = manager.getGenesKeys();
 		log.info("Gene Keys: "	+ geneKeys.size());
 		for(String s: geneKeys) {
-			list.add(new SiteMap(buildUrl(uriInfo, "api/sitemap/gene-sitemap-" + s + ".xml"), ConfigHelper.getAppStart()));
+			list.add(new SiteMap(buildUrl("api/sitemap/gene-sitemap-" + s + ".xml"), ConfigHelper.getAppStart()));
 		}
 		
 		List<String> diseaseKeys = manager.getDiseaseKeys();
 		log.info("Disease Keys: "  + diseaseKeys.size());
 		for(String s: diseaseKeys) {
-			list.add(new SiteMap(buildUrl(uriInfo, "api/sitemap/disease-sitemap-" + s + ".xml"), ConfigHelper.getAppStart()));
+			list.add(new SiteMap(buildUrl("api/sitemap/disease-sitemap-" + s + ".xml"), ConfigHelper.getAppStart()));
 		}
 		
 		List<String> alleleKeys = manager.getAlleleKeys();
 		log.info("Disease Keys: "  + alleleKeys.size());
 		for(String s: alleleKeys) {
-			list.add(new SiteMap(buildUrl(uriInfo, "api/sitemap/allele-sitemap-" + s + ".xml"), ConfigHelper.getAppStart()));
+			list.add(new SiteMap(buildUrl("api/sitemap/allele-sitemap-" + s + ".xml"), ConfigHelper.getAppStart()));
 		}
 		
 		SiteMapIndex index = new SiteMapIndex();
@@ -53,19 +47,19 @@ public class SiteMapController implements SiteMapRESTInterface {
 	}
 
 	@Override
-	public XMLURLSet getCategorySiteMap(String category, Integer page, UriInfo uriInfo) {
-		return buildSiteMapByCategory(category, page, uriInfo);
+	public XMLURLSet getCategorySiteMap(String category, Integer page) {
+		return buildSiteMapByCategory(category, page);
 	}
 
 
-	private XMLURLSet buildSiteMapByCategory(String category, Integer page, UriInfo uriInfo) {
+	private XMLURLSet buildSiteMapByCategory(String category, Integer page) {
 
 		if(category.equals("gene")) {
 			List<XMLURL> list = manager.getGenes(page.toString());
 			XMLURLSet set = new XMLURLSet();
 			set.setUrl(list);
 			for(XMLURL url: list) {
-				url.setLoc(buildUrl(uriInfo, url.getLoc()));
+				url.setLoc(buildUrl(url.getLoc()));
 			}
 			return set;
 		}
@@ -75,7 +69,7 @@ public class SiteMapController implements SiteMapRESTInterface {
 			XMLURLSet set = new XMLURLSet();
 			set.setUrl(list);
 			for(XMLURL url: list) {
-				url.setLoc(buildUrl(uriInfo, url.getLoc()));
+				url.setLoc(buildUrl(url.getLoc()));
 			}
 			return set;
 		}
@@ -85,7 +79,7 @@ public class SiteMapController implements SiteMapRESTInterface {
 			XMLURLSet set = new XMLURLSet();
 			set.setUrl(list);
 			for(XMLURL url: list) {
-				url.setLoc(buildUrl(uriInfo, url.getLoc()));
+				url.setLoc(buildUrl(url.getLoc()));
 			}
 			return set;
 		}
@@ -93,17 +87,10 @@ public class SiteMapController implements SiteMapRESTInterface {
 		return null;
 	}
 
-	private String buildUrl(UriInfo uriInfo, String inUrl) {
-		final URI uri = uriInfo.getAbsolutePath();
+	private String buildUrl(String inUrl) {
 		final StringBuilder url = new StringBuilder();
-		url.append("https://");
-		url.append(uri.getHost());
+		url.append("https://www.alliancegenome.org");
 
-		final int port = uri.getPort();
-		if (port != -1) {
-			url.append(":");
-			url.append(uri.getPort());
-		}
 		if(inUrl != null) {
 			url.append("/");
 			url.append(inUrl);

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/SiteMapRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/SiteMapRESTInterface.java
@@ -1,15 +1,9 @@
 package org.alliancegenome.api.rest.interfaces;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriInfo;
 
-import org.alliancegenome.api.model.xml.SiteMapIndex;
-import org.alliancegenome.api.model.xml.XMLURLSet;
+import org.alliancegenome.api.model.xml.*;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 @Path("/")
@@ -19,14 +13,13 @@ public interface SiteMapRESTInterface {
 
 	@GET
 	@Path("/sitemap.xml")
-	public SiteMapIndex getSiteMap(@Context UriInfo uriInfo);
+	public SiteMapIndex getSiteMap();
 
 	@GET
 	@Path("/sitemap/{category}-sitemap-{page}.xml")
 	public XMLURLSet getCategorySiteMap(
 		@PathParam("category") String category,
-		@PathParam("page") Integer page,
-		@Context UriInfo uriInfo
+		@PathParam("page") Integer page
 	);
 
 }

--- a/agr_java_core/pom.xml
+++ b/agr_java_core/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>4.10.0.201712302008-r</version>
+			<version>6.7.0.202309050840-r</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Site maps are only for production, and as the cloudfront with ALB don't pass the `Host:` header through the request anymore might as well just hardcode the sitemap to the production site. We only want google indexing the main site anyway.