### PR TITLE
SCRUM-4758: Add curated alleles to GeneAlleleDetailsTable

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.api.controller;
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -43,7 +42,6 @@ import org.alliancegenome.core.translators.tdf.AlleleToTdfTranslator;
 import org.alliancegenome.core.translators.tdf.GeneGeneticInteractionToTdfTranslator;
 import org.alliancegenome.core.translators.tdf.GeneMolecularInteractionToTdfTranslator;
 import org.alliancegenome.curation_api.model.document.es.AffectedGenomicModelDocument;
-import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
 import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.curation_api.model.document.es.GeneSummaryDocument;
 import org.alliancegenome.curation_api.model.document.es.SequenceSummaryDocument;
@@ -94,9 +92,6 @@ public class GeneController implements GeneRESTInterface {
 	@Inject
 	OrthologyCacheRepository orthologyCacheService;
 
-	//@Inject
-	//private HttpRequest request;
-
 	@Inject
 	ExpressionService service;
 
@@ -129,21 +124,9 @@ public class GeneController implements GeneRESTInterface {
 			return gene;
 		}
 	}
-	
+
 	@Override
-	public JsonResultResponse<ESDocument> getAllelesPerGene(String id,
-															Integer limit,
-															Integer page,
-															String sortBy,
-															String asc,
-															String symbol,
-															String synonym,
-															String variant,
-															String variantType,
-															String molecularConsequence,
-															String hasDisease,
-															String hasPhenotype,
-															String category) {
+	public JsonResultResponse<ESDocument> getAllelesPerGene(String id, Integer limit, Integer page, String sortBy, String asc, String symbol, String synonym, String variant, String variantType, String molecularConsequence, String hasDisease, String hasPhenotype, String category) {
 
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
@@ -180,27 +163,8 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<SequenceSummaryDocument> getAllelesVariantPerGene(
-		String id,
-		Integer limit,
-		Integer page,
-		String sortBy,
-		String asc,
-		String symbol,
-		String associatedGeneSymbol,
-		String synonyms,
-		String hgvsgName,
-		String variantType,
-		String molecularConsequence,
-		String impact,
-		String sequenceFeatureType,
-		String sequenceFeature,
-		String variantPolyphen,
-		String variantSift,
-		String hasDisease,
-		String hasPhenotype,
-		String category,
-		String location) {
+	public JsonResultResponse<SequenceSummaryDocument> getAllelesVariantPerGene(String id, Integer limit, Integer page, String sortBy, String asc, String symbol, String associatedGeneSymbol, String synonyms, String hgvsgName, String variantType, String molecularConsequence, String impact,
+		String sequenceFeatureType, String sequenceFeature, String variantPolyphen, String variantSift, String hasDisease, String hasPhenotype, String category, String location) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFieldFilter(FieldFilter.SYMBOL, symbol);
@@ -241,63 +205,20 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public Response getAllelesVariantPerGeneDownload(
-		String id,
-		String symbol,
-		String associatedGeneSymbol,
-		String synonyms,
-		String hgvsgName,
-		String variantType,
-		String molecularConsequence,
-		String impact,
-		String sequenceFeatureType,
-		String sequenceFeature,
-		String variantPolyphen,
-		String variantSift,
-		String hasDisease,
-		String hasPhenotype,
-		String category,
-		String location) {
-		JsonResultResponse<SequenceSummaryDocument> alleles = getAllelesVariantPerGene(id,
-			Integer.MAX_VALUE,
-			1,
-			null,
-			null,
-			symbol,
-			associatedGeneSymbol,
-			synonyms,
-			hgvsgName,
-			variantType,
-			molecularConsequence,
-			impact,
-			sequenceFeatureType,
-			sequenceFeature,
-			variantPolyphen,
-			variantSift,
-			hasDisease,
-			hasPhenotype,
-			category,
-			location);
+	public Response getAllelesVariantPerGeneDownload(String id, String symbol, String associatedGeneSymbol, String synonyms, String hgvsgName, String variantType, String molecularConsequence, String impact, String sequenceFeatureType, String sequenceFeature, String variantPolyphen,
+		String variantSift, String hasDisease, String hasPhenotype, String category, String location) {
+		JsonResultResponse<SequenceSummaryDocument> alleles = getAllelesVariantPerGene(id, Integer.MAX_VALUE, 1, null, null, symbol, associatedGeneSymbol, synonyms, hgvsgName, variantType, molecularConsequence, impact, sequenceFeatureType, sequenceFeature, variantPolyphen, variantSift, hasDisease,
+			hasPhenotype, category, location);
 
-		// TODO: Response.ResponseBuilder responseBuilder = Response.ok(alleleTranslator.getAllAlleleVariantDetailRows(alleles.getResults()));
+		// TODO: Response.ResponseBuilder responseBuilder =
+		// Response.ok(alleleTranslator.getAllAlleleVariantDetailRows(alleles.getResults()));
 		Response.ResponseBuilder responseBuilder = Response.ok("");
 		APIServiceHelper.setDownloadHeader(id, EntityType.GENE, EntityType.ALLELESANDVARIANT, responseBuilder);
 		return responseBuilder.build();
 	}
 
 	@Override
-	public Response getAllelesPerGeneDownload(
-		String id,
-		String sortBy,
-		String asc,
-		String symbol,
-		String synonym,
-		String variant,
-		String variantType,
-		String molecularConsequence,
-		String phenotype,
-		String disease,
-		String category) {
+	public Response getAllelesPerGeneDownload(String id, String sortBy, String asc, String symbol, String synonym, String variant, String variantType, String molecularConsequence, String phenotype, String disease, String category) {
 
 		JsonResultResponse<ESDocument> alleles = getAllelesPerGene(id, 200000, 1, sortBy, asc, symbol, synonym, variant, variantType, molecularConsequence, disease, phenotype, category);
 
@@ -306,20 +227,9 @@ public class GeneController implements GeneRESTInterface {
 		return responseBuilder.build();
 	}
 
-
 	@Override
-	public JsonResultResponse<GeneGeneticInteractionDocument> getGeneticInteractions(String id, Integer limit, Integer page, String sortBy, String asc,
-																					 String interactorGeneSymbol,
-																					 String interactorSpecies,
-																					 String source,
-																					 String reference,
-																					 String role,
-																					 String geneticPerturbation,
-																					 String interactorRole,
-																					 String interactorGeneticPerturbation,
-																					 String phenotypes,
-																					 String interactionType,
-																					 @Context UriInfo info) {
+	public JsonResultResponse<GeneGeneticInteractionDocument> getGeneticInteractions(String id, Integer limit, Integer page, String sortBy, String asc, String interactorGeneSymbol, String interactorSpecies, String source, String reference, String role, String geneticPerturbation,
+		String interactorRole, String interactorGeneticPerturbation, String phenotypes, String interactionType, @Context UriInfo info) {
 		long startTime = System.currentTimeMillis();
 
 		if (StringUtils.isEmpty(sortBy)) {
@@ -343,7 +253,7 @@ public class GeneController implements GeneRESTInterface {
 			}
 		}
 		// Todo: needs to be made generic
-		//pagination.validateFilterValues(info.getQueryParameters());
+		// pagination.validateFilterValues(info.getQueryParameters());
 		if (pagination.hasErrors()) {
 			RestErrorMessage message = new RestErrorMessage();
 			message.setErrors(pagination.getErrors());
@@ -363,18 +273,8 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public Response getGeneticInteractionsDownload(String id, String sortBy, String asc,
-												   String interactorGeneSymbol,
-												   String interactorSpecies,
-												   String source,
-												   String reference,
-												   String role,
-												   String geneticPerturbation,
-												   String interactorRole,
-												   String interactorGeneticPerturbation,
-												   String phenotypes,
-												   String interactionType
-	) {
+	public Response getGeneticInteractionsDownload(String id, String sortBy, String asc, String interactorGeneSymbol, String interactorSpecies, String source, String reference, String role, String geneticPerturbation, String interactorRole, String interactorGeneticPerturbation, String phenotypes,
+		String interactionType) {
 		if (StringUtils.isEmpty(sortBy)) {
 			sortBy = "geneGeneticInteraction.geneGeneAssociationObject.geneSymbol.displayText.sort";
 		}
@@ -403,17 +303,9 @@ public class GeneController implements GeneRESTInterface {
 		return responseBuilder.build();
 	}
 
-
 	@Override
-	public JsonResultResponse<GeneMolecularInteractionDocument> getMolecularInteractions(String id, Integer limit, Integer page, String sortBy, String asc,
-																						 String moleculeType,
-																						 String interactorGeneSymbol,
-																						 String interactorSpecies,
-																						 String interactorMoleculeType,
-																						 String detectionMethod,
-																						 String source,
-																						 String reference,
-																						 @Context UriInfo info) {
+	public JsonResultResponse<GeneMolecularInteractionDocument> getMolecularInteractions(String id, Integer limit, Integer page, String sortBy, String asc, String moleculeType, String interactorGeneSymbol, String interactorSpecies, String interactorMoleculeType, String detectionMethod,
+		String source, String reference, @Context UriInfo info) {
 		long startTime = System.currentTimeMillis();
 		if (StringUtils.isEmpty(sortBy)) {
 			sortBy = "geneMolecularInteraction.geneGeneAssociationObject.geneSymbol.displayText.sort";
@@ -433,7 +325,7 @@ public class GeneController implements GeneRESTInterface {
 			}
 		}
 		// Todo: needs to be made generic
-		//pagination.validateFilterValues(info.getQueryParameters());
+		// pagination.validateFilterValues(info.getQueryParameters());
 		if (pagination.hasErrors()) {
 			RestErrorMessage message = new RestErrorMessage();
 			message.setErrors(pagination.getErrors());
@@ -453,15 +345,7 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public Response getMolecularInteractionsDownload(String id, String sortBy, String asc,
-													 String moleculeType,
-													 String interactorGeneSymbol,
-													 String interactorSpecies,
-													 String interactorMoleculeType,
-													 String detectionMethod,
-													 String source,
-													 String reference
-	) {
+	public Response getMolecularInteractionsDownload(String id, String sortBy, String asc, String moleculeType, String interactorGeneSymbol, String interactorSpecies, String interactorMoleculeType, String detectionMethod, String source, String reference) {
 		if (StringUtils.isEmpty(sortBy)) {
 			sortBy = "geneMolecularInteraction.geneGeneAssociationObject.geneSymbol.displayText.sort";
 		}
@@ -487,14 +371,7 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<GenePhenotypeAnnotationDocument> getPhenotypeAnnotations(
-		String id, Integer limit, Integer page, String sortBy,
-		String geneticEntity,
-		String geneticEntityType,
-		String phenotype,
-		String reference,
-		String dataProvider,
-		String asc) {
+	public JsonResultResponse<GenePhenotypeAnnotationDocument> getPhenotypeAnnotations(String id, Integer limit, Integer page, String sortBy, String geneticEntity, String geneticEntityType, String phenotype, String reference, String dataProvider, String asc) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("phenotypeStatement", phenotype);
@@ -514,29 +391,13 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public Response getPhenotypeAnnotationsDownloadFile(
-		String id,
-		String sortBy,
-		String geneticEntity,
-		String geneticEntityType,
-		String phenotype,
-		String reference,
-		String dataProvider,
-		String asc) {
+	public Response getPhenotypeAnnotationsDownloadFile(String id, String sortBy, String geneticEntity, String geneticEntityType, String phenotype, String reference, String dataProvider, String asc) {
 		// retrieve all records
-		JsonResultResponse<GenePhenotypeAnnotationDocument> response =
-			getPhenotypeAnnotations(id, 250000, 1, sortBy,
-				geneticEntity,
-				geneticEntityType,
-				phenotype,
-				reference,
-				dataProvider,
-				asc);
+		JsonResultResponse<GenePhenotypeAnnotationDocument> response = getPhenotypeAnnotations(id, 250000, 1, sortBy, geneticEntity, geneticEntityType, phenotype, reference, dataProvider, asc);
 		Response.ResponseBuilder responseBuilder = Response.ok(translator.getAllRows(response.getResults()));
 		APIServiceHelper.setDownloadHeader(id, EntityType.GENE, EntityType.PHENOTYPE, responseBuilder);
 		return responseBuilder.build();
 	}
-
 
 	@Override
 	public JsonResultResponse<DiseaseAnnotation> getDiseaseAnnotations(String id, Integer limit, Integer page, String sortBy, String geneticEntity, String geneticEntityType, String disease, String reference, String asc) {
@@ -555,40 +416,16 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public Response getDiseaseAnnotationsDownloadFile(
-		String id,
-		String sortBy,
-		String geneticEntity,
-		String geneticEntityType,
-		String disease,
-		String reference,
-		String asc) {
+	public Response getDiseaseAnnotationsDownloadFile(String id, String sortBy, String geneticEntity, String geneticEntityType, String disease, String reference, String asc) {
 		// retrieve all records
-		JsonResultResponse<DiseaseAnnotation> response =
-			getDiseaseAnnotationDocumentJsonResultResponse(id, Integer.MAX_VALUE, 1, sortBy,
-				geneticEntity,
-				geneticEntityType,
-				disease,
-				reference,
-				asc);
+		JsonResultResponse<DiseaseAnnotation> response = getDiseaseAnnotationDocumentJsonResultResponse(id, Integer.MAX_VALUE, 1, sortBy, geneticEntity, geneticEntityType, disease, reference, asc);
 		Response.ResponseBuilder responseBuilder = Response.ok(diseaseTranslator.getAllRowsForGenes(response.getResults()));
 		APIServiceHelper.setDownloadHeader(id, EntityType.GENE, EntityType.DISEASE, responseBuilder);
 		return responseBuilder.build();
 	}
 
-
 	@Override
-	public JsonResultResponse<AffectedGenomicModelDocument> getPrimaryAnnotatedEntityForModel(String id,
-																							  Integer limit,
-																							  Integer page,
-																							  String sortBy,
-																							  String modelName,
-																							  String species,
-																							  String experimentalCondition,
-																							  String disease,
-																							  String phenotype,
-																							  String source,
-																							  String asc) {
+	public JsonResultResponse<AffectedGenomicModelDocument> getPrimaryAnnotatedEntityForModel(String id, Integer limit, Integer page, String sortBy, String modelName, String species, String experimentalCondition, String disease, String phenotype, String source, String asc) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		if (pagination.hasErrors()) {
@@ -629,19 +466,8 @@ public class GeneController implements GeneRESTInterface {
 		return diseaseAnnotations;
 	}
 
-	private JsonResultResponse<DiseaseAnnotation> getEmpiricalDiseaseAnnotation(String id,
-																				Integer limit,
-																				Integer page,
-																				String sortBy,
-																				String geneticEntity,
-																				String geneticEntityType,
-																				String disease,
-																				String associationType,
-																				String evidenceCode,
-																				String source,
-																				String reference,
-																				String asc,
-																				UriInfo ui) {
+	private JsonResultResponse<DiseaseAnnotation> getEmpiricalDiseaseAnnotation(String id, Integer limit, Integer page, String sortBy, String geneticEntity, String geneticEntityType, String disease, String associationType, String evidenceCode, String source, String reference, String asc,
+		UriInfo ui) {
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFieldFilter(FieldFilter.GENETIC_ENTITY, geneticEntity);
 		pagination.addFieldFilter(FieldFilter.GENETIC_ENTITY_TYPE, geneticEntityType);
@@ -651,23 +477,13 @@ public class GeneController implements GeneRESTInterface {
 		pagination.addFieldFilter(FieldFilter.DISEASE, disease);
 		pagination.addFieldFilter(FieldFilter.FREFERENCE, reference);
 		MultivaluedMap<String, String> parameterMap = ui.getQueryParameters();
-		List<String> invalidFilterNames = parameterMap.entrySet().stream()
-			.filter(entry -> FieldFilter.hasFieldFilterPrefix(entry.getKey()) && !FieldFilter.isFieldFilterValue(entry.getKey()))
-			.map(Map.Entry::getKey)
-			.collect(Collectors.toList());
+		List<String> invalidFilterNames = parameterMap.entrySet().stream().filter(entry -> FieldFilter.hasFieldFilterPrefix(entry.getKey()) && !FieldFilter.isFieldFilterValue(entry.getKey())).map(Map.Entry::getKey).collect(Collectors.toList());
 		pagination.setInvalidFilterList(invalidFilterNames);
 		return diseaseService.getDiseaseAnnotations(id, pagination);
 	}
 
 	@Override
-	public JsonResultResponse<GeneToGeneOrthologyDocument> getGeneOrthology(String id,
-																			List<String> geneIDs,
-																			String geneLister,
-																			String stringencyFilter,
-																			String taxonID,
-																			String method,
-																			Integer limit,
-																			Integer page) {
+	public JsonResultResponse<GeneToGeneOrthologyDocument> getGeneOrthology(String id, List<String> geneIDs, String geneLister, String stringencyFilter, String taxonID, String method, Integer limit, Integer page) {
 
 		List<String> geneList = new ArrayList<>();
 		if (id != null) {
@@ -724,9 +540,7 @@ public class GeneController implements GeneRESTInterface {
 		OrthologyFilter orthologyFilter = new OrthologyFilter(stringencyFilter, null, null);
 		orthologyFilter.setStart(1);
 		JsonResultResponse<HomologView> orthologs = orthologyCacheService.getOrthologyGenes(geneList, orthologyFilter);
-		List<HomologView> filteredList = orthologs.getResults().stream()
-			.filter(orthologView -> expressionCacheRepository.hasExpression(orthologView.getHomologGene().getPrimaryKey()))
-			.sorted(Comparator.comparing(orthologView -> orthologView.getHomologGene().getSymbol().toLowerCase()))
+		List<HomologView> filteredList = orthologs.getResults().stream().filter(orthologView -> expressionCacheRepository.hasExpression(orthologView.getHomologGene().getPrimaryKey())).sorted(Comparator.comparing(orthologView -> orthologView.getHomologGene().getSymbol().toLowerCase()))
 			.collect(Collectors.toList());
 		orthologs.setResults(filteredList);
 		orthologs.setTotal(filteredList.size());
@@ -762,60 +576,13 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<DiseaseAnnotation> getDiseaseByExperiment(String id,
-																		Integer limit,
-																		Integer page,
-																		String sortBy,
-																		String geneticEntity,
-																		String geneticEntityType,
-																		String disease,
-																		String associationType,
-																		String evidenceCode,
-																		String source,
-																		String reference,
-																		String asc,
-																		UriInfo ui) {
-		return getEmpiricalDiseaseAnnotation(id,
-			limit,
-			page,
-			sortBy,
-			geneticEntity,
-			geneticEntityType,
-			disease,
-			associationType,
-			evidenceCode,
-			source,
-			reference,
-			asc,
-			ui);
+	public JsonResultResponse<DiseaseAnnotation> getDiseaseByExperiment(String id, Integer limit, Integer page, String sortBy, String geneticEntity, String geneticEntityType, String disease, String associationType, String evidenceCode, String source, String reference, String asc, UriInfo ui) {
+		return getEmpiricalDiseaseAnnotation(id, limit, page, sortBy, geneticEntity, geneticEntityType, disease, associationType, evidenceCode, source, reference, asc, ui);
 	}
 
 	@Override
-	public Response getDiseaseByExperimentDownload(
-		String id,
-		String sortBy,
-		String geneticEntity,
-		String geneticEntityType,
-		String disease,
-		String associationType,
-		String evidenceCode,
-		String source,
-		String reference,
-		String asc,
-		UriInfo ui) {
-		JsonResultResponse<DiseaseAnnotation> response = getEmpiricalDiseaseAnnotation(id,
-			Integer.MAX_VALUE,
-			null,
-			sortBy,
-			geneticEntity,
-			geneticEntityType,
-			disease,
-			associationType,
-			evidenceCode,
-			source,
-			reference,
-			asc,
-			ui);
+	public Response getDiseaseByExperimentDownload(String id, String sortBy, String geneticEntity, String geneticEntityType, String disease, String associationType, String evidenceCode, String source, String reference, String asc, UriInfo ui) {
+		JsonResultResponse<DiseaseAnnotation> response = getEmpiricalDiseaseAnnotation(id, Integer.MAX_VALUE, null, sortBy, geneticEntity, geneticEntityType, disease, associationType, evidenceCode, source, reference, asc, ui);
 		Response.ResponseBuilder responseBuilder = Response.ok(diseaseTranslator.getEmpiricalDiseaseByGene(response.getResults()));
 		responseBuilder.type(MediaType.TEXT_PLAIN_TYPE);
 		responseBuilder.header("Content-Disposition", "attachment; filename=\"DiseaseAssociationsViaEmpiricalData-" + id.replace(":", "-") + ".tsv\"");
@@ -834,20 +601,8 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<GeneTransgenicAlleleSummaryDocument> getTransgenicAlleles(
-		String geneID,
-		Integer limit,
-		Integer page,
-		String sortBy,
-		String alleleSymbol,
-		String constructSymbol,
-		String constructRegulatedGene,
-		String constructTargetedGene,
-		String constructExpressedGene,
-		String species,
-		String hasPhenotype,
-		String hasDisease,
-		UriInfo ui) {
+	public JsonResultResponse<GeneTransgenicAlleleSummaryDocument> getTransgenicAlleles(String geneID, Integer limit, Integer page, String sortBy, String alleleSymbol, String constructSymbol, String constructRegulatedGene, String constructTargetedGene, String constructExpressedGene, String species,
+		String hasPhenotype, String hasDisease, UriInfo ui) {
 		if (sortBy != null && sortBy.isBlank()) {
 			sortBy = "transgenicAllele";
 		}
@@ -877,32 +632,9 @@ public class GeneController implements GeneRESTInterface {
 		}
 	}
 
-
 	@Override
-	public Response getTransgenicAllelesPerGeneDownload(String geneId,
-														String sortBy,
-														String alleleSymbol,
-														String constructSymbol,
-														String constructRegulatedGene,
-														String constructTargetedGene,
-														String constructExpressedGene,
-														String species,
-														String hasPhenotype,
-														String hasDisease,
-														UriInfo ui) {
-		JsonResultResponse<GeneTransgenicAlleleSummaryDocument> alleles = getTransgenicAlleles(geneId,
-			20_000,
-			1,
-			sortBy,
-			alleleSymbol,
-			constructSymbol,
-			constructRegulatedGene,
-			constructTargetedGene,
-			constructExpressedGene,
-			species,
-			hasPhenotype,
-			hasDisease,
-			ui);
+	public Response getTransgenicAllelesPerGeneDownload(String geneId, String sortBy, String alleleSymbol, String constructSymbol, String constructRegulatedGene, String constructTargetedGene, String constructExpressedGene, String species, String hasPhenotype, String hasDisease, UriInfo ui) {
+		JsonResultResponse<GeneTransgenicAlleleSummaryDocument> alleles = getTransgenicAlleles(geneId, 20_000, 1, sortBy, alleleSymbol, constructSymbol, constructRegulatedGene, constructTargetedGene, constructExpressedGene, species, hasPhenotype, hasDisease, ui);
 
 		Response.ResponseBuilder responseBuilder = Response.ok(alleleTranslator.getAllTransgenicAlleleRows(alleles.getResults()));
 		APIServiceHelper.setDownloadHeader(geneId, EntityType.GENE, EntityType.TRANSGENICALLELE, responseBuilder);

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/AlleleSummaryCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/AlleleSummaryCurationIndexer.java
@@ -4,9 +4,12 @@ import java.util.List;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import org.alliancegenome.core.config.ConfigHelper;
+import org.alliancegenome.core.variant.converters.AlleleSequenceSummaryConverter;
 import org.alliancegenome.curation_api.interfaces.document.AlleleDocumentInterface;
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
+import org.alliancegenome.curation_api.model.document.es.SequenceSummaryDocument;
 import org.alliancegenome.curation_api.response.SearchResponse;
+import org.alliancegenome.curation_api.view.CurationView;
 import org.alliancegenome.es.rest.RestConfig;
 import org.alliancegenome.indexer.config.IndexerConfig;
 import org.alliancegenome.indexer.indexers.Indexer;
@@ -21,6 +24,7 @@ import si.mazi.rescu.RestProxyFactory;
 public class AlleleSummaryCurationIndexer extends Indexer {
 
 	private final AlleleDocumentInterface alleleApi = RestProxyFactory.createProxy(AlleleDocumentInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
+	private final AlleleSequenceSummaryConverter sequenceSummaryConverter = new AlleleSequenceSummaryConverter();
 
 	private List<List<Long>> idBatches;
 
@@ -67,6 +71,9 @@ public class AlleleSummaryCurationIndexer extends Indexer {
 				}
 
 				indexDocuments(response.getResults());
+
+				List<SequenceSummaryDocument> sequenceDocs = sequenceSummaryConverter.convert(response.getResults());
+				indexDocuments(sequenceDocs, CurationView.SequenceSummaryDocument.class);
 			} catch (Exception e) {
 				log.error("Error while indexing...", e);
 				System.exit(-1);

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSequenceSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSequenceSummaryConverter.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.core.variant.converters;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
@@ -16,25 +17,32 @@ public class AlleleSequenceSummaryConverter {
 		List<SequenceSummaryDocument> result = new ArrayList<>();
 
 		for (AlleleSummaryDocument doc : alleleDocs) {
+			HashSet<String> geneIds = new HashSet<>();
+			if(doc.getAlleleOfGene() != null) {
+				geneIds.add(doc.getAlleleOfGene().getPrimaryExternalId());
+			} else {
+				continue;
+			}
+
 			if (CollectionUtils.isEmpty(doc.getVariants())) {
-				result.add(buildDoc(doc, null, null));
+				result.add(buildDocument(doc, null, null, geneIds));
 				continue;
 			}
 
 			for (Variant variant : doc.getVariants()) {
 				if (CollectionUtils.isEmpty(variant.getCuratedVariantGenomicLocations())) {
-					result.add(buildDoc(doc, null, null));
+					result.add(buildDocument(doc, null, null, geneIds));
 					continue;
 				}
 
 				for (CuratedVariantGenomicLocationAssociation location : variant.getCuratedVariantGenomicLocations()) {
 					if (CollectionUtils.isEmpty(location.getPredictedVariantConsequences())) {
-						result.add(buildDoc(doc, location, null));
+						result.add(buildDocument(doc, location, null, geneIds));
 						continue;
 					}
 
 					for (PredictedVariantConsequence consequence : location.getPredictedVariantConsequences()) {
-						result.add(buildDoc(doc, location, consequence));
+						result.add(buildDocument(doc, location, consequence, geneIds));
 					}
 				}
 			}
@@ -43,7 +51,7 @@ public class AlleleSequenceSummaryConverter {
 		return result;
 	}
 
-	private SequenceSummaryDocument buildDoc(AlleleSummaryDocument doc, CuratedVariantGenomicLocationAssociation location, PredictedVariantConsequence consequence) {
+	private SequenceSummaryDocument buildDocument(AlleleSummaryDocument doc, CuratedVariantGenomicLocationAssociation location, PredictedVariantConsequence consequence, HashSet<String> geneIds) {
 		SequenceSummaryDocument ssd = new SequenceSummaryDocument();
 		ssd.setAllele(doc.getAllele());
 		ssd.setGeneIds(doc.getGeneIds());
@@ -52,6 +60,7 @@ public class AlleleSequenceSummaryConverter {
 		ssd.setHasDisease(doc.getHasDisease() != null && doc.getHasDisease());
 		ssd.setVariant(location);
 		ssd.setConsequence(consequence);
+		ssd.setGeneIds(geneIds);
 		return ssd;
 	}
 

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSequenceSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSequenceSummaryConverter.java
@@ -18,7 +18,7 @@ public class AlleleSequenceSummaryConverter {
 
 		for (AlleleSummaryDocument doc : alleleDocs) {
 			HashSet<String> geneIds = new HashSet<>();
-			if(doc.getAlleleOfGene() != null) {
+			if (doc.getAlleleOfGene() != null) {
 				geneIds.add(doc.getAlleleOfGene().getPrimaryExternalId());
 			} else {
 				continue;

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSequenceSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSequenceSummaryConverter.java
@@ -1,0 +1,58 @@
+package org.alliancegenome.core.variant.converters;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
+import org.alliancegenome.curation_api.model.document.es.SequenceSummaryDocument;
+import org.alliancegenome.curation_api.model.entities.PredictedVariantConsequence;
+import org.alliancegenome.curation_api.model.entities.Variant;
+import org.alliancegenome.curation_api.model.entities.associations.CuratedVariantGenomicLocationAssociation;
+import org.apache.commons.collections4.CollectionUtils;
+
+public class AlleleSequenceSummaryConverter {
+
+	public List<SequenceSummaryDocument> convert(List<AlleleSummaryDocument> alleleDocs) {
+		List<SequenceSummaryDocument> result = new ArrayList<>();
+
+		for (AlleleSummaryDocument doc : alleleDocs) {
+			if (CollectionUtils.isEmpty(doc.getVariants())) {
+				result.add(buildDoc(doc, null, null));
+				continue;
+			}
+
+			for (Variant variant : doc.getVariants()) {
+				if (CollectionUtils.isEmpty(variant.getCuratedVariantGenomicLocations())) {
+					result.add(buildDoc(doc, null, null));
+					continue;
+				}
+
+				for (CuratedVariantGenomicLocationAssociation location : variant.getCuratedVariantGenomicLocations()) {
+					if (CollectionUtils.isEmpty(location.getPredictedVariantConsequences())) {
+						result.add(buildDoc(doc, location, null));
+						continue;
+					}
+
+					for (PredictedVariantConsequence consequence : location.getPredictedVariantConsequences()) {
+						result.add(buildDoc(doc, location, consequence));
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	private SequenceSummaryDocument buildDoc(AlleleSummaryDocument doc, CuratedVariantGenomicLocationAssociation location, PredictedVariantConsequence consequence) {
+		SequenceSummaryDocument ssd = new SequenceSummaryDocument();
+		ssd.setAllele(doc.getAllele());
+		ssd.setGeneIds(doc.getGeneIds());
+		ssd.setSequenceSummaryCategory("allele");
+		ssd.setHasPhenotype(doc.getHasPhenotype() != null && doc.getHasPhenotype());
+		ssd.setHasDisease(doc.getHasDisease() != null && doc.getHasDisease());
+		ssd.setVariant(location);
+		ssd.setConsequence(consequence);
+		return ssd;
+	}
+
+}

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
@@ -78,7 +78,6 @@ public class AlleleVariantIndexService {
 			for (SearchHit searchHit : searchResponse.getHits().getHits()) {
 				try {
 					SequenceSummaryDocument doc = mapper.readValue(searchHit.getSourceAsString(), SequenceSummaryDocument.class);
-					doc.setCategory("variant"); // will need to change this once we get the other file types
 					docList.add(doc);
 				} catch (JsonProcessingException e) {
 					e.printStackTrace();

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/SearchDAO.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/SearchDAO.java
@@ -25,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SearchDAO extends ESDAO {
 
-
 	public Long performCountQuery(QueryBuilder query) {
 		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
@@ -43,7 +42,6 @@ public class SearchDAO extends ESDAO {
 			e.printStackTrace();
 		}
 
-
 		if (response != null && response.getHits() != null) {
 			return response.getHits().getTotalHits().value;
 		} else {
@@ -52,27 +50,12 @@ public class SearchDAO extends ESDAO {
 
 	}
 
-	public SearchResponse performQuery(QueryBuilder query,
-									   List<AggregationBuilder> aggBuilders,
-									   QueryRescorerBuilder rescorerBuilder,
-									   List<String> responseFields,
-									   int limit, int offset,
-									   HighlightBuilder highlighter,
-									   LinkedHashMap<String, SortOrder> sorts, Boolean debug) {
+	public SearchResponse performQuery(QueryBuilder query, List<AggregationBuilder> aggBuilders, QueryRescorerBuilder rescorerBuilder, List<String> responseFields, int limit, int offset, HighlightBuilder highlighter, LinkedHashMap<String, SortOrder> sorts, Boolean debug) {
 		return performQuery(query, aggBuilders, rescorerBuilder, responseFields, limit, offset, highlighter, sorts, null, debug);
 	}
 
-
-	public SearchResponse performQuery(QueryBuilder query,
-									   List<AggregationBuilder> aggBuilders,
-									   QueryRescorerBuilder rescorerBuilder,
-									   List<String> responseFields,
-									   int limit, int offset,
-									   HighlightBuilder highlighter,
-									   LinkedHashMap<String, SortOrder> sorts,
-									   Map<String, Boolean> fieldSorter,
-									   Boolean debug) {
-
+	public SearchResponse performQuery(QueryBuilder query, List<AggregationBuilder> aggBuilders, QueryRescorerBuilder rescorerBuilder, List<String> responseFields, int limit, int offset, HighlightBuilder highlighter, LinkedHashMap<String, SortOrder> sorts, Map<String, Boolean> fieldSorter,
+		Boolean debug) {
 
 		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
@@ -120,7 +103,7 @@ public class SearchDAO extends ESDAO {
 		SearchRequest searchRequest = new SearchRequest(ConfigHelper.getEsIndex());
 		searchRequest.source(searchSourceBuilder);
 		// This request cache doesn't work 07/07/2021
-		//searchRequest.requestCache(true);
+		// searchRequest.requestCache(true);
 
 		if (debug != null && debug) {
 			log.info("Request: " + searchRequest);

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/SearchDAO.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/SearchDAO.java
@@ -102,8 +102,6 @@ public class SearchDAO extends ESDAO {
 
 		SearchRequest searchRequest = new SearchRequest(ConfigHelper.getEsIndex());
 		searchRequest.source(searchSourceBuilder);
-		// This request cache doesn't work 07/07/2021
-		// searchRequest.requestCache(true);
 
 		if (debug != null && debug) {
 			log.info("Request: " + searchRequest);

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
@@ -159,6 +159,7 @@ public class Mapping extends Builder {
 
 		new FieldBuilder(builder, "branch", "text").keyword().build(); // go
 		new FieldBuilder(builder, "category", "keyword").symbol().autocomplete().keyword().build(); // ALL document must have
+		new FieldBuilder(builder, "sequenceSummaryCategory", "keyword").symbol().autocomplete().keyword().build(); // sequence_summary
 
 		new FieldBuilder(builder, "crossReferences", "text").keyword().classicText().build(); // allele, gene, dataset, disease
 


### PR DESCRIPTION
## Summary
- New `AlleleSequenceSummaryConverter` flattens `AlleleSummaryDocument` into `SequenceSummaryDocument` rows (one per predicted variant consequence)
- Integrated into `AlleleSummaryCurationIndexer` to produce `sequence_summary` docs alongside `allele_summary` docs
- Added `sequenceSummaryCategory` ES mapping to distinguish allele vs variant rows
- Removed stale `doc.setCategory("variant")` override in `AlleleVariantIndexService`

## Test plan
- Build: `mvn clean install -DskipTests` passes
- Run `AlleleSummaryCurationIndexer` against stage curation API — verify both `allele_summary` and `sequence_summary` docs are produced
- Query `site_index` for `category.keyword = "sequence_summary"` with `sequenceSummaryCategory.keyword = "allele"` to verify allele-derived docs