### PR TITLE
Remove obsolete zen tools and API key parameters from Claude workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,9 +28,6 @@ jobs:
       # Java backend-specific focus for Spring Boot application
       review_focus: "critical bugs, database performance issues, and security vulnerabilities in the Java Spring Boot backend. Focus on: SQL injection, N+1 queries, missing indexes, transaction management errors, memory leaks, thread safety issues, and API security flaws"
       trigger_phrase: "@claude"
-      use_zen_tools: true
-      # Use centralized thresholds from .github repo (skip_threshold: 3, pr_size_threshold: 40)
+      # Use centralized threshold from .github repo (skip_threshold: 3)
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}


### PR DESCRIPTION
- Remove use_zen_tools parameter that is no longer supported
- Remove OPENAI_API_KEY and GOOGLE_API_KEY secrets
- Keep only ANTHROPIC_API_KEY as required secret
- Align with simplified reusable workflow in alliance-genome/.github

🤖 Generated with [Claude Code](https://claude.ai/code)