### PR TITLE
SCRUM-4854 fix allele-variant-detail query, mapping, and filters

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
@@ -2,6 +2,7 @@ package org.alliancegenome.core.variant.service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +47,7 @@ public class AlleleVariantIndexService {
 			SearchSourceBuilder srb = new SearchSourceBuilder();
 
 			srb.query(buildBoolQuery(geneId, pagination));
-			srb.sort(new FieldSortBuilder(getSortFields(pagination)[0].getField()).order(SortOrder.ASC));
+			srb.sort(new FieldSortBuilder(getSortFields(pagination)[0].getField()).order(SortOrder.ASC).unmappedType("integer"));
 			srb.from(pagination.getStart());
 			srb.size(pagination.getLimit());
 			srb.trackTotalHits(true);
@@ -153,6 +154,7 @@ public class AlleleVariantIndexService {
 					aggregations.get(filterKey).add(b.getKeyAsString());
 				}
 			}
+			Collections.sort(aggregations.get(filterKey), String.CASE_INSENSITIVE_ORDER);
 		}
 	}
 

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
@@ -158,7 +158,7 @@ public class AlleleVariantIndexService {
 
 	public BoolQueryBuilder buildBoolQuery(String geneId, Pagination pagination) {
 		BoolQueryBuilder queryBuilder = new BoolQueryBuilder();
-		queryBuilder.filter(QueryBuilders.termQuery("geneIds.keyword", geneId));
+		queryBuilder.filter(QueryBuilders.termQuery("geneIds", geneId));
 		queryBuilder.filter(QueryBuilders.termQuery("category.keyword", "sequence_summary"));
 		if (pagination != null) {
 			Map<FieldFilter, String> filterValueMap = pagination.getFieldFilterValueMap();

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
@@ -47,7 +47,7 @@ public class AlleleVariantIndexService {
 			SearchSourceBuilder srb = new SearchSourceBuilder();
 
 			srb.query(buildBoolQuery(geneId, pagination));
-			srb.sort(new FieldSortBuilder(getSortFields(pagination)[0].getField()).order(SortOrder.ASC).unmappedType("integer"));
+			srb.sort(new FieldSortBuilder(getSortFields(pagination)[0].getField()).order(SortOrder.ASC));
 			srb.from(pagination.getStart());
 			srb.size(pagination.getLimit());
 			srb.trackTotalHits(true);

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
@@ -62,19 +62,24 @@ public class VariantMapping extends Mapping {
 			new FieldBuilder(builder, "id", "text").keyword().build();
 			builder.endObject();
 			builder.endObject();
-			// AlleleVariantSequence: aggregation on variant.variantType.name.keyword
-			builder.startObject("variantType");
-			builder.startObject("properties");
-			new FieldBuilder(builder, "name", "text").keyword().build();
-			builder.endObject();
-			builder.endObject();
+			new FieldBuilder(builder, "variantAssociationSubject.variantType.name", "text").keyword().sort().build();
 			builder.endObject();
 			builder.endObject();
 
-			// consequence: dynamic false for now, add explicit field mappings as UI sorting/filtering is implemented
+			// consequence: dynamic false, only map fields queried by AlleleVariantIndexService
 			builder.startObject("consequence");
 			builder.field("dynamic", false);
 			builder.startObject("properties");
+			new FieldBuilder(builder, "variantTranscript.curie", "text").keyword().build();
+			new FieldBuilder(builder, "variantTranscript.transcriptType.name", "text").keyword().sort().build();
+			new FieldBuilder(builder, "variantTranscript.transcriptGeneAssociations.transcriptGeneAssociationObject.geneSymbol.displayText", "text").keyword().sort().build();
+			new FieldBuilder(builder, "intronExonLocation", "text").keyword().build();
+			new FieldBuilder(builder, "vepConsequences.name", "text").keyword().sort().build();
+			new FieldBuilder(builder, "vepImpact.name", "text").keyword().sort().build();
+			new FieldBuilder(builder, "siftPrediction.name", "text").keyword().sort().build();
+			new FieldBuilder(builder, "siftScore", "float").build();
+			new FieldBuilder(builder, "polyphenPrediction.name", "text").keyword().sort().build();
+			new FieldBuilder(builder, "polyphenScore", "float").build();
 			builder.endObject();
 			builder.endObject();
 

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
@@ -22,11 +22,10 @@ public class VariantMapping extends Mapping {
 			new FieldBuilder(builder, "associatedPhenotype", "text").keyword().sort().build();
 			new FieldBuilder(builder, "diseaseTerms.name", "text").keyword().sort().build();
 			new FieldBuilder(builder, "sequenceSummaryCategory", "keyword").symbol().autocomplete().keyword().build(); // sequence_summary
-
 			new FieldBuilder(builder, "hasDisease", "boolean").build();
 			new FieldBuilder(builder, "hasPhenotype", "boolean").build();
-			new FieldBuilder(builder, "alterationTypeSortOrder", "integer").keyword().sort().build();
-			
+			new FieldBuilder(builder, "alterationTypeSortOrder", "integer").build();
+
 			// allele: dynamic false prevents indexing the deep curation API Allele tree
 			// Only map fields actually queried in ES
 			builder.startObject("allele");
@@ -43,7 +42,6 @@ public class VariantMapping extends Mapping {
 			builder.startObject("variants");
 			builder.field("dynamic", false);
 			builder.startObject("properties");
-			// VariantSummaryDocument: queried via MatchQuery on allele.primaryExternalId
 			new FieldBuilder(builder, "variantType.name", "text").keyword().sort().build();
 			new FieldBuilder(builder, "curatedVariantGenomicLocations.predictedVariantConsequences.vepConsequences.name", "text").keyword().sort().build();
 			new FieldBuilder(builder, "curatedVariantGenomicLocations.hgvs", "text").keyword().sort().build();


### PR DESCRIPTION
## Summary
- Fix `geneIds.keyword` -> `geneIds` in AlleleVariantIndexService (field is mapped as keyword directly)
- Move `hasDisease`, `hasPhenotype`, `alterationTypeSortOrder` to root level in VariantMapping
- Add all consequence sub-fields to VariantMapping: vepConsequences, vepImpact, siftPrediction/Score, polyphenPrediction/Score, variantTranscript (curie, transcriptType, associatedGene), intronExonLocation
- Fix `variant.variantAssociationSubject.variantType.name` path in VariantMapping
- Sort aggregation filter values alphabetically

## Test plan
- Requires full indexer + variant indexer run after merge to populate new mappings
- Verify allele-variant-detail table loads alleles and variants
- Verify all checkbox filters populate and apply correctly