### PR TITLE
SCRUM-4816: Add GeneSearchResultCurationIndexer with ID-batch pattern

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
@@ -40,7 +40,7 @@ public enum IndexerConfig {
 	DiseaseAnnotationIndexer("diseaseAnnotation", DiseaseAnnotationCurationIndexer.class, 1, 1500, 1500, 2, 1, false),
 	VariantSummaryIndexer("variantSummary", VariantSummaryCurationIndexer.class, 1, 3000, 1500, 8, 1, false),
 
-	GeneSearchResultCurationIndexer("geneSearchResult", GeneSearchResultCurationIndexer.class, 4, 1000, 1500, 4, 1, false),
+	//GeneSearchResultCurationIndexer("geneSearchResult", GeneSearchResultCurationIndexer.class, 4, 1000, 1500, 4, 1, false),
 
 	;
 

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
@@ -40,7 +40,7 @@ public enum IndexerConfig {
 	DiseaseAnnotationIndexer("diseaseAnnotation", DiseaseAnnotationCurationIndexer.class, 1, 1500, 1500, 2, 1, false),
 	VariantSummaryIndexer("variantSummary", VariantSummaryCurationIndexer.class, 1, 3000, 1500, 8, 1, false),
 
-	//GeneSearchResultCurationIndexer("geneSearchResult", GeneSearchResultCurationIndexer.class, 4, 250, 1000, 4, 1),
+	GeneSearchResultCurationIndexer("geneSearchResult", GeneSearchResultCurationIndexer.class, 4, 1000, 1500, 4, 1, false),
 
 	;
 

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/GeneSearchResultCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/GeneSearchResultCurationIndexer.java
@@ -1,6 +1,6 @@
 package org.alliancegenome.indexer.indexers.curation;
 
-import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import org.alliancegenome.core.config.ConfigHelper;
@@ -23,63 +23,49 @@ public class GeneSearchResultCurationIndexer extends Indexer {
 
 	private final GeneDocumentInterface geneApi = RestProxyFactory.createProxy(GeneDocumentInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
 
+	private List<List<Long>> idBatches;
+
 	public GeneSearchResultCurationIndexer(IndexerConfig indexerConfig) {
 		super(indexerConfig);
 	}
 
 	@Override
 	protected void index() {
-
-		HashMap<String, Object> params = new HashMap<>();
-		params.put("internal", false);
-		params.put("obsolete", false);
-
 		try {
-			SearchResponse<GeneSearchResultDocument> resp = geneApi.findSearchResult(0, 0, params);
+			log.info("Fetching all gene IDs...");
+			SearchResponse<Long> idsResponse = geneApi.getAllIds();
+			List<Long> allIds = idsResponse.getResults();
+			log.info("Fetched {} gene IDs", allIds.size());
 
-			log.info("Gene count: " + resp.getTotalResults());
-
-			int totalPages = (int) (resp.getTotalResults() / indexerConfig.getBufferSize());
+			idBatches = partition(allIds, indexerConfig.getBufferSize());
+			log.info("Partitioned into {} batches of up to {}", idBatches.size(), indexerConfig.getBufferSize());
 
 			LinkedBlockingDeque<String> queue = new LinkedBlockingDeque<>();
-
-			for (int i = 0; i <= totalPages; i++) {
+			for (int i = 0; i < idBatches.size(); i++) {
 				queue.add(String.valueOf(i));
 			}
 
 			initiateThreading(queue);
-		} catch (InterruptedException e) {
+		} catch (Exception e) {
+			log.error("Error while indexing...", e);
 			ExceptionCatcher.report(e);
-			e.printStackTrace();
+			System.exit(-1);
 		}
-
 	}
 
 	@Override
 	protected void startSingleThread(LinkedBlockingDeque<String> queue) {
-
-		HashMap<String, Object> params = new HashMap<>();
-		params.put("internal", false);
-		params.put("obsolete", false);
-		// params.put("primaryExternalId", "Xenbase:XB-GENE-17345583"); //
-		// params.put("primaryExternalId", "RGD:621017");
-		// params.put("primaryExternalId", "WB:WBGene00003883"); // alleles
-		// params.put("primaryExternalId", "ZFIN:ZDB-GENE-110114-3");
-
 		while (true) {
 			try {
 				if (queue.isEmpty()) {
 					return;
 				}
+				String batchIndex = queue.takeFirst();
+				List<Long> batchIds = idBatches.get(Integer.parseInt(batchIndex));
 
-				String page = queue.takeFirst();
-				// log.info(queue.size() + " pages to process " +
-				// Thread.currentThread().getName() + " starting page: " + page);
-
-				SearchResponse<GeneSearchResultDocument> response = geneApi.findSearchResult(Integer.valueOf(page), indexerConfig.getBufferSize(), params);
-				// log.info("Search Response: " + response);
+				SearchResponse<GeneSearchResultDocument> response = geneApi.findSearchResultByIds(batchIds);
 				if (response == null || CollectionUtils.isEmpty(response.getResults())) {
-					return;
+					continue;
 				}
 
 				indexDocuments(response.getResults());
@@ -90,7 +76,6 @@ public class GeneSearchResultCurationIndexer extends Indexer {
 				return;
 			}
 		}
-
 	}
 
 	@Override

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>0.0.0</curation.version>
+		<curation.version>v0.46.39</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.46.39</curation.version>
+		<curation.version>0.0.0</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary
- Add GeneSearchResultCurationIndexer using ID-batch pattern: fetches all gene IDs, partitions into batches of 1000, 4 threads call `findSearchResultByIds` endpoint
- Indexer is currently commented out in IndexerConfig pending curation API release with the new endpoint
- pom.xml curation.version set to 0.0.0 (local install) -- needs update to actual release version after curation PR merge

## Test plan
- [ ] After curation release: update `curation.version` in pom.xml to released version
- [ ] Uncomment GeneSearchResultCurationIndexer in IndexerConfig
- [ ] Run indexer end-to-end, verify gene documents are indexed correctly