### PR TITLE
feat: add diseasesWithParents to allele search results (SCRUM-5829)

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/AlleleSummaryCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/AlleleSummaryCurationIndexer.java
@@ -75,12 +75,16 @@ public class AlleleSummaryCurationIndexer extends Indexer {
 					continue;
 				}
 
-				indexDocuments(response.getResults());
-
+				// Convert to derived documents first (consumes transport-only fields)
 				List<SequenceSummaryDocument> sequenceDocs = sequenceSummaryConverter.convert(response.getResults());
-				indexDocuments(sequenceDocs, CurationView.SequenceSummaryDocument.class);
-
 				List<AlleleSearchResultDocument> searchDocs = alleleSearchResultConverter.convert(response.getResults());
+
+				// Strip fields only needed by derived documents before indexing to OpenSearch
+				response.getResults().forEach(AlleleSummaryDocument::removeTransportFields);
+
+				// Index all document types
+				indexDocuments(response.getResults());
+				indexDocuments(sequenceDocs, CurationView.SequenceSummaryDocument.class);
 				indexDocuments(searchDocs);
 			} catch (Exception e) {
 				log.error("Error while indexing...", e);

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/AlleleSummaryCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/AlleleSummaryCurationIndexer.java
@@ -79,7 +79,7 @@ public class AlleleSummaryCurationIndexer extends Indexer {
 				List<SequenceSummaryDocument> sequenceDocs = sequenceSummaryConverter.convert(response.getResults());
 				List<AlleleSearchResultDocument> searchDocs = alleleSearchResultConverter.convert(response.getResults());
 
-				// Strip fields only needed by derived documents before indexing to OpenSearch
+				// Strip fields only needed by derived documents before indexing to ES
 				response.getResults().forEach(AlleleSummaryDocument::removeTransportFields);
 
 				// Index all document types

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
@@ -102,6 +102,9 @@ public class AlleleSearchResultConverter {
 			if (doc.getDiseasesAgrSlim() != null && !doc.getDiseasesAgrSlim().isEmpty()) {
 				searchDoc.setDiseasesAgrSlim(new ArrayList<>(doc.getDiseasesAgrSlim()));
 			}
+			if (doc.getDiseasesWithParents() != null && !doc.getDiseasesWithParents().isEmpty()) {
+				searchDoc.setDiseasesWithParents(new ArrayList<>(doc.getDiseasesWithParents()));
+			}
 
 			if (doc.getConstructExpressedComponents() != null && !doc.getConstructExpressedComponents().isEmpty()) {
 				searchDoc.setConstructExpressedComponent(doc.getConstructExpressedComponents());

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
@@ -39,6 +39,7 @@ public class AlleleSearchResultDocument extends ESDocument {
 	private List<String> genes;
 	private List<String> diseases;
 	private List<String> diseasesAgrSlim;
+	private List<String> diseasesWithParents;
 	private List<String> phenotypeStatements;
 	private String globalId;
 	private String localId;

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.47.9</curation.version>
+		<curation.version>v0.47.12</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary
- Add `diseasesWithParents` field to `AlleleSearchResultDocument` and copy it from `AlleleSummaryDocument` in the converter
- Reorder `AlleleSummaryCurationIndexer` to convert derived documents first, then strip transport-only fields via `removeTransportFields()` before indexing summary documents to ES

## Context
Companion to agr_curation release/v0.47.12. The curation side populates `diseasesWithParents` on the summary document; this change ensures it flows through to the `AlleleSearchResultDocument` in ES, enabling disease→allele related data links in search results.

## Test plan
- [ ] Deploy to stage
- [ ] Reindex after curation release deploys
- [ ] Verify allele search result documents in ES contain `diseasesWithParents`
- [ ] Verify disease search results show Allele related data links