### PR TITLE
Fix: PhenotypeAnnotationCurationIndexer NoClassDefFoundError

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/PhenotypeAnnotationCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/PhenotypeAnnotationCurationIndexer.java
@@ -23,7 +23,7 @@ import org.alliancegenome.curation_api.model.entities.GenePhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.entities.PhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.entities.Reference;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
-import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
+import org.alliancegenome.es.util.ProcessDisplayHelper;
 import org.alliancegenome.es.rest.RestConfig;
 import org.alliancegenome.indexer.config.IndexerConfig;
 import org.alliancegenome.indexer.indexers.Indexer;


### PR DESCRIPTION
## Summary
- Switch `PhenotypeAnnotationCurationIndexer` from `org.alliancegenome.curation_api.util.ProcessDisplayHelper` to `org.alliancegenome.es.util.ProcessDisplayHelper`
- The curation API version pulls in `org.jboss.logging.Logger` which is excluded from our dependency tree, causing `NoClassDefFoundError` at runtime
- All other curation indexers already use the local ES util version

## Test plan
- [ ] Indexer runs without `NoClassDefFoundError` on `PhenotypeAnnotationCurationIndexer`