### PR TITLE
Unify high throughput and low throughput alleles in gene alleles endpoint

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
@@ -44,6 +44,7 @@ import org.alliancegenome.core.translators.tdf.GeneGeneticInteractionToTdfTransl
 import org.alliancegenome.core.translators.tdf.GeneMolecularInteractionToTdfTranslator;
 import org.alliancegenome.curation_api.model.document.es.AffectedGenomicModelDocument;
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
+import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.curation_api.model.document.es.GeneSummaryDocument;
 import org.alliancegenome.curation_api.model.document.es.SequenceSummaryDocument;
 import org.alliancegenome.es.model.query.FieldFilter;
@@ -130,7 +131,7 @@ public class GeneController implements GeneRESTInterface {
 	}
 	
 	@Override
-	public JsonResultResponse<AlleleSummaryDocument> getAllelesPerGene(String id,
+	public JsonResultResponse<ESDocument> getAllelesPerGene(String id,
 															Integer limit,
 															Integer page,
 															String sortBy,
@@ -162,7 +163,7 @@ public class GeneController implements GeneRESTInterface {
 		}
 
 		try {
-			JsonResultResponse<AlleleSummaryDocument> alleles = alleleESService.getAllelesByGene(id, pagination);
+			JsonResultResponse<ESDocument> alleles = alleleESService.getAllelesByGene(id, pagination);
 			alleles.setHttpServletRequest(null);
 			alleles.calculateRequestDuration(startTime);
 			return alleles;
@@ -298,7 +299,7 @@ public class GeneController implements GeneRESTInterface {
 		String disease,
 		String category) {
 
-		JsonResultResponse<AlleleSummaryDocument> alleles = getAllelesPerGene(id, 200000, 1, sortBy, asc, symbol, synonym, variant, variantType, molecularConsequence, disease, phenotype, category);
+		JsonResultResponse<ESDocument> alleles = getAllelesPerGene(id, 200000, 1, sortBy, asc, symbol, synonym, variant, variantType, molecularConsequence, disease, phenotype, category);
 
 		Response.ResponseBuilder responseBuilder = Response.ok(alleleTranslator.getAllRows(alleles.getResults()));
 		APIServiceHelper.setDownloadHeader(id, EntityType.GENE, EntityType.ALLELE, responseBuilder);

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/GeneRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/GeneRESTInterface.java
@@ -14,6 +14,7 @@ import org.alliancegenome.api.entity.GeneTransgenicAlleleSummaryDocument;
 import org.alliancegenome.cache.repository.helper.JsonResultResponse;
 import org.alliancegenome.curation_api.model.document.es.AffectedGenomicModelDocument;
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
+import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.curation_api.model.document.es.GeneSummaryDocument;
 import org.alliancegenome.curation_api.model.document.es.SequenceSummaryDocument;
 import org.alliancegenome.curation_api.view.CurationView;
@@ -83,7 +84,7 @@ public interface GeneRESTInterface {
 				description = "Alleles for a gene.",
 				content = @Content(mediaType = "application/json",
 					schema = @Schema(implementation = Null.class)))})
-	JsonResultResponse<AlleleSummaryDocument> getAllelesPerGene(
+	JsonResultResponse<ESDocument> getAllelesPerGene(
 		//@ApiParam(name = "id", description = "Search for Alleles for a given Gene by ID")
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Search for Alleles for a given Gene by ID", required = true, schema = @Schema(type = SchemaType.STRING))
 		@PathParam("id") String id,

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/GeneRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/GeneRESTInterface.java
@@ -231,10 +231,10 @@ public interface GeneRESTInterface {
 		@QueryParam("filter.variantType") String variantType,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.molecularConsequence", description = "Consequence", schema = @Schema(type = SchemaType.STRING))
 		@QueryParam("filter.molecularConsequence") String consequence,
-		@Parameter(in = ParameterIn.QUERY, name = "filter.hasPhenotype", description = "Phenotypes", schema = @Schema(type = SchemaType.STRING))
-		@QueryParam("filter.hasPhenotype") String phenotype,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.hasDisease", description = "Disease for a given allele", schema = @Schema(type = SchemaType.STRING))
 		@QueryParam("filter.hasDisease") String disease,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.hasPhenotype", description = "Phenotypes", schema = @Schema(type = SchemaType.STRING))
+		@QueryParam("filter.hasPhenotype") String phenotype,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.alleleCategory", description = "Category of an allele", schema = @Schema(type = SchemaType.STRING))
 		@QueryParam("filter.alleleCategory") String alleleCategory
 	);

--- a/agr_api/src/main/java/org/alliancegenome/api/service/AlleleESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/AlleleESService.java
@@ -20,6 +20,7 @@ import org.alliancegenome.es.model.query.Pagination;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.SortOrder;
@@ -133,21 +134,25 @@ public class AlleleESService extends ESService {
 
 	public JsonResultResponse<ESDocument> getAllelesByGene(String geneId, Pagination pagination) {
 
-		BoolQueryBuilder bool = boolQuery();
-		bool.must(new MatchQueryBuilder("geneIds", geneId));
-		bool.filter(new TermQueryBuilder("category", "allele_summary"));
+		BoolQueryBuilder queryBuilder = new BoolQueryBuilder();
+		BoolQueryBuilder shouldQueryBuilder = new BoolQueryBuilder();
+		queryBuilder.must(QueryBuilders.termQuery("geneIds", geneId));
+		shouldQueryBuilder.should(QueryBuilders.termQuery("category.keyword", "allele_summary"));
+		shouldQueryBuilder.should(QueryBuilders.termQuery("category.keyword", "variant_summary"));
+		queryBuilder.must(shouldQueryBuilder);
+
 		JsonResultResponse<ESDocument> ret = new JsonResultResponse<>();
-		ret.setSupplementalData(getAlleleSupplementalData(bool));
-		addTableFilter(pagination, bool);
-		SearchResponse searchResponse = getSearchResponse(bool, pagination, sortMap.get(pagination.getSortBy()), false);
+		ret.setSupplementalData(getAlleleSupplementalData(queryBuilder));
+		addTableFilter(pagination, queryBuilder);
+		SearchResponse searchResponse = getSearchResponse(queryBuilder, pagination, sortMap.get(pagination.getSortBy()), true);
 		List<ESDocument> list = new ArrayList<>();
 		Arrays.stream(searchResponse.getHits().getHits()).forEach(searchHit -> {
 			try {
-				ESDocument object = mapper.readValue(searchHit.getSourceAsString(), ESDocument.class);
-				if (object.getCategory().equals("allele_summary")) {
+				String category = (String)searchHit.getSourceAsMap().get("category");
+				if (category.equals("allele_summary")) {
 					AlleleSummaryDocument asd = mapper.readValue(searchHit.getSourceAsString(), AlleleSummaryDocument.class);
 					list.add(asd);
-				} else if (object.getCategory().equals("variant_summary")) {
+				} else if (category.equals("variant_summary")) {
 					VariantSummaryDocument vsd = mapper.readValue(searchHit.getSourceAsString(), VariantSummaryDocument.class);
 					list.add(vsd);
 				}

--- a/agr_api/src/main/java/org/alliancegenome/api/service/AlleleESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/AlleleESService.java
@@ -148,7 +148,7 @@ public class AlleleESService extends ESService {
 		List<ESDocument> list = new ArrayList<>();
 		Arrays.stream(searchResponse.getHits().getHits()).forEach(searchHit -> {
 			try {
-				String category = (String)searchHit.getSourceAsMap().get("category");
+				String category = (String) searchHit.getSourceAsMap().get("category");
 				if (category.equals("allele_summary")) {
 					AlleleSummaryDocument asd = mapper.readValue(searchHit.getSourceAsString(), AlleleSummaryDocument.class);
 					list.add(asd);

--- a/agr_api/src/main/java/org/alliancegenome/api/service/AlleleESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/AlleleESService.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.alliancegenome.cache.repository.helper.JsonResultResponse;
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
+import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.curation_api.model.document.es.TransgenicAlleleDocument;
 import org.alliancegenome.curation_api.model.document.es.VariantSummaryDocument;
 import org.alliancegenome.es.model.query.Pagination;
@@ -130,20 +131,26 @@ public class AlleleESService extends ESService {
 		return ret;
 	}
 
-	public JsonResultResponse<AlleleSummaryDocument> getAllelesByGene(String geneId, Pagination pagination) {
+	public JsonResultResponse<ESDocument> getAllelesByGene(String geneId, Pagination pagination) {
 
 		BoolQueryBuilder bool = boolQuery();
-		bool.must(new MatchQueryBuilder("alleleOfGene.primaryExternalId", geneId));
+		bool.must(new MatchQueryBuilder("geneIds", geneId));
 		bool.filter(new TermQueryBuilder("category", "allele_summary"));
-		JsonResultResponse<AlleleSummaryDocument> ret = new JsonResultResponse<>();
+		JsonResultResponse<ESDocument> ret = new JsonResultResponse<>();
 		ret.setSupplementalData(getAlleleSupplementalData(bool));
 		addTableFilter(pagination, bool);
 		SearchResponse searchResponse = getSearchResponse(bool, pagination, sortMap.get(pagination.getSortBy()), false);
-		List<AlleleSummaryDocument> list = new ArrayList<>();
+		List<ESDocument> list = new ArrayList<>();
 		Arrays.stream(searchResponse.getHits().getHits()).forEach(searchHit -> {
 			try {
-				AlleleSummaryDocument object = mapper.readValue(searchHit.getSourceAsString(), AlleleSummaryDocument.class);
-				list.add(object);
+				ESDocument object = mapper.readValue(searchHit.getSourceAsString(), ESDocument.class);
+				if (object.getCategory().equals("allele_summary")) {
+					AlleleSummaryDocument asd = mapper.readValue(searchHit.getSourceAsString(), AlleleSummaryDocument.class);
+					list.add(asd);
+				} else if (object.getCategory().equals("variant_summary")) {
+					VariantSummaryDocument vsd = mapper.readValue(searchHit.getSourceAsString(), VariantSummaryDocument.class);
+					list.add(vsd);
+				}
 			} catch (Exception e) {
 				e.printStackTrace();
 			}

--- a/agr_api/src/test/java/org/alliancegenome/api/tests/integration/AlleleIT.java
+++ b/agr_api/src/test/java/org/alliancegenome/api/tests/integration/AlleleIT.java
@@ -28,6 +28,7 @@ import org.alliancegenome.cache.CacheAlliance;
 import org.alliancegenome.cache.repository.helper.JsonResultResponse;
 import org.alliancegenome.core.config.ConfigHelper;
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
+import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.es.model.query.FieldFilter;
 import org.alliancegenome.es.model.query.Pagination;
 import org.alliancegenome.neo4j.entity.DiseaseAnnotation;
@@ -411,7 +412,7 @@ public class AlleleIT {
 	@Ignore
 	public void checkAllelesGeneTableSynonymFilter() {
 		GeneController ctrl = new GeneController();
-		JsonResultResponse<AlleleSummaryDocument> response = ctrl.getAllelesPerGene("RGD:2219", 10, 1, "", "true", "", "brc", "", "", "", "", "", "allele");
+		JsonResultResponse<ESDocument> response = ctrl.getAllelesPerGene("RGD:2219", 10, 1, "", "true", "", "brc", "", "", "", "", "", "allele");
 		assertNotNull(response);
 
 	}

--- a/agr_api/src/test/java/org/alliancegenome/api/tests/unit/TestES.java
+++ b/agr_api/src/test/java/org/alliancegenome/api/tests/unit/TestES.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 import org.alliancegenome.api.controller.GeneController;
 import org.alliancegenome.cache.repository.helper.JsonResultResponse;
-import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
+import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.es.util.EsClientFactory;
 
 public class TestES {
@@ -13,7 +13,7 @@ public class TestES {
 	
 	public static void main(String[] args) throws IOException {
 		GeneController ctrl = new GeneController();
-		JsonResultResponse<AlleleSummaryDocument> res = ctrl.getAllelesPerGene("HGNC:6190", 10, 1, null, "true", "", "", "", "", "intron_variant", "", "", "allele|allele with multiple associated variants|allele with one associated variant|variant");
+		JsonResultResponse<ESDocument> res = ctrl.getAllelesPerGene("HGNC:6190", 10, 1, null, "true", "", "", "", "", "intron_variant", "", "", "allele|allele with multiple associated variants|allele with one associated variant|variant");
 		System.out.println("DONE!!" + "RESULTS SIZE:" + res.getResults().size());
 		EsClientFactory.getDefaultEsClient().close();
 

--- a/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/AlleleToTdfTranslator.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/AlleleToTdfTranslator.java
@@ -10,6 +10,7 @@ import org.alliancegenome.api.entity.AlleleVariantSequence;
 import org.alliancegenome.api.entity.GeneTransgenicAlleleSummaryDocument;
 import org.alliancegenome.api.entity.TransgenicAlleleSummaryDocument;
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
+import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.curation_api.model.document.es.VariantSummaryDocument;
 import org.alliancegenome.curation_api.model.entities.Allele;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
@@ -23,7 +24,7 @@ import org.apache.commons.collections.CollectionUtils;
 
 public class AlleleToTdfTranslator {
 
-	public String getAllRows(List<AlleleSummaryDocument> annotations) {
+	public String getAllRows(List<ESDocument> annotations) {
 
 		List<AlleleDownloadRow> list = getAlleleDownloadRowsForGenes(annotations);
 		List<DownloadHeader> headers = List.of(
@@ -41,17 +42,14 @@ public class AlleleToTdfTranslator {
 		return DownloadHeader.getDownloadOutput(list, headers);
 	}
 
-	public List<AlleleDownloadRow> getAlleleDownloadRowsForGenes(List<AlleleSummaryDocument> annotations) {
+	public List<AlleleDownloadRow> getAlleleDownloadRowsForGenes(List<ESDocument> annotations) {
 		return annotations.stream()
+			.filter(AlleleSummaryDocument.class::isInstance)
+			.map(AlleleSummaryDocument.class::cast)
 			.map(annotation -> {
 				if (CollectionUtils.isNotEmpty(annotation.getVariants())) {
 					return annotation.getVariants().stream()
-						.map(join -> {
-								return annotation.getVariants().stream()
-									.map(var -> getBaseDownloadRow(annotation, var))
-									.collect(Collectors.toList());
-
-						}).flatMap(Collection::stream)
+						.map(var -> getBaseDownloadRow(annotation, var))
 						.collect(Collectors.toList());
 				} else {
 					return List.of(getBaseDownloadRow(annotation, null));

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
@@ -31,6 +31,7 @@ import org.alliancegenome.curation_api.model.entities.slotAnnotations.GeneSymbol
 import org.alliancegenome.es.index.site.cache.GeneDocumentCache;
 import org.alliancegenome.neo4j.entity.SpeciesType;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 import htsjdk.variant.variantcontext.VariantContext;
 
@@ -154,7 +155,8 @@ public class VariantSummaryConverter {
 
 			// Parse VEP consequences from CSQ field
 			Set<String> hgvsGList = new HashSet<>();
-			List<PredictedVariantConsequence> consequences = getConsequences(csqList, vepAllele, speciesType, hgvsGList);
+			Pair<List<PredictedVariantConsequence>, HashSet<String>> resultPair = getConsequences(csqList, vepAllele, speciesType, hgvsGList);
+			List<PredictedVariantConsequence> consequences = resultPair.getLeft();
 			if (consequences.isEmpty()) {
 				continue;
 			}
@@ -260,6 +262,7 @@ public class VariantSummaryConverter {
 			doc.setSubCategory("HTP_variant");
 			doc.setAllele(allele);
 			doc.setVariant(cvgla);
+			doc.setGeneIds(resultPair.getRight());
 
 			returnDocuments.add(doc);
 		}
@@ -273,10 +276,11 @@ public class VariantSummaryConverter {
 	 *
 	 * @param hgvsGList
 	 */
-	private List<PredictedVariantConsequence> getConsequences(List<String> csqList, String varNuc, SpeciesType speciesType, Set<String> hgvsGList) {
+	private Pair<List<PredictedVariantConsequence>, HashSet<String>> getConsequences(List<String> csqList, String varNuc, SpeciesType speciesType, Set<String> hgvsGList) {
 
 		List<PredictedVariantConsequence> consequences = new ArrayList<>();
 		HashSet<String> alreadyAdded = new HashSet<>();
+		HashSet<String> geneIds = new HashSet<>();
 
 		for (String csq : csqList) {
 			if (csq.isEmpty()) {
@@ -335,6 +339,7 @@ public class VariantSummaryConverter {
 					Gene gene = new Gene();
 					gene.setCurie(infos[geneIdx]);
 					gene.setTaxon(taxon);
+					geneIds.add(infos[geneIdx]);
 
 					// Set gene symbol if available
 					if (!infos[geneSymbolIdx].isEmpty()) {
@@ -445,7 +450,8 @@ public class VariantSummaryConverter {
 
 			consequences.add(consequence);
 		}
-		return consequences;
+		
+		return Pair.of(consequences, geneIds);
 	}
 
 	/**

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
@@ -18,6 +18,7 @@ public class VariantMapping extends Mapping {
 			new FieldBuilder(builder, "name_key", "keyword").build();
 			new FieldBuilder(builder, "alterationType", "text").keyword().build();
 			new FieldBuilder(builder, "genes", "text").keyword().build();
+			new FieldBuilder(builder, "geneIds", "keyword").build();
 			new FieldBuilder(builder, "associatedPhenotype", "text").keyword().sort().build();
 			new FieldBuilder(builder, "diseaseTerms.name", "text").keyword().sort().build();
 


### PR DESCRIPTION
## Summary
- Unified allele and variant summary documents in the gene alleles endpoint by querying both `allele_summary` and `variant_summary` categories
- Changed return type to `ESDocument` to support polymorphic document handling
- Added `geneIds` field to variant documents for proper gene-based filtering during VCF parsing
- Updated download translator to handle mixed document types

## Test plan
- [ ] Verify the `/api/gene/{id}/alleles` endpoint returns both allele and variant summary documents
- [ ] Confirm filtering works correctly for both document types
- [ ] Test the alleles download functionality produces correct output
- [ ] Validate that high throughput variants are now included in gene allele queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)