### PR TITLE
SCRUM-3286 Update curation library to v0.25.0

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/DiseaseAnnotationCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/DiseaseAnnotationCurationIndexer.java
@@ -107,7 +107,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 				
 				VocabularyTerm diseaseRelation = vocabService.getVocabularyTerm("is_implicated_in");
 				if (da instanceof GeneDiseaseAnnotation) {
-					diseaseRelation = da.getDiseaseRelation();
+					diseaseRelation = da.getRelation();
 				}
 
 				String key = diseaseRelation.getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
@@ -178,7 +178,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 			HashMap<String, AlleleDiseaseAnnotationDocument> lookup = new HashMap<>();
 
 			for (DiseaseAnnotation da : entry.getValue().getRight()) {
-				String key = da.getDiseaseRelation().getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
+				String key = da.getRelation().getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
 				AlleleDiseaseAnnotationDocument adad = lookup.get(key);
 
 				if (adad == null) {
@@ -186,7 +186,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 					HashMap<String, Integer> order = SpeciesType.getSpeciesOrderByTaxonID(entry.getValue().getLeft().getTaxon().getCurie());
 					adad.setSpeciesOrder(order);
 					adad.setSubject(entry.getValue().getLeft());
-					adad.setDiseaseRelation(da.getDiseaseRelation());
+					adad.setDiseaseRelation(da.getRelation());
 					adad.setObject(da.getObject());
 					lookup.put(key, adad);
 				}
@@ -217,7 +217,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 			HashMap<String, AGMDiseaseAnnotationDocument> lookup = new HashMap<>();
 
 			for (DiseaseAnnotation da : entry.getValue().getRight()) {
-				String key = da.getDiseaseRelation().getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
+				String key = da.getRelation().getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
 				AGMDiseaseAnnotationDocument adad = lookup.get(key);
 
 				if (adad == null) {
@@ -225,7 +225,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 					HashMap<String, Integer> order = SpeciesType.getSpeciesOrderByTaxonID(entry.getValue().getLeft().getTaxon().getCurie());
 					adad.setSpeciesOrder(order);
 					adad.setSubject(entry.getValue().getLeft());
-					adad.setDiseaseRelation(da.getDiseaseRelation());
+					adad.setDiseaseRelation(da.getRelation());
 					adad.setObject(da.getObject());
 					lookup.put(key, adad);
 				}

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/DiseaseAnnotationCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/DiseaseAnnotationCurationIndexer.java
@@ -107,7 +107,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 				
 				VocabularyTerm diseaseRelation = vocabService.getVocabularyTerm("is_implicated_in");
 				if (da instanceof GeneDiseaseAnnotation) {
-					diseaseRelation = da.getRelation();
+					diseaseRelation = da.getDiseaseRelation();
 				}
 
 				String key = diseaseRelation.getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
@@ -178,7 +178,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 			HashMap<String, AlleleDiseaseAnnotationDocument> lookup = new HashMap<>();
 
 			for (DiseaseAnnotation da : entry.getValue().getRight()) {
-				String key = da.getRelation().getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
+				String key = da.getDiseaseRelation().getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
 				AlleleDiseaseAnnotationDocument adad = lookup.get(key);
 
 				if (adad == null) {
@@ -186,7 +186,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 					HashMap<String, Integer> order = SpeciesType.getSpeciesOrderByTaxonID(entry.getValue().getLeft().getTaxon().getCurie());
 					adad.setSpeciesOrder(order);
 					adad.setSubject(entry.getValue().getLeft());
-					adad.setDiseaseRelation(da.getRelation());
+					adad.setDiseaseRelation(da.getDiseaseRelation());
 					adad.setObject(da.getObject());
 					lookup.put(key, adad);
 				}
@@ -217,7 +217,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 			HashMap<String, AGMDiseaseAnnotationDocument> lookup = new HashMap<>();
 
 			for (DiseaseAnnotation da : entry.getValue().getRight()) {
-				String key = da.getRelation().getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
+				String key = da.getDiseaseRelation().getName() + "_" + da.getObject().getName() + "_" + da.getNegated();
 				AGMDiseaseAnnotationDocument adad = lookup.get(key);
 
 				if (adad == null) {
@@ -225,7 +225,7 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 					HashMap<String, Integer> order = SpeciesType.getSpeciesOrderByTaxonID(entry.getValue().getLeft().getTaxon().getCurie());
 					adad.setSpeciesOrder(order);
 					adad.setSubject(entry.getValue().getLeft());
-					adad.setDiseaseRelation(da.getRelation());
+					adad.setDiseaseRelation(da.getDiseaseRelation());
 					adad.setObject(da.getObject());
 					lookup.put(key, adad);
 				}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
 		<quarkus.platform.version>${quarkus.version}</quarkus.platform.version>
-		<curation.version>v0.24.0</curation.version>
+		<curation.version>v0.25.0</curation.version>
 		<!-- <curation.version>0.0.0-SNAPSHOT</curation.version> -->
 	</properties>
 	<dependencyManagement>


### PR DESCRIPTION
@oblodgett @cmpich 
v0.25.0 brings in a breaking change for disease annotations in that `diseaseRelation` has been renamed to `relation`.  If my understanding of the main site is correct (probably not) then if we keep `diseaseRelation` in the DiseaseAnnotationDocument then the UI should be unaffected by this change and the only changes required are the changes made here to the DiseaseAnnotationCurationIndexer.

However, I don't know if we also want to change the document to bring it in line with the latest LinkML version and make any required UI changes.  Given there's a bunch of stuff going on in the document that's not covered by the LinkML model then I'm guessing this isn't really necessary.