### PR TITLE
SCRUM-4816 SCRUM-4937: Update search API for gene and disease search result documents

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/SiteMapController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/SiteMapController.java
@@ -4,8 +4,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 import org.alliancegenome.api.model.xml.SiteMap;
 import org.alliancegenome.api.model.xml.SiteMapIndex;
@@ -14,6 +12,7 @@ import org.alliancegenome.api.model.xml.XMLURLSet;
 import org.alliancegenome.api.rest.interfaces.SiteMapRESTInterface;
 import org.alliancegenome.api.service.SiteMapService;
 import org.alliancegenome.core.config.ConfigHelper;
+import org.alliancegenome.es.model.search.Category;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.SearchHit;
 
@@ -82,20 +81,26 @@ public class SiteMapController implements SiteMapRESTInterface {
 
 		Log.info("Id Lookup: " + id);
 
-		Map<String, String> map = Map.of("gene", "primaryKey", "allele", "primaryKey", "variant", "primaryKey", "disease", "primaryKey");
+		// Each entry: [urlPath, esCategory, keyField]
+		String[][] lookups = {
+			{"gene", Category.GENE.getName(), "curie"},
+			{"allele", "allele", "primaryKey"},
+			{"variant", "variant", "primaryKey"},
+			{"disease", Category.DISEASE.getName(), "primaryKey"},
+		};
 
-		for (Entry<String, String> entry : map.entrySet()) {
-			SearchResponse response = siteMapService.getAccession(entry.getKey(), entry.getValue(), id);
+		for (String[] lookup : lookups) {
+			String urlPath = lookup[0];
+			String esCategory = lookup[1];
+			String keyField = lookup[2];
+			SearchResponse response = siteMapService.getAccession(esCategory, keyField, id);
 
 			if (response == null || response.getHits() == null || response.getHits().getHits() == null || response.getHits().getHits().length == 0) {
 				continue;
 			} else {
-				System.out.println(entry + " " + id);
+				Log.info(urlPath + " " + id);
 
-				String url = null;
-				if (url == null) {
-					url = "https://www.alliancegenome.org/" + entry.getKey() + "/" + id;
-				}
+				String url = "https://www.alliancegenome.org/" + urlPath + "/" + id;
 
 				try {
 					URI uri = new URI(url);

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ExpressionRibbonESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ExpressionRibbonESService.java
@@ -22,6 +22,7 @@ import org.alliancegenome.curation_api.model.document.es.GeneExpressionRibbonSum
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.GeneExpressionAnnotation;
 import org.alliancegenome.es.model.query.Pagination;
+import org.alliancegenome.es.model.search.Category;
 import org.alliancegenome.neo4j.entity.SpeciesType;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MultiValuedMap;
@@ -112,10 +113,8 @@ public class ExpressionRibbonESService extends ESService {
 
 	public Map<String, Object> getGene(String geneID) {
 		BoolQueryBuilder boolQuery = boolQuery();
-		// Need to change category = gene to new category when the search functionlity
-		// is converted into ES
-		boolQuery.filter(new TermQueryBuilder("category", "gene"));
-		boolQuery.filter(new TermQueryBuilder("primaryKey", geneID));
+		boolQuery.filter(new TermQueryBuilder("category", Category.GENE.getName()));
+		boolQuery.filter(new TermQueryBuilder("curie", geneID));
 		LinkedHashMap<String, SortOrder> sorts = new LinkedHashMap<>();
 		Pagination pagination = new Pagination();
 		SearchResponse searchResponse = getSearchResponse(boolQuery, pagination, sorts, false);

--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -170,6 +170,7 @@ public class SearchService {
 		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("species.synonyms", q), ScoreFunctionBuilders.weightFactorFunction(2F)));
 
 		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("automatedGeneSynopsis", q), ScoreFunctionBuilders.weightFactorFunction(1.5F)));
+		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("automatedGeneDescription", q), ScoreFunctionBuilders.weightFactorFunction(1.5F)));
 
 		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("diseases", q), ScoreFunctionBuilders.weightFactorFunction(1.2F)));
 
@@ -354,12 +355,12 @@ public class SearchService {
 		} else if (StringUtils.equals(category, Category.GO.getName())) {
 			String goType = (String) result.get("branch");
 			if (StringUtils.equals(goType, "biological_process")) {
-				links.add(getRelatedDataLink("gene", "biologicalProcessWithParents", nameKey, "Genes Annotated with this GO Term"));
+				links.add(getRelatedDataLink(Category.GENE.getName(), "biologicalProcessWithParents", nameKey, "Genes Annotated with this GO Term"));
 			} else if (StringUtils.equals(goType, "molecular_function")) {
-				links.add(getRelatedDataLink("gene", "molecularFunctionWithParents", nameKey, "Genes Annotated with this GO Term"));
+				links.add(getRelatedDataLink(Category.GENE.getName(), "molecularFunctionWithParents", nameKey, "Genes Annotated with this GO Term"));
 			} else if (StringUtils.equals(goType, "cellular_component")) {
-				links.add(getRelatedDataLink("gene", "cellularComponentWithParents", nameKey, "Genes Annotated with this GO Term"));
-				links.add(getRelatedDataLink("gene", "cellularComponentExpressionWithParents", nameKey, "Genes Expressed in this Structure"));
+				links.add(getRelatedDataLink(Category.GENE.getName(), "cellularComponentWithParents", nameKey, "Genes Annotated with this GO Term"));
+				links.add(getRelatedDataLink(Category.GENE.getName(), "cellularComponentExpressionWithParents", nameKey, "Genes Expressed in this Structure"));
 			}
 		}
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
@@ -30,11 +30,11 @@ public class SearchHelper {
 				{
 					add("species");
 					add("biotypes");
-					add("diseasesAgrSlim");
+					add("diseasesWithParents");
 					add("biologicalProcessAgrSlim");
 					add("molecularFunctionAgrSlim");
 					add("cellularComponentAgrSlim");
-					add("anatomicalExpression");
+					add("anatomicalExpressionWithParents");
 					add("subcellularExpressionAgrSlim");
 				}
 			});

--- a/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/AutocompleteIntegrationSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/AutocompleteIntegrationSpec.groovy
@@ -39,7 +39,7 @@ class AutocompleteIntegrationSpec extends Specification {
         categories == [category]
 
         where:
-        category << ["gene", "disease", "go"]
+        category << ["gene_search_result", "disease", "go"]
 
     }
 
@@ -58,9 +58,9 @@ class AutocompleteIntegrationSpec extends Specification {
 
         where:
         category | query
-        "gene"   | "pax"
-        "gene"   | "fgf"
-        "gene"   | "bmp"
+        "gene_search_result"   | "pax"
+        "gene_search_result"   | "fgf"
+        "gene_search_result"   | "bmp"
     }
 
 }

--- a/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/DiseaseAnnotationSearchIntegrationSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/DiseaseAnnotationSearchIntegrationSpec.groovy
@@ -13,7 +13,7 @@ class DiseaseAnnotationSearchIntegrationSpec extends Specification {
         when:
         def encodedQuery = URLEncoder.encode(query, "UTF-8")
         //todo: need to set the base search url in a nicer way
-        def results = ApiTester.getApiResults("/api/search?category=gene&limit=500&offset=0&q=$encodedQuery$filter")
+        def results = ApiTester.getApiResults("/api/search?category=gene_search_result&limit=500&offset=0&q=$encodedQuery$filter")
 
         def betterResult = results.find { it.id == betterResultId }
         def worseResult = results.find { it.id == worseResultId }
@@ -37,7 +37,7 @@ class DiseaseAnnotationSearchIntegrationSpec extends Specification {
         when:
         def encodedQuery = URLEncoder.encode(query, "UTF-8")
         //todo: need to set the base search url in a nicer way
-        def results = ApiTester.getApiResults("/api/search?category=gene&limit=50&offset=0&q=$encodedQuery")
+        def results = ApiTester.getApiResults("/api/search?category=gene_search_result&limit=50&offset=0&q=$encodedQuery")
         def firstResultSymbol = results.first().get("symbol").toLowerCase()
 
         then:

--- a/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryMatchIntegrationSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryMatchIntegrationSpec.groovy
@@ -19,12 +19,12 @@ class QueryMatchIntegrationSpec extends Specification {
 
         where:
         filter             | query                    | issue
-        "&category=gene"   | "FBgn0086442"            | "AGR-525"
-        "&category=gene"   | "FB:FBgn0086442"         | "AGR-525"
-        "&category=gene"   | "ZDB-GENE-001120-2"      | "AGR-525"
-        "&category=gene"   | "ZFIN:ZDB-GENE-001120-2" | "AGR-525"
-        "&category=gene"   | "WBGene00000244"         | "AGR-525"
-        "&category=gene"   | "WB:WBGene00000244"      | "AGR-525"
+        "&category=gene_search_result"   | "FBgn0086442"            | "AGR-525"
+        "&category=gene_search_result"   | "FB:FBgn0086442"         | "AGR-525"
+        "&category=gene_search_result"   | "ZDB-GENE-001120-2"      | "AGR-525"
+        "&category=gene_search_result"   | "ZFIN:ZDB-GENE-001120-2" | "AGR-525"
+        "&category=gene_search_result"   | "WBGene00000244"         | "AGR-525"
+        "&category=gene_search_result"   | "WB:WBGene00000244"      | "AGR-525"
         "&category=allele" | "MGI:5752578"            | "AGR-525"
 
     }

--- a/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryRankIntegrationSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryRankIntegrationSpec.groovy
@@ -30,8 +30,8 @@ class QueryRankIntegrationSpec extends Specification {
 
         where:
         query                 | filter                               | betterResultId             | worseResultId             | issue
-        "parkinson's disease" | "&category=gene&species=Danio+rerio" | "ZFIN:ZDB-GENE-050417-109" | "ZFIN:ZDB-GENE-040827-4"  | "AGR-461"
-        "melanogaster kinase" | "&category=gene"                     | "FB:FBgn0028427"           | "RGD:1308199"             | "AGR-461"
+        "parkinson's disease" | "&category=gene_search_result&species=Danio+rerio" | "ZFIN:ZDB-GENE-050417-109" | "ZFIN:ZDB-GENE-040827-4"  | "AGR-461"
+        "melanogaster kinase" | "&category=gene_search_result"                     | "FB:FBgn0028427"           | "RGD:1308199"             | "AGR-461"
         "maple bark"          | ""                                   | "DOID:8484"                | "FB:FBgn0031571"          | "AGR-461"
     }
 
@@ -41,7 +41,7 @@ class QueryRankIntegrationSpec extends Specification {
         when:
         def encodedQuery = URLEncoder.encode(query, "UTF-8")
         //todo: need to set the base search url in a nicer way
-        def results = ApiTester.getApiResults("/api/search?category=gene&limit=50&offset=0&q=$encodedQuery")
+        def results = ApiTester.getApiResults("/api/search?category=gene_search_result&limit=50&offset=0&q=$encodedQuery")
         def firstResultSymbol = results.first().get("symbol").toLowerCase()
 
         then:
@@ -59,7 +59,7 @@ class QueryRankIntegrationSpec extends Specification {
         when:
         def encodedQuery = URLEncoder.encode(query, "UTF-8")
         //todo: need to set the base search url in a nicer way
-        def results = ApiTester.getApiResults("/api/search?category=gene&limit=50&offset=0&q=$encodedQuery")
+        def results = ApiTester.getApiResults("/api/search?category=gene_search_result&limit=50&offset=0&q=$encodedQuery")
         def names = (results.take(n)*.symbol)*.toLowerCase()
 
         def results2 = ApiTester.getApiResults("/api/search_autocomplete?q=$encodedQuery")
@@ -83,7 +83,7 @@ class QueryRankIntegrationSpec extends Specification {
         when:
         def encodedQuery = URLEncoder.encode(query, "UTF-8")
         //todo: need to set the base search url in a nicer way
-        def results = ApiTester.getApiResults("/api/search?category=gene&limit=50&offset=0&q=$encodedQuery")
+        def results = ApiTester.getApiResults("/api/search?category=gene_search_result&limit=50&offset=0&q=$encodedQuery")
 
         def resultIds = results*.id
 
@@ -157,16 +157,16 @@ class QueryRankIntegrationSpec extends Specification {
        positions.get(id) <= n
 
        where:
-       query                            | id           | nameKey        | category | n
-       "breast cancer"                  | "HGNC:1100"  | "BRCA1 (Hsa)"  | "gene"   | 2
-       "breast cancer"                  | "HGNC:1101"  | "BRCA2 (Hsa)"  | "gene"   | 2
-       "Huntington’s"                   | "HGNC:4851"  | "HTT (Hsa)"    | "gene"   | 7
-       "familial adenomatous polyposis" | "HGNC:583"   | "APC (Hsa)"    | "gene"   | 3
-       "Parkinson’s"                    | "HGNC:8607"   | "PRKN (Hsa)"  | "gene"   | 20
-//       "Alzheimer’s"                    | "HGNC:620"    | "APP (Hsa)"   | "gene"   | 10 //failing at 27
-//       "Alzheimer’s"                    | "HGNC:9508"   | "PSEN1 (Hsa)" | "gene"   | 10 //failing at 223 !
-//       "Alzheimer’s"                    | "HGNC:9509"   | "PSEN2 (Hsa)" | "gene"   | 10 //failing at 21
-       "Cystic fibrosis"                | "HGNC:1884"   | "CFTR"        | "gene"   | 1
+       query                            | id           | nameKey        | category              | n
+       "breast cancer"                  | "HGNC:1100"  | "BRCA1 (Hsa)"  | "gene_search_result"   | 2
+       "breast cancer"                  | "HGNC:1101"  | "BRCA2 (Hsa)"  | "gene_search_result"   | 2
+       "Huntington’s"                   | "HGNC:4851"  | "HTT (Hsa)"    | "gene_search_result"   | 7
+       "familial adenomatous polyposis" | "HGNC:583"   | "APC (Hsa)"    | "gene_search_result"   | 3
+       "Parkinson’s"                    | "HGNC:8607"   | "PRKN (Hsa)"  | "gene_search_result"   | 20
+//       "Alzheimer’s"                    | "HGNC:620"    | "APP (Hsa)"   | "gene_search_result"   | 10 //failing at 27
+//       "Alzheimer’s"                    | "HGNC:9508"   | "PSEN1 (Hsa)" | "gene_search_result"   | 10 //failing at 223 !
+//       "Alzheimer’s"                    | "HGNC:9509"   | "PSEN2 (Hsa)" | "gene_search_result"   | 10 //failing at 21
+       "Cystic fibrosis"                | "HGNC:1884"   | "CFTR"        | "gene_search_result"   | 1
     }
 
 }

--- a/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryTokenizationIntegrationSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryTokenizationIntegrationSpec.groovy
@@ -54,12 +54,12 @@ class QueryTokenizationIntegrationSpec extends Specification {
 
         where:
         filter             | query                                   | resultId                  | missing
-        "&category=gene"   | "fgf8a pax2a"                           | "ZFIN:ZDB-GENE-990415-72" | ["pax2a"]
-        "&category=gene"   | "fgf8a pax2a"                           | "ZFIN:ZDB-GENE-990415-8"  | ["fgf8a"]
-        "&category=gene"   | "fgf8a ZFIN:ZDB-GENE-990415-72"         | "ZFIN:ZDB-GENE-990415-72" | []
-        "&category=gene"   | "alzheimer's disease psen1"             | "HGNC:9508"               | []
-        "&category=gene"   | "ZDB-GENE-001103-1 watermellon"         | "ZFIN:ZDB-GENE-001103-1"  | ["watermellon"]
-        "&category=gene"   | "Two pore calcium channel protein 1"    | "HGNC:18182"              | []
+        "&category=gene_search_result"   | "fgf8a pax2a"                           | "ZFIN:ZDB-GENE-990415-72" | ["pax2a"]
+        "&category=gene_search_result"   | "fgf8a pax2a"                           | "ZFIN:ZDB-GENE-990415-8"  | ["fgf8a"]
+        "&category=gene_search_result"   | "fgf8a ZFIN:ZDB-GENE-990415-72"         | "ZFIN:ZDB-GENE-990415-72" | []
+        "&category=gene_search_result"   | "alzheimer's disease psen1"             | "HGNC:9508"               | []
+        "&category=gene_search_result"   | "ZDB-GENE-001103-1 watermellon"         | "ZFIN:ZDB-GENE-001103-1"  | ["watermellon"]
+        "&category=gene_search_result"   | "Two pore calcium channel protein 1"    | "HGNC:18182"              | []
         "&category=allele" | "NC_000083.6:g.75273979T>A MGI:5316784" | "MGI:5316784"             | []
 
     }

--- a/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/RelatedDataServiceIntegrationSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/RelatedDataServiceIntegrationSpec.groovy
@@ -23,9 +23,9 @@ class RelatedDataServiceIntegrationSpec extends Specification {
         where:
         nameKey                 | category  | targetField                    | min    | max
         "fgf8a (Dre)"           | "disease" | "genes"                        | 1      | Integer.MAX_VALUE
-        "sa2545 (Dre)"          | "gene"    | "alleles"                      | 1      | 1
-        "cancer"                | "gene"    | "diseasesWithParents"          | 1000   | Integer.MAX_VALUE
-        "extracellular space"   | "gene"    | "cellularComponentWithParents" | 8000   | Integer.MAX_VALUE
+        "sa2545 (Dre)"          | "gene_search_result"    | "alleles"                      | 1      | 1
+        "cancer"                | "gene_search_result"    | "diseasesWithParents"          | 1000   | Integer.MAX_VALUE
+        "extracellular space"   | "gene_search_result"    | "cellularComponentWithParents" | 8000   | Integer.MAX_VALUE
     }
 
 

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
@@ -1,7 +1,6 @@
 package org.alliancegenome.indexer.config;
 
-import org.alliancegenome.indexer.indexers.DiseaseIndexer;
-import org.alliancegenome.indexer.indexers.GeneIndexer;
+
 import org.alliancegenome.indexer.indexers.LiteratureIndexer;
 import org.alliancegenome.indexer.indexers.ModelIndexer;
 import org.alliancegenome.indexer.indexers.curation.AffectedGenomicModelCurationIndexer;
@@ -25,13 +24,10 @@ import org.alliancegenome.indexer.indexers.curation.SiteMapAccessionCurationInde
 import org.alliancegenome.indexer.indexers.curation.TransgenicAlleleCurationIndexer;
 import org.alliancegenome.indexer.indexers.curation.VariantSummaryCurationIndexer;
 
+
 public enum IndexerConfig {
 
 	// Neo Indexers
-	GeneIndexer("gene", GeneIndexer.class, 4, 359, 359, 8, 1, false),
-	//DatasetIndexer("dataset", DatasetIndexer.class, 4, 566, 566, 8, 1, false), // Disabled: Dataset indexing now handled by HTPDatasetSearchResultCurationIndexer
-	DiseaseIndexer("disease", DiseaseIndexer.class, 4, 680, 680, 8, 1, false),
-	//GoIndexer("go", GoIndexer.class, 4, 914, 914, 8, 1, false), // Disabled: GO indexing now handled by GOSearchResultCurationIndexer
 	ModelIndexer("model", ModelIndexer.class, 4, 1500, 1426, 4, 1, false),
 
 	// Curation Indexers

--- a/agr_java_core/src/main/java/org/alliancegenome/core/translators/document/DiseaseTranslator.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/translators/document/DiseaseTranslator.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import org.alliancegenome.core.translators.EntityDocumentTranslator;
 import org.alliancegenome.es.index.site.document.SearchableItemDocument;
+import org.alliancegenome.es.model.search.Category;
 import org.alliancegenome.neo4j.entity.node.CrossReference;
 import org.alliancegenome.neo4j.entity.node.DOTerm;
 import org.alliancegenome.neo4j.entity.node.Synonym;
@@ -20,7 +21,7 @@ public class DiseaseTranslator extends EntityDocumentTranslator<DOTerm, Searchab
 	private SearchableItemDocument getTermDiseaseDocument(DOTerm doTerm) {
 		SearchableItemDocument document = new SearchableItemDocument();
 
-		document.setCategory("disease");
+		document.setCategory(Category.DISEASE.getName());
 		document.setSearchable(true);
 		document.setPrimaryKey(doTerm.getPrimaryKey());
 		document.setName(doTerm.getName());

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
 import org.alliancegenome.curation_api.model.entities.Allele;
 import org.alliancegenome.es.model.AlleleSearchResultDocument;
+import org.alliancegenome.es.model.search.Category;
 import org.alliancegenome.es.model.search.RelatedDataLink;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -71,7 +72,7 @@ public class AlleleSearchResultConverter {
 			List<RelatedDataLink> relatedData = new ArrayList<>();
 			if (doc.getAlleleOfGene() != null && doc.getAlleleOfGene().getGeneSymbol() != null) {
 				RelatedDataLink geneLink = new RelatedDataLink();
-				geneLink.setCategory("gene");
+				geneLink.setCategory(Category.GENE.getName());
 				geneLink.setTargetField("alleles");
 				geneLink.setSourceName(searchDoc.getNameKey());
 				geneLink.setCount(1L);
@@ -79,7 +80,7 @@ public class AlleleSearchResultConverter {
 			}
 			if (Boolean.TRUE.equals(doc.getHasDisease())) {
 				RelatedDataLink diseaseLink = new RelatedDataLink();
-				diseaseLink.setCategory("disease");
+				diseaseLink.setCategory(Category.DISEASE.getName());
 				diseaseLink.setTargetField("alleles");
 				diseaseLink.setSourceName(searchDoc.getNameKey());
 				diseaseLink.setCount(1L);

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
@@ -2,10 +2,10 @@ package org.alliancegenome.es.model;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.es.model.search.RelatedDataLink;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/search/Category.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/search/Category.java
@@ -6,9 +6,9 @@ public enum Category {
 	ALLELE_VARIANT("allele_variant_search_result", true),
 	VARIANT("variant_search_result", true),
 	SEQUENCE_SUMMARY("sequence_summary", false),
-	DISEASE("disease", true),
+	DISEASE("disease_search_result", true),
 	MODEL("model", true),
-	GENE("gene", true),
+	GENE("gene_search_result", true),
 	GO("go_search_result", true),
 	DATASET("htp_dataset_search_result", true);
 


### PR DESCRIPTION
## Summary

Updates the search/API layer to work with the new `gene_search_result` and `disease_search_result` document types that are now indexed from the curation PostgreSQL database instead of Neo4j.

- **SCRUM-4816**: Gene search results loaded from Postgres into ES
- **SCRUM-4937**: Disease search results loaded from Postgres into ES

## Changes

- **Category enum**: `GENE` now maps to `gene_search_result`, `DISEASE` to `disease_search_result`
- **ExpressionRibbonESService**: Use `Category.GENE` enum and query `curie` field instead of `primaryKey`
- **SiteMapController**: Restructured accession lookup to use `Category` enums and correct key fields per document type
- **SearchService**: Added `automatedGeneDescription` scoring boost; updated related data links to use `Category.GENE`
- **SearchHelper**: Updated gene category filter facets (`diseasesWithParents`, `anatomicalExpressionWithParents`)
- **AlleleSearchResultConverter**: Gene and disease related data links use `Category` enums
- **DiseaseTranslator**: Use `Category.DISEASE` enum instead of hardcoded string
- **IndexerConfig**: Removed old Neo4j `GeneIndexer` and `DiseaseIndexer` entries
- **Tests**: All integration specs updated to use new category names

## Test plan

- [ ] Deploy to stage and verify gene search returns results
- [ ] Verify disease search returns results
- [ ] Verify autocomplete works for genes and diseases
- [ ] Verify sitemap accession redirects work for genes and diseases
- [ ] Verify expression ribbon gene lookup works
- [ ] Verify allele search result related data links point to correct categories