### PR TITLE
SCRUM-4854: Update curation dependency to v0.46.29

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
@@ -92,7 +92,7 @@ public class AlleleVariantIndexService {
 
 		if (pagination.getSortBy() != null && !pagination.getSortBy().equalsIgnoreCase("default")) {
 			if (pagination.getSortBy().equalsIgnoreCase("variantType")) {
-				sortField[0] = new SortField("variant.variantAssociationSubject.variantType.name.keyword", SortField.Type.STRING);
+				sortField[0] = new SortField("variantLocation.variantAssociationSubject.variantType.name.keyword", SortField.Type.STRING);
 			}
 			if (pagination.getSortBy().equalsIgnoreCase("molecularConsequence")) {
 				sortField[0] = new SortField("consequence.vepConsequences.name.keyword", SortField.Type.STRING);
@@ -104,7 +104,7 @@ public class AlleleVariantIndexService {
 				sortField[0] = new SortField("consequence.variantTranscript.curie.keyword", SortField.Type.STRING);
 			}
 			if (pagination.getSortBy().equalsIgnoreCase("VariantHgvsName") || pagination.getSortBy().equalsIgnoreCase("symbol")) {
-				sortField[0] = new SortField("variant.hgvs.sort", SortField.Type.STRING);
+				sortField[0] = new SortField("variantLocation.hgvs.sort", SortField.Type.STRING);
 			}
 		} else {
 			sortField[0] = new SortField("alterationTypeSortOrder", SortField.Type.INT);
@@ -180,7 +180,7 @@ public class AlleleVariantIndexService {
 							queryBuilder.filter(QueryBuilders.termsQuery("alterationType.keyword", value.split("\\|")));
 							break;
 						case VARIANT_TYPE:
-							queryBuilder.filter(QueryBuilders.termsQuery("variant.variantAssociationSubject.variantType.name.keyword", value.split("\\|")));
+							queryBuilder.filter(QueryBuilders.termsQuery("variantLocation.variantAssociationSubject.variantType.name.keyword", value.split("\\|")));
 							break;
 						case HAS_DISEASE:
 							queryBuilder.filter(QueryBuilders.termsQuery("hasDisease", value.split("\\|")));
@@ -210,7 +210,7 @@ public class AlleleVariantIndexService {
 							queryBuilder.filter(QueryBuilders.termsQuery("consequence.variantTranscript.transcriptGeneAssociations.transcriptGeneAssociationObject.geneSymbol.displayText.keyword", value.split("\\|")));
 							break;
 						case VARIANT_HGVS_G:
-							queryBuilder.must(QueryBuilders.wildcardQuery("variant.hgvs", "*" + value.toLowerCase() + "*"));
+							queryBuilder.must(QueryBuilders.wildcardQuery("variantLocation.hgvs", "*" + value.toLowerCase() + "*"));
 							break;
 						case VARIANT_LOCATION:
 							queryBuilder.must(QueryBuilders.wildcardQuery("consequence.intronExonLocation", "*" + value.toLowerCase() + "*"));
@@ -226,7 +226,7 @@ public class AlleleVariantIndexService {
 
 
 	public void buildAggregations(SearchSourceBuilder srb) {
-		srb.aggregation(AggregationBuilders.terms("variantType").field("variant.variantAssociationSubject.variantType.name.keyword"));
+		srb.aggregation(AggregationBuilders.terms("variantType").field("variantLocation.variantAssociationSubject.variantType.name.keyword"));
 		srb.aggregation(AggregationBuilders.terms("hasDisease").field("hasDisease"));
 		srb.aggregation(AggregationBuilders.terms("hasPhenotype").field("hasPhenotype"));
 		srb.aggregation(AggregationBuilders.terms("impact").field("consequence.vepImpact.name.keyword"));

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
@@ -296,8 +296,8 @@ public class Mapping extends Builder {
 		builder.field("dynamic", false);
 		builder.endObject();
 
-		// SequenceSummaryDocument: variant (CuratedVariantGenomicLocationAssociation)
-		builder.startObject("variant");
+		// SequenceSummaryDocument: variantLocation (CuratedVariantGenomicLocationAssociation)
+		builder.startObject("variantLocation");
 		builder.field("type", "object");
 		builder.field("dynamic", false);
 		builder.startObject("properties");
@@ -306,8 +306,8 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "end", "integer").build();
 		builder.endObject();
 		builder.endObject();
-		new FieldBuilder(builder, "variant.variantAssociationSubject.variantType.name", "text").keyword().sort().build();
-		new FieldBuilder(builder, "variant.variantGenomicLocationAssociationObject.name", "text").keyword().build();
+		new FieldBuilder(builder, "variantLocation.variantAssociationSubject.variantType.name", "text").keyword().sort().build();
+		new FieldBuilder(builder, "variantLocation.variantGenomicLocationAssociationObject.name", "text").keyword().build();
 
 		// SequenceSummaryDocument: consequence (PredictedVariantConsequence)
 		builder.startObject("consequence");
@@ -325,6 +325,7 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "consequence.siftPrediction.name", "text").keyword().build();
 		new FieldBuilder(builder, "consequence.polyphenPrediction.name", "text").keyword().build();
 		new FieldBuilder(builder, "consequence.variantTranscript.curie", "text").keyword().build();
+		new FieldBuilder(builder, "consequence.variantTranscript.name", "text").keyword().build();
 		new FieldBuilder(builder, "consequence.variantTranscript.transcriptType.name", "text").keyword().build();
 		new FieldBuilder(builder, "consequence.variantTranscript.transcriptGeneAssociations.transcriptGeneAssociationObject.geneSymbol.displayText", "text").keyword().build();
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.46.28</curation.version>
+		<curation.version>v0.46.29</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary
- Updates curation dependency from v0.46.28 to v0.46.29
- v0.46.29 includes:
  - AlleleDAO intron/exon location computation for Variant Location column
  - Transcript.name SequenceSummaryDocument @JsonView for Sequence Feature column

## Test plan
- [ ] Build succeeds
- [ ] After merge + indexer run, verify Variant Location and Sequence Feature columns on allele-details page