### PR TITLE
SCRUM-4854: Add taxon to variant wrapper in HTP VariantSummaryConverter

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
@@ -266,6 +266,7 @@ public class VariantSummaryConverter {
 			doc.setAllele(allele);
 			Variant variantWrapper = new Variant();
 			variantWrapper.setVariantType(variantType);
+			variantWrapper.setTaxon(taxon);
 			variantWrapper.setCuratedVariantGenomicLocations(List.of(cvgla));
 			doc.setVariants(List.of(variantWrapper));
 			doc.setGeneIds(resultPair.getRight());


### PR DESCRIPTION
## Summary
- Add `variantWrapper.setTaxon(taxon)` in VariantSummaryConverter so HTP variant_summary docs have taxon on the Variant entity
- Needed alongside curation PR #2515 (LTP taxon fix) for the variant page to display species

## Test plan
- [ ] After indexer run, verify HTP variants have taxon in ES
- [ ] Variant page shows species for HTP variants