### PR TITLE
Update actions permission to write for auto-retry support

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
       issues: write
       # REQUIRED: Must grant id-token permission to the reusable workflow
       id-token: write
-      # REQUIRED: Allow reusable workflow to read CI results
-      actions: read
+      # REQUIRED: Allow reusable workflow to read CI results and auto-retry via run rerun
+      actions: write
     uses: alliance-genome/.github/.github/workflows/claude-code-review.yml@main
     with:
       max_turns: "60"


### PR DESCRIPTION
## Summary
- Update `actions: read` → `actions: write` in Claude Code Review caller workflow
- Required for the auto-retry mechanism which uses `gh run rerun` API (see alliance-genome/.github#7)

## Test plan
- [ ] Merge alliance-genome/.github#7 first
- [ ] Merge this PR
- [ ] Verify auto-retry works on next silent drop