### PR TITLE
Fix indexer NoClassDefFoundError and variant NPE

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/PhenotypeAnnotationCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/PhenotypeAnnotationCurationIndexer.java
@@ -23,7 +23,7 @@ import org.alliancegenome.curation_api.model.entities.GenePhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.entities.PhenotypeAnnotation;
 import org.alliancegenome.curation_api.model.entities.Reference;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
-import org.alliancegenome.curation_api.util.ProcessDisplayHelper;
+import org.alliancegenome.es.util.ProcessDisplayHelper;
 import org.alliancegenome.es.rest.RestConfig;
 import org.alliancegenome.indexer.config.IndexerConfig;
 import org.alliancegenome.indexer.indexers.Indexer;

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchConverter.java
@@ -32,7 +32,7 @@ public class VariantSearchConverter {
 				if (variant.getVariantAssociationSubject().getTaxon() != null) {
 					vsd.setSpecies(variant.getVariantAssociationSubject().getTaxon().getName());
 				}
-				if (variant.getVariantAssociationSubject().getVariantType() != null) {
+				if (variant.getVariantAssociationSubject().getVariantType() != null && variant.getVariantAssociationSubject().getVariantType().getName() != null) {
 					vsd.setVariantType(List.of(variant.getVariantAssociationSubject().getVariantType().getName()));
 				}
 			}


### PR DESCRIPTION
## Summary
- Switch `PhenotypeAnnotationCurationIndexer` from `org.alliancegenome.curation_api.util.ProcessDisplayHelper` to `org.alliancegenome.es.util.ProcessDisplayHelper` -- the curation API version pulls in `org.jboss.logging.Logger` which is excluded from our dependency tree, causing `NoClassDefFoundError` at runtime
- Add null check for `getVariantType().getName()` in `VariantSearchConverter` -- `List.of(null)` throws NPE when the variant type has no name

## Test plan
- [ ] IndexerStage runs without `NoClassDefFoundError` on `PhenotypeAnnotationCurationIndexer`
- [ ] VariantIndexerStage runs without NPE in `VariantSearchConverter`