### PR TITLE
SCRUM-5821 Migrate HTP dataset indexing from Neo4j to curation API

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -245,7 +245,7 @@ public class SearchService {
 		// apply filters if a category has been set
 		if (StringUtils.isNotEmpty(category)) {
 			if (Category.ALLELE_VARIANT.getName().equals(category)) {
-				bool.filter(termsQuery("category", Category.ALLELE.getName(), Category.VARIANT_SEARCH_RESULT.getName()));
+				bool.filter(termsQuery("category", Category.ALLELE.getName(), Category.VARIANT.getName()));
 			} else {
 				bool.filter(new TermQueryBuilder("category", category));
 			}

--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
@@ -26,7 +26,7 @@ public class SearchHelper {
 
 	private HashMap<String, List<String>> categoryFilters = new HashMap<>() {
 		{
-			put("gene", new ArrayList<>() {
+			put(Category.GENE.getName(), new ArrayList<>() {
 				{
 					add("species");
 					add("biotypes");
@@ -45,7 +45,7 @@ public class SearchHelper {
 					add("genes");
 				}
 			});
-			put("dataset", new ArrayList<String>() {
+			put(Category.DATASET.getName(), new ArrayList<String>() {
 				{
 					add("species");
 					add("tags");
@@ -55,14 +55,14 @@ public class SearchHelper {
 //					  add("stage"); will be implemented in the future
 				}
 			});
-			put("disease", new ArrayList<>() {
+			put(Category.DISEASE.getName(), new ArrayList<>() {
 				{
 					add("diseaseGroup");
 					add("genes");
 					add("associatedSpecies");
 				}
 			});
-			put("allele", new ArrayList<>() {
+			put(Category.ALLELE.getName(), new ArrayList<>() {
 				{
 					add("species");
 					add("alterationType");
@@ -75,7 +75,7 @@ public class SearchHelper {
 					add("constructRegulatoryRegion");
 				}
 			});
-			put("model", new ArrayList<>() {
+			put(Category.MODEL.getName(), new ArrayList<>() {
 				{
 					add("species");
 					add("diseasesAgrSlim");
@@ -83,7 +83,7 @@ public class SearchHelper {
 					add("alleles");
 				}
 			});
-			put("variant_search_result", new ArrayList<>() {
+			put(Category.VARIANT_SEARCH_RESULT.getName(), new ArrayList<>() {
 				{
 					add("species");
 					add("alterationType");
@@ -92,7 +92,7 @@ public class SearchHelper {
 					add("genes");
 				}
 			});
-			put("allele_variant", new ArrayList<>() {
+			put(Category.ALLELE_VARIANT.getName(), new ArrayList<>() {
 				{
 					add("species");
 					add("alterationType");
@@ -390,7 +390,7 @@ public class SearchHelper {
 		Category.GO.getName(),
 		Category.DISEASE.getName(),
 		Category.MODEL.getName(),
-		"dataset"
+		Category.DATASET.getName()
 	);
 
 	/**

--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
@@ -83,7 +83,7 @@ public class SearchHelper {
 					add("alleles");
 				}
 			});
-			put(Category.VARIANT_SEARCH_RESULT.getName(), new ArrayList<>() {
+			put(Category.VARIANT.getName(), new ArrayList<>() {
 				{
 					add("species");
 					add("alterationType");
@@ -348,7 +348,7 @@ public class SearchHelper {
 			// Allow allele and variant_search_result through for merging
 			Set<String> acceptableKeys = new HashSet<>(categoryFilters.keySet());
 			acceptableKeys.add(Category.ALLELE.getName());
-			acceptableKeys.add(Category.VARIANT_SEARCH_RESULT.getName());
+			acceptableKeys.add(Category.VARIANT.getName());
 			AggResult ares = new AggResult("category", aggs, acceptableKeys);
 			mergeAlleleVariantBuckets(ares);
 			orderCategoryBuckets(ares);
@@ -373,7 +373,7 @@ public class SearchHelper {
 		long combinedCount = 0;
 		List<AggDocCount> toRemove = new ArrayList<>();
 		for (AggDocCount bucket : aggResult.getValues()) {
-			if (bucket.getKey().equals(Category.ALLELE.getName()) || bucket.getKey().equals(Category.VARIANT_SEARCH_RESULT.getName())) {
+			if (bucket.getKey().equals(Category.ALLELE.getName()) || bucket.getKey().equals(Category.VARIANT.getName())) {
 				combinedCount += bucket.getTotal();
 				toRemove.add(bucket);
 			}

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
@@ -7,7 +7,7 @@ public enum IndexerConfig {
 
 	// Neo Indexers
 	GeneIndexer("gene", GeneIndexer.class, 4, 359, 359, 8, 1, false),
-	DatasetIndexer("dataset", DatasetIndexer.class, 4, 566, 566, 8, 1, false),
+	//DatasetIndexer("dataset", DatasetIndexer.class, 4, 566, 566, 8, 1, false), // Disabled: Dataset indexing now handled by HTPDatasetSearchResultCurationIndexer
 	DiseaseIndexer("disease", DiseaseIndexer.class, 4, 680, 680, 8, 1, false),
 	AlleleIndexer("allele", AlleleIndexer.class, 4, 1517, 1517, 8, 1, false),
 	//GoIndexer("go", GoIndexer.class, 4, 914, 914, 8, 1, false), // Disabled: GO indexing now handled by GOSearchResultCurationIndexer
@@ -18,6 +18,7 @@ public enum IndexerConfig {
 	// Run Parallelly
 	ParalogyIndexer("paralogy", GeneToGeneParalogyIndexer.class, 4, 5000, 5000, 8, 1, true),
 	GOSearchResultCurationIndexer("goSearchResult", GOSearchResultCurationIndexer.class, 4, 1500, 1500, 4, 1, true),
+	HTPDatasetSearchResultCurationIndexer("htpDatasetSearchResult", HTPDatasetSearchResultCurationIndexer.class, 4, 1500, 1500, 4, 1, true),
 	LiteratureIndexer("literature", LiteratureIndexer.class, 4, 5000, 5000, 1, 1, true),
 	GeneGeneticInteractionIndexers("geneGeneticInteraction", GeneGeneticInteractionCurationIndexer.class, 4, 1500, 1500, 2, 1, true),
 	AffectedGenomicModelIndexer("affectedGenomicModels", AffectedGenomicModelCurationIndexer.class, 4, 1500, 1500, 8, 1, true),

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/HTPDatasetSearchResultCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/HTPDatasetSearchResultCurationIndexer.java
@@ -1,0 +1,82 @@
+package org.alliancegenome.indexer.indexers.curation;
+
+import java.util.List;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import org.alliancegenome.core.config.ConfigHelper;
+import org.alliancegenome.curation_api.interfaces.document.HTPDatasetDocumentInterface;
+import org.alliancegenome.curation_api.model.document.es.HTPDatasetSearchResultDocument;
+import org.alliancegenome.curation_api.response.SearchResponse;
+import org.alliancegenome.es.rest.RestConfig;
+import org.alliancegenome.indexer.config.IndexerConfig;
+import org.alliancegenome.indexer.indexers.Indexer;
+import org.apache.commons.collections.CollectionUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+import si.mazi.rescu.RestProxyFactory;
+
+@Slf4j
+public class HTPDatasetSearchResultCurationIndexer extends Indexer {
+
+	private final HTPDatasetDocumentInterface htpApi = RestProxyFactory.createProxy(HTPDatasetDocumentInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
+
+	private List<List<Long>> idBatches;
+
+	public HTPDatasetSearchResultCurationIndexer(IndexerConfig indexerConfig) {
+		super(indexerConfig);
+	}
+
+	@Override
+	protected void index() {
+		try {
+			log.info("Fetching all HTP dataset search result IDs...");
+			SearchResponse<Long> idsResponse = htpApi.getAllIds();
+			List<Long> allIds = idsResponse.getResults();
+			log.info("Fetched {} HTP dataset search result IDs", allIds.size());
+
+			idBatches = partition(allIds, indexerConfig.getBufferSize());
+			log.info("Partitioned into {} batches of up to {}", idBatches.size(), indexerConfig.getBufferSize());
+
+			LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
+			for (int i = 0; i < idBatches.size(); i++) {
+				queue.add(String.valueOf(i));
+			}
+
+			initiateThreading(queue);
+		} catch (Exception e) {
+			log.error("Error while indexing...", e);
+			System.exit(-1);
+		}
+	}
+
+	@Override
+	protected void startSingleThread(LinkedBlockingDeque<String> queue) {
+		while (true) {
+			try {
+				if (queue.isEmpty()) {
+					return;
+				}
+				String batchIndex = queue.takeFirst();
+				List<Long> batchIds = idBatches.get(Integer.parseInt(batchIndex));
+
+				SearchResponse<HTPDatasetSearchResultDocument> response = htpApi.findByIds(batchIds);
+				if (response == null || CollectionUtils.isEmpty(response.getResults())) {
+					continue;
+				}
+
+				indexDocuments(response.getResults());
+			} catch (Exception e) {
+				log.error("Error while indexing...", e);
+				System.exit(-1);
+				return;
+			}
+		}
+	}
+
+	@Override
+	protected ObjectMapper customizeObjectMapper(ObjectMapper objectMapper) {
+		return RestConfig.config.getJacksonObjectMapperFactory().createObjectMapper();
+	}
+}

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/search/Category.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/search/Category.java
@@ -4,7 +4,7 @@ public enum Category {
 
 	ALLELE("allele", true),
 	ALLELE_VARIANT("allele_variant", true),
-	VARIANT_SEARCH_RESULT("variant_search_result", true),
+	VARIANT("variant_search_result", true),
 	DISEASE("disease", true),
 	MODEL("model", true),
 	GENE("gene", true),

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/search/Category.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/search/Category.java
@@ -8,7 +8,8 @@ public enum Category {
 	DISEASE("disease", true),
 	MODEL("model", true),
 	GENE("gene", true),
-	GO("go_search_result", true);
+	GO("go_search_result", true),
+	DATASET("htp_dataset_search_result", true);
 
 	private String name;
 	private Boolean searchable;

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.46.30</curation.version>
+		<curation.version>v0.46.32</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
Replace DatasetIndexer with HTPDatasetSearchResultCurationIndexer following the GO search result pattern. Category changes from "dataset" to "htp_dataset_search_result".

Also standardize categoryFilters in SearchHelper to use Category enum instead of hardcoded strings.

Bump curation.version to v0.46.32.