### PR TITLE
SCRUM-4854: Allele-variant-detail download for SequenceSummaryDocument

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
@@ -191,12 +191,19 @@ public class GeneController implements GeneRESTInterface {
 	@Override
 	public Response getAllelesVariantPerGeneDownload(String id, String symbol, String associatedGeneSymbol, String synonyms, String hgvsgName, String variantType, String molecularConsequence, String impact, String sequenceFeatureType, String sequenceFeature, String variantPolyphen,
 		String variantSift, String hasDisease, String hasPhenotype, String category, String location) {
-		JsonResultResponse<SequenceSummaryDocument> alleles = getAllelesVariantPerGene(id, Integer.MAX_VALUE, 1, null, null, symbol, associatedGeneSymbol, synonyms, hgvsgName, variantType, molecularConsequence, impact, sequenceFeatureType, sequenceFeature, variantPolyphen, variantSift, hasDisease,
-			hasPhenotype, category, location);
+		int pageSize = 10000;
+		int page = 1;
+		List<SequenceSummaryDocument> allResults = new java.util.ArrayList<>();
+		long total;
+		do {
+			JsonResultResponse<SequenceSummaryDocument> batch = getAllelesVariantPerGene(id, pageSize, page, null, null, symbol, associatedGeneSymbol, synonyms, hgvsgName, variantType, molecularConsequence, impact, sequenceFeatureType, sequenceFeature, variantPolyphen, variantSift, hasDisease,
+				hasPhenotype, category, location);
+			allResults.addAll(batch.getResults());
+			total = batch.getTotal();
+			page++;
+		} while (allResults.size() < total);
 
-		// TODO: Response.ResponseBuilder responseBuilder =
-		// Response.ok(alleleTranslator.getAllAlleleVariantDetailRows(alleles.getResults()));
-		Response.ResponseBuilder responseBuilder = Response.ok("");
+		Response.ResponseBuilder responseBuilder = Response.ok(alleleTranslator.getAllSequenceSummaryDetailRows(allResults));
 		APIServiceHelper.setDownloadHeader(id, EntityType.GENE, EntityType.ALLELESANDVARIANT, responseBuilder);
 		return responseBuilder.build();
 	}

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
@@ -193,7 +193,7 @@ public class GeneController implements GeneRESTInterface {
 		String variantSift, String hasDisease, String hasPhenotype, String category, String location) {
 		int pageSize = 10000;
 		int page = 1;
-		List<SequenceSummaryDocument> allResults = new java.util.ArrayList<>();
+		List<SequenceSummaryDocument> allResults = new ArrayList<>();
 		long total;
 		do {
 			JsonResultResponse<SequenceSummaryDocument> batch = getAllelesVariantPerGene(id, pageSize, page, null, null, symbol, associatedGeneSymbol, synonyms, hgvsgName, variantType, molecularConsequence, impact, sequenceFeatureType, sequenceFeature, variantPolyphen, variantSift, hasDisease,

--- a/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/AlleleToTdfTranslator.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/AlleleToTdfTranslator.java
@@ -6,12 +6,12 @@ import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
-import org.alliancegenome.api.entity.AlleleVariantSequence;
 import org.alliancegenome.api.entity.GeneTransgenicAlleleSummaryDocument;
 import org.alliancegenome.api.entity.TransgenicAlleleSummaryDocument;
 import org.alliancegenome.curation_api.model.document.es.AVSParentDocument;
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
 import org.alliancegenome.curation_api.model.document.es.ESDocument;
+import org.alliancegenome.curation_api.model.document.es.SequenceSummaryDocument;
 import org.alliancegenome.curation_api.model.document.es.VariantSummaryDocument;
 import org.alliancegenome.curation_api.model.entities.Allele;
 import org.alliancegenome.curation_api.model.entities.CrossReference;
@@ -70,13 +70,6 @@ public class AlleleToTdfTranslator {
 		};
 	}
 
-	public List<AlleleVariantSequenceDownloadRow> alleleVariantSequenceDownloadRow(List<AlleleVariantSequence> annotations) {
-		return annotations.stream()
-			.map(this::getBaseAlleleVariantDownloadRow)
-			.collect(Collectors.toList());
-	}
-
-
 	private AlleleDownloadRow getBaseDownloadRow(AVSParentDocument annotation, Variant variant) {
 		AlleleDownloadRow row = new AlleleDownloadRow();
 		Allele allele = annotation.getAllele();
@@ -120,43 +113,6 @@ public class AlleleToTdfTranslator {
 
 		row.setHasPhenotype(annotation.getHasPhenotype() != null ? annotation.getHasPhenotype().toString() : "false");
 		row.setHasDisease(annotation.getHasDisease() != null ? annotation.getHasDisease().toString() : "false");
-		return row;
-	}
-
-	private AlleleVariantSequenceDownloadRow getBaseAlleleVariantDownloadRow(AlleleVariantSequence annotation) {
-		AlleleVariantSequenceDownloadRow row = new AlleleVariantSequenceDownloadRow();
-
-		row.setAlleleID(annotation.getAllele().getPrimaryKey());
-		row.setAlleleSymbol(annotation.getAllele().getSymbol());
-		String synonyms = "";
-		if (CollectionUtils.isNotEmpty(annotation.getAllele().getSynonyms())) {
-			StringJoiner synonymJoiner = new StringJoiner(",");
-			annotation.getAllele().getSynonyms().forEach(synonym -> synonymJoiner.add(synonym.getName()));
-			synonyms = synonymJoiner.toString();
-		}
-		row.setAlleleSynonyms(synonyms);
-		row.setVariantCategory(annotation.getAllele().getCategory());
-		row.setHasDisease(annotation.getAllele().hasDisease().toString());
-		row.setHasPhenotype(annotation.getAllele().hasPhenotype().toString());
-		if (annotation.getVariant() != null) {
-			row.setHgvsgName(annotation.getVariant().getHgvsNomenclature());
-			row.setVariantType(annotation.getVariant().getVariantType().getName());
-		}
-		if (annotation.getConsequence() != null) {
-			row.setMolecularConsequences(annotation.getConsequence().getMolecularConsequences());
-			row.setSequenceFeature(annotation.getConsequence().getTranscript().getName());
-			row.setSequenceFeatureType(annotation.getConsequence().getSequenceFeatureType());
-			row.setLocation(annotation.getConsequence().getLocation());
-			row.setVepImpact(annotation.getConsequence().getImpact());
-			row.setSiftPrediction(annotation.getConsequence().getSiftPrediction());
-			row.setSiftScore(annotation.getConsequence().getSiftScore());
-			row.setPolyphenPrediction(annotation.getConsequence().getPolyphenPrediction());
-			row.setPolyphenScore(annotation.getConsequence().getPolyphenScore());
-			if (annotation.getConsequence().getAssociatedGene() != null) {
-				row.setSequenceFeatureAssociatedGene(annotation.getConsequence().getAssociatedGene().getSymbol());
-				row.setSequenceFeatureAssociatedGeneID(annotation.getConsequence().getAssociatedGene().getPrimaryKey());
-			}
-		}
 		return row;
 	}
 
@@ -402,9 +358,81 @@ public class AlleleToTdfTranslator {
 		return hgvsCs;
 	}
 
-	public String getAllAlleleVariantDetailRows(List<AlleleVariantSequence> annotations) {
+	public String getAllSequenceSummaryDetailRows(List<SequenceSummaryDocument> documents) {
+		List<AlleleVariantSequenceDownloadRow> list = documents.stream().map(doc -> {
+			AlleleVariantSequenceDownloadRow row = new AlleleVariantSequenceDownloadRow();
+			Allele allele = doc.getAllele();
+			Variant variant = doc.getVariant();
+			PredictedVariantConsequence consequence = doc.getConsequence();
 
-		List<AlleleVariantSequenceDownloadRow> list = alleleVariantSequenceDownloadRow(annotations);
+			if (allele != null) {
+				row.setAlleleID(allele.getPrimaryExternalId());
+				if (allele.getAlleleSymbol() != null) {
+					row.setAlleleSymbol(allele.getAlleleSymbol().getDisplayText());
+				}
+				if (CollectionUtils.isNotEmpty(allele.getAlleleSynonyms())) {
+					row.setAlleleSynonyms(allele.getAlleleSynonyms().stream()
+						.map(s -> s.getDisplayText())
+						.collect(Collectors.joining(",")));
+				}
+			}
+			row.setVariantCategory(doc.getAlterationType());
+			row.setHasDisease(doc.getHasDisease() != null ? doc.getHasDisease().toString() : "");
+			row.setHasPhenotype(doc.getHasPhenotype() != null ? doc.getHasPhenotype().toString() : "");
+
+			if (variant != null) {
+				if (variant.getVariantType() != null) {
+					row.setVariantType(variant.getVariantType().getName());
+				}
+				if (CollectionUtils.isNotEmpty(variant.getCuratedVariantGenomicLocations())) {
+					CuratedVariantGenomicLocationAssociation loc = variant.getCuratedVariantGenomicLocations().get(0);
+					if (loc != null) {
+						row.setHgvsgName(loc.getHgvs());
+					}
+				}
+			}
+
+			if (consequence != null) {
+				if (consequence.getVariantTranscript() != null) {
+					row.setSequenceFeature(consequence.getVariantTranscript().getName());
+					if (consequence.getVariantTranscript().getTranscriptType() != null) {
+						row.setSequenceFeatureType(consequence.getVariantTranscript().getTranscriptType().getName());
+					}
+					if (CollectionUtils.isNotEmpty(consequence.getVariantTranscript().getTranscriptGeneAssociations())) {
+						TranscriptGeneAssociation tga = consequence.getVariantTranscript().getTranscriptGeneAssociations().get(0);
+						if (tga != null && tga.getTranscriptGeneAssociationObject() != null) {
+							if (tga.getTranscriptGeneAssociationObject().getGeneSymbol() != null) {
+								row.setSequenceFeatureAssociatedGene(tga.getTranscriptGeneAssociationObject().getGeneSymbol().getDisplayText());
+							}
+							row.setSequenceFeatureAssociatedGeneID(tga.getTranscriptGeneAssociationObject().getIdentifier());
+						}
+					}
+				}
+				if (CollectionUtils.isNotEmpty(consequence.getVepConsequences())) {
+					row.setMolecularConsequences(consequence.getVepConsequences().stream()
+						.map(SOTerm::getName)
+						.collect(Collectors.toList()));
+				}
+				row.setLocation(consequence.getIntronExonLocation());
+				if (consequence.getVepImpact() != null) {
+					row.setVepImpact(consequence.getVepImpact().getName());
+				}
+				if (consequence.getSiftPrediction() != null) {
+					row.setSiftPrediction(consequence.getSiftPrediction().getName());
+				}
+				if (consequence.getSiftScore() != null) {
+					row.setSiftScore(consequence.getSiftScore().toString());
+				}
+				if (consequence.getPolyphenPrediction() != null) {
+					row.setPolyphenPrediction(consequence.getPolyphenPrediction().getName());
+				}
+				if (consequence.getPolyphenScore() != null) {
+					row.setPolyphenScore(consequence.getPolyphenScore().toString());
+				}
+			}
+			return row;
+		}).collect(Collectors.toList());
+
 		List<DownloadHeader> headers = List.of(
 			new DownloadHeader<>("Allele ID", AlleleVariantSequenceDownloadRow::getAlleleID),
 			new DownloadHeader<>("Allele Symbol", AlleleVariantSequenceDownloadRow::getAlleleSymbol),
@@ -429,7 +457,6 @@ public class AlleleToTdfTranslator {
 
 		return DownloadHeader.getDownloadOutput(list, headers);
 	}
-
 
 }
 

--- a/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/AlleleVariantSequenceDownloadRow.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/translators/tdf/AlleleVariantSequenceDownloadRow.java
@@ -23,7 +23,7 @@ public class AlleleVariantSequenceDownloadRow {
 	private String sequenceFeatureAssociatedGene;
 	private String sequenceFeatureAssociatedGeneID;
 	private String location;
-	private List<String> molecularConsequences;
+	private List<String> molecularConsequences = List.of();
 	private String vepImpact;
 	private String siftPrediction;
 	private String siftScore;


### PR DESCRIPTION
## Summary
- Implement paginated download for allele-variant-detail endpoint using SequenceSummaryDocument
- Replace Integer.MAX_VALUE limit with 10k-chunk pagination to avoid exceeding ES max_result_window
- Add new translator method for SequenceSummaryDocument -> TSV download (19 columns)
- Remove dead Neo4j-based download code
- Fix NPE on null molecularConsequences list

## Test plan
- [ ] `GET /api/gene/MGI:109583/allele-variant-detail/download` returns 6750 rows
- [ ] `GET /api/gene/MGI:109583/allele-variant-detail/download?filter.alleleCategory=variant` returns filtered subset
- [ ] `GET /api/gene/MGI:109583/allele-variant-detail/download?filter.hasPhenotype=true` returns 10 rows
- [ ] Download includes all 19 columns with correct data