### PR TITLE
fix: resolve LiteratureIndexer ES mapping and date parse errors

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
@@ -237,8 +237,14 @@ public class Mapping extends Builder {
 		builder.endObject();
 		new FieldBuilder(builder, "geneToGeneOrthologyGenerated.subjectGene.primaryExternalId", "text").keyword().build();
 
+		builder.startObject("literatureSummary");
+		builder.field("type", "object");
+		builder.field("dynamic", false);
+		builder.endObject();
 		new FieldBuilder(builder, "literatureSummary.date_arrived_in_pubmed", "text").keyword().build();
 		new FieldBuilder(builder, "literatureSummary.date_published", "text").keyword().build();
+		new FieldBuilder(builder, "literatureSummary.date_last_modified_in_pubmed", "text").keyword().build();
+		new FieldBuilder(builder, "literatureSummary.page_range", "keyword").build();
 
 		// GeneExpressionDocument: dynamic false (78 -> ~8 indexed fields)
 		builder.startObject("geneExpressionAnnotation");


### PR DESCRIPTION
## Summary
- Add explicit `keyword` mapping for `literatureSummary.page_range` to prevent ES from dynamically mapping page ranges (e.g. `2389-99`) as dates
- Normalize `date_last_modified_in_pubmed` to zero-padded ISO 8601 (`YYYY-MM-DD`) before indexing to fix `strict_date_optional_time` parse failures on values like `2021-7-8`
- Remove unused `ObjectMapper` import

## Test plan
- [ ] Verify `agr_java_core` and `agr_indexer` compile cleanly
- [ ] Run the stage indexer and confirm no more `mapper_parsing_exception` errors for `page_range` or `date_last_modified_in_pubmed`
- [ ] Verify literature documents are searchable after re-index

🤖 Generated with [Claude Code](https://claude.com/claude-code)