### PR TITLE
SCRUM-4854: Refactor to use Variant entity directly on SSD/VSD

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/TestSynonyms.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/TestSynonyms.java
@@ -49,18 +49,18 @@ public class TestSynonyms {
 								for (int i = 0; i < Math.min(5, loc.getPredictedVariantConsequences().size()); i++) {
 									PredictedVariantConsequence pvc = loc.getPredictedVariantConsequences().get(i);
 									Transcript t = pvc.getVariantTranscript();
-									System.out.println("    [" + i + "] transcript curie: " + (t != null ? t.getCurie() : "null"));
-									System.out.println("        transcript name: " + (t != null ? t.getName() : "null"));
-									System.out.println("        transcript primaryExternalId: " + (t != null ? t.getPrimaryExternalId() : "null"));
-									System.out.println("        transcriptType: " + (t != null && t.getTranscriptType() != null ? t.getTranscriptType().getName() : "null"));
-									System.out.println("        vepImpact: " + (pvc.getVepImpact() != null ? pvc.getVepImpact().getName() : "null"));
-									System.out.println("        introns: " + pvc.getIntrons());
-									System.out.println("        exons: " + pvc.getExons());
-									System.out.println("        intronExonLocation: " + pvc.getIntronExonLocation());
-									System.out.println("        geneLevelConsequence: " + pvc.getGeneLevelConsequence());
+									System.out.println("	[" + i + "] transcript curie: " + (t != null ? t.getCurie() : "null"));
+									System.out.println("		transcript name: " + (t != null ? t.getName() : "null"));
+									System.out.println("		transcript primaryExternalId: " + (t != null ? t.getPrimaryExternalId() : "null"));
+									System.out.println("		transcriptType: " + (t != null && t.getTranscriptType() != null ? t.getTranscriptType().getName() : "null"));
+									System.out.println("		vepImpact: " + (pvc.getVepImpact() != null ? pvc.getVepImpact().getName() : "null"));
+									System.out.println("		introns: " + pvc.getIntrons());
+									System.out.println("		exons: " + pvc.getExons());
+									System.out.println("		intronExonLocation: " + pvc.getIntronExonLocation());
+									System.out.println("		geneLevelConsequence: " + pvc.getGeneLevelConsequence());
 								}
 								if (loc.getPredictedVariantConsequences().size() > 5) {
-									System.out.println("    ... and " + (loc.getPredictedVariantConsequences().size() - 5) + " more");
+									System.out.println("	... and " + (loc.getPredictedVariantConsequences().size() - 5) + " more");
 								}
 							}
 						}

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/VariantSummaryCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/VariantSummaryCurationIndexer.java
@@ -8,8 +8,6 @@ import java.util.concurrent.LinkedBlockingDeque;
 import org.alliancegenome.core.config.ConfigHelper;
 import org.alliancegenome.curation_api.interfaces.document.VariantDocumentInterface;
 import org.alliancegenome.curation_api.model.document.es.VariantSummaryDocument;
-import org.alliancegenome.curation_api.model.entities.Variant;
-import org.alliancegenome.curation_api.model.entities.associations.CuratedVariantGenomicLocationAssociation;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.es.rest.RestConfig;
 import org.alliancegenome.indexer.config.IndexerConfig;
@@ -77,25 +75,14 @@ public class VariantSummaryCurationIndexer extends Indexer {
 				}
 
 				List<VariantSummaryDocument> list = new ArrayList<>();
-				for (VariantSummaryDocument variantSummaryDto : results) {
-					if (variantSummaryDto == null) {
+				for (VariantSummaryDocument document : results) {
+					if (document == null) {
 						continue;
 					}
-					VariantSummaryDocument document = new VariantSummaryDocument();
-					document.setSubCategory("LTP_variant");
 					document.setAlterationType("variant");
 					document.setAlterationTypeSortOrder(4);
 					document.setHasPhenotype(false);
 					document.setHasDisease(false);
-					CuratedVariantGenomicLocationAssociation cvgla = variantSummaryDto.getVariantLocation();
-					document.setVariantLocation(cvgla);
-					if (cvgla != null && cvgla.getVariantAssociationSubject() != null) {
-						Variant variantWrapper = new Variant();
-						variantWrapper.setVariantType(cvgla.getVariantAssociationSubject().getVariantType());
-						variantWrapper.setCuratedVariantGenomicLocations(List.of(cvgla));
-						document.setVariants(List.of(variantWrapper));
-					}
-					document.setAllele(variantSummaryDto.getAllele());
 					list.add(document);
 				}
 

--- a/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/AlleleToTdfTranslator.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/AlleleToTdfTranslator.java
@@ -270,7 +270,7 @@ public class AlleleToTdfTranslator {
 
 	private VariantDownloadRow getBaseDownloadVariantRow(VariantSummaryDocument annotation) {
 		VariantDownloadRow row = new VariantDownloadRow();
-		CuratedVariantGenomicLocationAssociation variant = annotation.getVariantLocation();
+		CuratedVariantGenomicLocationAssociation variant = annotation.getVariants().get(0).getCuratedVariantGenomicLocations().get(0);
 		if (variant == null) {
 			return row;
 		}

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSequenceSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSequenceSummaryConverter.java
@@ -33,12 +33,12 @@ public class AlleleSequenceSummaryConverter {
 
 				for (CuratedVariantGenomicLocationAssociation location : variant.getCuratedVariantGenomicLocations()) {
 					if (CollectionUtils.isEmpty(location.getPredictedVariantConsequences())) {
-						result.add(buildDocument(doc, location, null, geneIds));
+						result.add(buildDocument(doc, variant, null, geneIds));
 						continue;
 					}
 
 					for (PredictedVariantConsequence consequence : location.getPredictedVariantConsequences()) {
-						result.add(buildDocument(doc, location, consequence, geneIds));
+						result.add(buildDocument(doc, variant, consequence, geneIds));
 					}
 				}
 			}
@@ -47,19 +47,15 @@ public class AlleleSequenceSummaryConverter {
 		return result;
 	}
 
-	private SequenceSummaryDocument buildDocument(AlleleSummaryDocument doc, CuratedVariantGenomicLocationAssociation location, PredictedVariantConsequence consequence, HashSet<String> geneIds) {
+	private SequenceSummaryDocument buildDocument(AlleleSummaryDocument doc, Variant variant, PredictedVariantConsequence consequence, HashSet<String> geneIds) {
 		SequenceSummaryDocument ssd = new SequenceSummaryDocument();
 		ssd.setAllele(doc.getAllele());
 		ssd.setGeneIds(doc.getGeneIds());
-		ssd.setSequenceSummaryCategory("allele");
 		ssd.setHasPhenotype(doc.getHasPhenotype() != null && doc.getHasPhenotype());
 		ssd.setHasDisease(doc.getHasDisease() != null && doc.getHasDisease());
 		ssd.setAlterationType(doc.getAlterationType());
 		ssd.setAlterationTypeSortOrder(doc.getAlterationTypeSortOrder());
-		ssd.setVariantLocation(location);
-		if (location != null && location.getVariantAssociationSubject() != null) {
-			ssd.setVariants(List.of(location.getVariantAssociationSubject()));
-		}
+		ssd.setVariant(variant);
 		ssd.setConsequence(consequence);
 		ssd.setGeneIds(geneIds);
 		return ssd;

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/SequenceSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/SequenceSummaryConverter.java
@@ -21,7 +21,7 @@ public class SequenceSummaryConverter {
 		List<SequenceSummaryDocument> result = new ArrayList<>();
 
 		for (VariantSummaryDocument doc : docs) {
-			CuratedVariantGenomicLocationAssociation variantLocation = doc.getVariantLocation();
+			CuratedVariantGenomicLocationAssociation variantLocation = doc.getVariants().get(0).getCuratedVariantGenomicLocations().get(0);
 			if (variantLocation == null || variantLocation.getPredictedVariantConsequences() == null) {
 				continue;
 			}
@@ -30,9 +30,7 @@ public class SequenceSummaryConverter {
 				if (consequence.getVariantTranscript() != null && consequence.getVariantTranscript().getTranscriptGeneAssociations() != null) {
 					SequenceSummaryDocument ssd = new SequenceSummaryDocument();
 					ssd.setAllele(doc.getAllele());
-					ssd.setVariantLocation(variantLocation);
 					ssd.setConsequence(consequence);
-					ssd.setSequenceSummaryCategory("variant");
 					ssd.setAlterationType("variant");
 
 					HashSet<String> geneIds = new HashSet<>();

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/SequenceSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/SequenceSummaryConverter.java
@@ -30,6 +30,7 @@ public class SequenceSummaryConverter {
 				if (consequence.getVariantTranscript() != null && consequence.getVariantTranscript().getTranscriptGeneAssociations() != null) {
 					SequenceSummaryDocument ssd = new SequenceSummaryDocument();
 					ssd.setAllele(doc.getAllele());
+					ssd.setVariant(doc.getVariants().get(0));
 					ssd.setConsequence(consequence);
 					ssd.setAlterationType("variant");
 

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
@@ -18,31 +18,31 @@ public class VariantSearchResultConverter {
 		List<VariantSearchResultDocument> result = new ArrayList<>();
 
 		for (VariantSummaryDocument doc : variantSummaryDocuments) {
-			CuratedVariantGenomicLocationAssociation curatedVariantGenomicLocationAssociation = doc.getVariantLocation();
-			if (curatedVariantGenomicLocationAssociation == null) {
+			CuratedVariantGenomicLocationAssociation variantLocation = doc.getVariants().get(0).getCuratedVariantGenomicLocations().get(0);
+			if (variantLocation == null) {
 				continue;
 			}
 
 			VariantSearchResultDocument vsd = new VariantSearchResultDocument();
 			vsd.setSearchable(true);
 			vsd.setAlterationType("variant");
-			vsd.setPrimaryKey(curatedVariantGenomicLocationAssociation.getHgvs());
-			vsd.setName(curatedVariantGenomicLocationAssociation.getHgvs());
-			vsd.setNameKey(curatedVariantGenomicLocationAssociation.getHgvs());
+			vsd.setPrimaryKey(variantLocation.getHgvs());
+			vsd.setName(variantLocation.getHgvs());
+			vsd.setNameKey(variantLocation.getHgvs());
 
-			if (curatedVariantGenomicLocationAssociation.getVariantAssociationSubject() != null) {
-				if (curatedVariantGenomicLocationAssociation.getVariantAssociationSubject().getTaxon() != null) {
-					vsd.setSpecies(curatedVariantGenomicLocationAssociation.getVariantAssociationSubject().getTaxon().getName());
+			if (variantLocation.getVariantAssociationSubject() != null) {
+				if (variantLocation.getVariantAssociationSubject().getTaxon() != null) {
+					vsd.setSpecies(variantLocation.getVariantAssociationSubject().getTaxon().getName());
 				}
-				if (curatedVariantGenomicLocationAssociation.getVariantAssociationSubject().getVariantType() != null && curatedVariantGenomicLocationAssociation.getVariantAssociationSubject().getVariantType().getName() != null) {
-					vsd.setVariantType(List.of(curatedVariantGenomicLocationAssociation.getVariantAssociationSubject().getVariantType().getName()));
+				if (variantLocation.getVariantAssociationSubject().getVariantType() != null && variantLocation.getVariantAssociationSubject().getVariantType().getName() != null) {
+					vsd.setVariantType(List.of(variantLocation.getVariantAssociationSubject().getVariantType().getName()));
 				}
 			}
 
 			vsd.setPopularity(0.0);
 
-			if (curatedVariantGenomicLocationAssociation.getPredictedVariantConsequences() != null) {
-				List<String> geneNames = curatedVariantGenomicLocationAssociation.getPredictedVariantConsequences().stream()
+			if (variantLocation.getPredictedVariantConsequences() != null) {
+				List<String> geneNames = variantLocation.getPredictedVariantConsequences().stream()
 					.filter(pvc -> pvc.getVariantTranscript() != null && pvc.getVariantTranscript().getTranscriptGeneAssociations() != null)
 					.flatMap(pvc -> pvc.getVariantTranscript().getTranscriptGeneAssociations().stream())
 					.map(TranscriptGeneAssociation::getTranscriptGeneAssociationObject)
@@ -65,9 +65,9 @@ public class VariantSearchResultConverter {
 				}
 			}
 
-			if (curatedVariantGenomicLocationAssociation.getVariantAssociationSubject() != null && curatedVariantGenomicLocationAssociation.getVariantAssociationSubject().getCrossReferences() != null) {
+			if (variantLocation.getVariantAssociationSubject() != null && variantLocation.getVariantAssociationSubject().getCrossReferences() != null) {
 				List<String> crossRefs = new ArrayList<>();
-				for (var xref : curatedVariantGenomicLocationAssociation.getVariantAssociationSubject().getCrossReferences()) {
+				for (var xref : variantLocation.getVariantAssociationSubject().getCrossReferences()) {
 					crossRefs.add(xref.getDisplayName());
 				}
 				if (!crossRefs.isEmpty()) {
@@ -75,9 +75,9 @@ public class VariantSearchResultConverter {
 				}
 			}
 
-			if (curatedVariantGenomicLocationAssociation.getPredictedVariantConsequences() != null) {
+			if (variantLocation.getPredictedVariantConsequences() != null) {
 				HashSet<String> consequences = new HashSet<>();
-				for (PredictedVariantConsequence pvc : curatedVariantGenomicLocationAssociation.getPredictedVariantConsequences()) {
+				for (PredictedVariantConsequence pvc : variantLocation.getPredictedVariantConsequences()) {
 					if (pvc.getVepConsequences() != null) {
 						for (var soTerm : pvc.getVepConsequences()) {
 							consequences.add(soTerm.getName());

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
@@ -308,6 +308,11 @@ public class VariantSummaryConverter {
 				continue;
 			}
 
+			// Skip consequences without a gene
+			if (infos[geneIdx].isEmpty()) {
+				continue;
+			}
+
 			if (!infos[hgvsgIdx].isEmpty()) {
 				hgvsGList.add(infos[hgvsgIdx]);
 			}

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
@@ -259,13 +259,11 @@ public class VariantSummaryConverter {
 			cvgla.setPredictedVariantConsequences(consequences);
 			// Create the document for each consequence (full flattening)
 			VariantSummaryDocument doc = new VariantSummaryDocument();
-			doc.setSubCategory("HTP_variant");
 			doc.setAlterationType("variant");
 			doc.setAlterationTypeSortOrder(4);
 			doc.setHasPhenotype(false);
 			doc.setHasDisease(false);
 			doc.setAllele(allele);
-			doc.setVariantLocation(cvgla);
 			Variant variantWrapper = new Variant();
 			variantWrapper.setVariantType(variantType);
 			variantWrapper.setCuratedVariantGenomicLocations(List.of(cvgla));

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
@@ -101,7 +101,7 @@ public class AlleleVariantIndexService {
 				sortField[0] = new SortField("allele.alleleSymbol.displayText.sort", SortField.Type.STRING);
 			}
 			if (pagination.getSortBy().equalsIgnoreCase("transcript")) {
-				sortField[0] = new SortField("consequence.variantTranscript.curie.keyword", SortField.Type.STRING);
+				sortField[0] = new SortField("consequence.variantTranscript.name.keyword", SortField.Type.STRING);
 			}
 			if (pagination.getSortBy().equalsIgnoreCase("VariantHgvsName") || pagination.getSortBy().equalsIgnoreCase("symbol")) {
 				sortField[0] = new SortField("variant.curatedVariantGenomicLocations.hgvs.sort", SortField.Type.STRING);
@@ -201,7 +201,7 @@ public class AlleleVariantIndexService {
 							queryBuilder.filter(QueryBuilders.termsQuery("consequence.polyphenPrediction.name.keyword", value.split("\\|")));
 							break;
 						case SEQUENCE_FEATURE:
-							queryBuilder.must(QueryBuilders.wildcardQuery("consequence.variantTranscript.curie", "*" + value.toLowerCase() + "*"));
+							queryBuilder.must(QueryBuilders.wildcardQuery("consequence.variantTranscript.name", "*" + value.toLowerCase() + "*"));
 							break;
 						case SEQUENCE_FEATURE_TYPE:
 							queryBuilder.filter(QueryBuilders.termsQuery("consequence.variantTranscript.transcriptType.name.keyword", value.split("\\|")));

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/service/AlleleVariantIndexService.java
@@ -92,7 +92,7 @@ public class AlleleVariantIndexService {
 
 		if (pagination.getSortBy() != null && !pagination.getSortBy().equalsIgnoreCase("default")) {
 			if (pagination.getSortBy().equalsIgnoreCase("variantType")) {
-				sortField[0] = new SortField("variants.variantType.name.keyword", SortField.Type.STRING);
+				sortField[0] = new SortField("variant.variantType.name.keyword", SortField.Type.STRING);
 			}
 			if (pagination.getSortBy().equalsIgnoreCase("molecularConsequence")) {
 				sortField[0] = new SortField("consequence.vepConsequences.name.keyword", SortField.Type.STRING);
@@ -104,7 +104,7 @@ public class AlleleVariantIndexService {
 				sortField[0] = new SortField("consequence.variantTranscript.curie.keyword", SortField.Type.STRING);
 			}
 			if (pagination.getSortBy().equalsIgnoreCase("VariantHgvsName") || pagination.getSortBy().equalsIgnoreCase("symbol")) {
-				sortField[0] = new SortField("variantLocation.hgvs.sort", SortField.Type.STRING);
+				sortField[0] = new SortField("variant.curatedVariantGenomicLocations.hgvs.sort", SortField.Type.STRING);
 			}
 		} else {
 			sortField[0] = new SortField("alterationTypeSortOrder", SortField.Type.INT);
@@ -180,7 +180,7 @@ public class AlleleVariantIndexService {
 							queryBuilder.filter(QueryBuilders.termsQuery("alterationType.keyword", value.split("\\|")));
 							break;
 						case VARIANT_TYPE:
-							queryBuilder.filter(QueryBuilders.termsQuery("variants.variantType.name.keyword", value.split("\\|")));
+							queryBuilder.filter(QueryBuilders.termsQuery("variant.variantType.name.keyword", value.split("\\|")));
 							break;
 						case HAS_DISEASE:
 							queryBuilder.filter(QueryBuilders.termsQuery("hasDisease", value.split("\\|")));
@@ -210,7 +210,7 @@ public class AlleleVariantIndexService {
 							queryBuilder.filter(QueryBuilders.termsQuery("consequence.variantTranscript.transcriptGeneAssociations.transcriptGeneAssociationObject.geneSymbol.displayText.keyword", value.split("\\|")));
 							break;
 						case VARIANT_HGVS_G:
-							queryBuilder.must(QueryBuilders.wildcardQuery("variantLocation.hgvs", "*" + value.toLowerCase() + "*"));
+							queryBuilder.must(QueryBuilders.wildcardQuery("variant.curatedVariantGenomicLocations.hgvs", "*" + value.toLowerCase() + "*"));
 							break;
 						case VARIANT_LOCATION:
 							queryBuilder.must(QueryBuilders.wildcardQuery("consequence.intronExonLocation", "*" + value.toLowerCase() + "*"));
@@ -226,7 +226,7 @@ public class AlleleVariantIndexService {
 
 
 	public void buildAggregations(SearchSourceBuilder srb) {
-		srb.aggregation(AggregationBuilders.terms("variantType").field("variants.variantType.name.keyword"));
+		srb.aggregation(AggregationBuilders.terms("variantType").field("variant.variantType.name.keyword"));
 		srb.aggregation(AggregationBuilders.terms("hasDisease").field("hasDisease"));
 		srb.aggregation(AggregationBuilders.terms("hasPhenotype").field("hasPhenotype"));
 		srb.aggregation(AggregationBuilders.terms("impact").field("consequence.vepImpact.name.keyword"));

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/VariantESDAO.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/VariantESDAO.java
@@ -227,7 +227,7 @@ public class VariantESDAO extends ESDAO {
 		for (SearchHit hit : searchHits) {
 			try {
 				VariantSummaryDocument summaryDoc = mapper.readValue(hit.getSourceAsString(), VariantSummaryDocument.class);
-				if (summaryDoc != null && summaryDoc.getVariantLocation() != null) {
+				if (summaryDoc != null && summaryDoc.getVariants() != null && !summaryDoc.getVariants().isEmpty()) {
 					return summaryDoc;
 				}
 			} catch (IOException e) {

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
@@ -323,7 +323,6 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "consequence.vepConsequences.name", "text").keyword().sort().build();
 		new FieldBuilder(builder, "consequence.siftPrediction.name", "text").keyword().build();
 		new FieldBuilder(builder, "consequence.polyphenPrediction.name", "text").keyword().build();
-		new FieldBuilder(builder, "consequence.variantTranscript.curie", "text").keyword().build();
 		new FieldBuilder(builder, "consequence.variantTranscript.name", "text").keyword().build();
 		new FieldBuilder(builder, "consequence.variantTranscript.transcriptType.name", "text").keyword().build();
 		new FieldBuilder(builder, "consequence.variantTranscript.transcriptGeneAssociations.transcriptGeneAssociationObject.geneSymbol.displayText", "text").keyword().build();

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
@@ -159,7 +159,6 @@ public class Mapping extends Builder {
 
 		new FieldBuilder(builder, "branch", "text").keyword().build(); // go
 		new FieldBuilder(builder, "category", "keyword").symbol().autocomplete().keyword().build(); // ALL document must have
-		new FieldBuilder(builder, "sequenceSummaryCategory", "keyword").symbol().autocomplete().keyword().build(); // sequence_summary
 
 		new FieldBuilder(builder, "crossReferences", "text").keyword().classicText().build(); // allele, gene, dataset, disease
 		new FieldBuilder(builder, "curie", "keyword").build(); // go_search_result
@@ -296,17 +295,18 @@ public class Mapping extends Builder {
 		builder.field("dynamic", false);
 		builder.endObject();
 
-		// SequenceSummaryDocument: variantLocation (CuratedVariantGenomicLocationAssociation)
-		builder.startObject("variantLocation");
+		// SequenceSummaryDocument: variant (Variant)
+		builder.startObject("variant");
 		builder.field("type", "object");
 		builder.field("dynamic", false);
 		builder.startObject("properties");
-		new FieldBuilder(builder, "hgvs", "text").keyword().sort().build();
-		new FieldBuilder(builder, "start", "integer").build();
-		new FieldBuilder(builder, "end", "integer").build();
 		builder.endObject();
 		builder.endObject();
-		new FieldBuilder(builder, "variantLocation.variantGenomicLocationAssociationObject.name", "text").keyword().build();
+		new FieldBuilder(builder, "variant.variantType.name", "text").keyword().sort().build();
+		new FieldBuilder(builder, "variant.curatedVariantGenomicLocations.hgvs", "text").keyword().sort().build();
+		new FieldBuilder(builder, "variant.curatedVariantGenomicLocations.start", "integer").build();
+		new FieldBuilder(builder, "variant.curatedVariantGenomicLocations.end", "integer").build();
+		new FieldBuilder(builder, "variant.curatedVariantGenomicLocations.variantGenomicLocationAssociationObject.name", "text").keyword().build();
 
 		// SequenceSummaryDocument: consequence (PredictedVariantConsequence)
 		builder.startObject("consequence");

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
@@ -64,7 +64,7 @@ public class VariantMapping extends Mapping {
 			builder.startObject("consequence");
 			builder.field("dynamic", false);
 			builder.startObject("properties");
-			new FieldBuilder(builder, "variantTranscript.curie", "text").keyword().build();
+			new FieldBuilder(builder, "variantTranscript.name", "text").keyword().build();
 			new FieldBuilder(builder, "variantTranscript.transcriptType.name", "text").keyword().sort().build();
 			new FieldBuilder(builder, "variantTranscript.transcriptGeneAssociations.transcriptGeneAssociationObject.geneSymbol.displayText", "text").keyword().sort().build();
 			new FieldBuilder(builder, "intronExonLocation", "text").keyword().build();

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
@@ -21,7 +21,6 @@ public class VariantMapping extends Mapping {
 			new FieldBuilder(builder, "geneIds", "keyword").build();
 			new FieldBuilder(builder, "associatedPhenotype", "text").keyword().sort().build();
 			new FieldBuilder(builder, "diseaseTerms.name", "text").keyword().sort().build();
-			new FieldBuilder(builder, "sequenceSummaryCategory", "keyword").symbol().autocomplete().keyword().build(); // sequence_summary
 			new FieldBuilder(builder, "hasDisease", "boolean").build();
 			new FieldBuilder(builder, "hasPhenotype", "boolean").build();
 			new FieldBuilder(builder, "alterationTypeSortOrder", "integer").sort().build();
@@ -49,20 +48,15 @@ public class VariantMapping extends Mapping {
 			builder.endObject();
 			builder.endObject();
 
-			// variant: dynamic false prevents indexing the deep variant association tree
-			// Only map fields actually queried in ES
+			// variant: dynamic false prevents indexing the deep Variant entity tree
 			builder.startObject("variant");
 			builder.field("dynamic", false);
 			builder.startObject("properties");
-			// VariantSummaryDocument: queried via TermQuery on variant.hgvs.keyword
-			new FieldBuilder(builder, "hgvs", "text").keyword().build();
-			// AlleleVariantSequence: queried via TermQuery on variant.gene.id.keyword
-			builder.startObject("gene");
-			builder.startObject("properties");
-			new FieldBuilder(builder, "id", "text").keyword().build();
-			builder.endObject();
-			builder.endObject();
-			new FieldBuilder(builder, "variantAssociationSubject.variantType.name", "text").keyword().sort().build();
+			new FieldBuilder(builder, "variantType.name", "text").keyword().sort().build();
+			new FieldBuilder(builder, "curatedVariantGenomicLocations.hgvs", "text").keyword().sort().build();
+			new FieldBuilder(builder, "curatedVariantGenomicLocations.start", "integer").build();
+			new FieldBuilder(builder, "curatedVariantGenomicLocations.end", "integer").build();
+			new FieldBuilder(builder, "curatedVariantGenomicLocations.variantGenomicLocationAssociationObject.name", "text").keyword().build();
 			builder.endObject();
 			builder.endObject();
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.46.29</curation.version>
+		<curation.version>v0.46.30</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary
- Update curation dependency to v0.46.30 (SSD/VSD now use Variant entity directly)
- All converters updated: `setVariantLocation()` -> `setVariant()` / access via `getVariants()`
- Removed `setSubCategory` and `setSequenceSummaryCategory` calls
- Mapping.java and VariantMapping.java: `variant` object updated for Variant entity paths, `sequenceSummaryCategory` removed
- AlleleVariantIndexService: field paths updated for SSD's `variant.*` structure
- Both `variant` (singular, SSD) and `variants` (plural, ASD/VSD) mapped in both mapping files

## Test plan
- [ ] Build succeeds
- [ ] After indexer run, verify allele-details page displays all columns
- [ ] Verify allele summary table still works (uses `variants` plural paths)