### PR TITLE
Use Species for allele display names, normalize nameKey field

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/AutoCompleteService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/AutoCompleteService.java
@@ -42,7 +42,6 @@ public class AutoCompleteService {
 		MultiMatchQueryBuilder multi = QueryBuilders.multiMatchQuery(queryTerm);
 		multi.field("symbol", 5.0F);
 		multi.field("symbol.keyword", 8.0F);
-		multi.field("name_key.autocomplete", 3.0F);
 		multi.field("nameKey.autocomplete", 3.0F);
 		multi.field("name.keyword", 2.0F);
 		multi.field("name.autocomplete");
@@ -77,11 +76,9 @@ public class AutoCompleteService {
 		for (SearchHit hit: res.getHits()) {
 			String category = (String) hit.getSourceAsMap().get("category");
 
-			//this comes over from the Python code, use symbol for geneMap,
-			//seems like maybe it could also use name_key for everyone...
+			//this comes over from the Python code, use symbol for geneMap
 			if (StringUtils.equals(category, Category.GENE.getName())) {
 				hit.getSourceAsMap().put("name", hit.getSourceAsMap().get("symbol"));
-				hit.getSourceAsMap().put("name_key", hit.getSourceAsMap().get("nameKey"));
 			}
 			ret.add(hit.getSourceAsMap());
 		}

--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -153,16 +153,13 @@ public class SearchService {
 		functionList.add(rnaBoost());
 		functionList.add(pseudogeneBoost());
 
-		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("name_key.keyword", q), ScoreFunctionBuilders.weightFactorFunction(1000F)));
 		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("nameKey.keyword", q), ScoreFunctionBuilders.weightFactorFunction(1000F)));
 
 		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("primaryKey", q), ScoreFunctionBuilders.weightFactorFunction(1000F)));
 		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("curie", q), ScoreFunctionBuilders.weightFactorFunction(1000F)));
 
-		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("name_key.keywordAutocomplete", q), ScoreFunctionBuilders.weightFactorFunction(500F)));
 		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("nameKey.keywordAutocomplete", q), ScoreFunctionBuilders.weightFactorFunction(500F)));
 
-		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("name_key.standardBigrams", q), ScoreFunctionBuilders.weightFactorFunction(500F)));
 		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("nameKey.standardBigrams", q), ScoreFunctionBuilders.weightFactorFunction(500F)));
 
 		functionList.add(new FunctionScoreQueryBuilder.FilterFunctionBuilder(matchQuery("species", q), ScoreFunctionBuilders.weightFactorFunction(2F)));
@@ -325,11 +322,7 @@ public class SearchService {
 		if (result.containsKey("relatedData")) {
 			return;
 		}
-		String nameKey = (String) result.get("name_key");
-		// Gene documents use "name_key" (snake_case), GO search result documents use "nameKey" (camelCase)
-		if (nameKey == null) {
-			nameKey = (String) result.get("nameKey");
-		}
+		String nameKey = (String) result.get("nameKey");
 		// String name = (String) result.get("name");
 		String category = (String) result.get("category");
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
@@ -185,12 +185,6 @@ public class SearchHelper {
 			add("curie");
 			add("id");
 			add("localId");
-			add("name_key");
-			add("name_key.autocomplete");
-			add("name_key.htmlSmoosh");
-			add("name_key.keyword");
-			add("name_key.standardBigrams");
-			add("name_key.keywordAutocomplete");
 			add("nameKey");
 			add("nameKey.autocomplete");
 			add("nameKey.htmlSmoosh");
@@ -273,7 +267,7 @@ public class SearchHelper {
 			add("molecularConsequence");
 			add("molecularFunction");
 			add("name");
-			add("name_key");
+			add("nameKey");
 			add("nameKey");
 			add("primaryKey");
 			add("soTermName");

--- a/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryRankIntegrationSpec.groovy
+++ b/agr_api/src/test/groovy/org/alliancegenome/api/tests/integration/QueryRankIntegrationSpec.groovy
@@ -105,13 +105,13 @@ class QueryRankIntegrationSpec extends Specification {
 
     @Unroll
     @Ignore
-    def "When querying for #query first result name_key should be #nameKey"() {
+    def "When querying for #query first result nameKey should be #nameKey"() {
         when:
         def encodedQuery = URLEncoder.encode(query, "UTF-8")
         //todo: need to set the base search url in a nicer way
         def results = ApiTester.getApiResults("/api/search?limit=50&offset=0&q=$encodedQuery")
 
-        def firstResultNameKey = results.first().get("name_key")
+        def firstResultNameKey = results.first().get("nameKey")
 
         then:
         results //should be some results

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
@@ -41,7 +41,7 @@ public class AlleleSearchResultConverter {
 			NCBITaxonTerm taxon = allele.getTaxon();
 			if (taxon != null) {
 				Species species = taxon.getSpecies();
-				if(species != null) {
+				if (species != null) {
 					searchDoc.setSpecies(species.getFullName());
 					if (allele.getAlleleSymbol() != null) {
 						searchDoc.setNameKey(allele.getAlleleSymbol().getFormatText() + " (" + species.getAbbreviation() + ")");

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
@@ -2,6 +2,7 @@ package org.alliancegenome.core.variant.converters;
 
 import org.alliancegenome.curation_api.model.document.es.AlleleSummaryDocument;
 import org.alliancegenome.curation_api.model.entities.Allele;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.ontology.NCBITaxonTerm;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.NameSlotAnnotation;
 import org.alliancegenome.es.model.AlleleSearchResultDocument;
@@ -39,9 +40,17 @@ public class AlleleSearchResultConverter {
 
 			NCBITaxonTerm taxon = allele.getTaxon();
 			if (taxon != null) {
-				searchDoc.setSpecies(taxon.getName());
-				if (allele.getAlleleSymbol() != null) {
-					searchDoc.setNameKey(allele.getAlleleSymbol().getFormatText() + " (" + taxon.getName() + ")");
+				Species species = taxon.getSpecies();
+				if(species != null) {
+					searchDoc.setSpecies(species.getFullName());
+					if (allele.getAlleleSymbol() != null) {
+						searchDoc.setNameKey(allele.getAlleleSymbol().getFormatText() + " (" + species.getAbbreviation() + ")");
+					}
+				} else {
+					searchDoc.setSpecies(taxon.getName());
+					if (allele.getAlleleSymbol() != null) {
+						searchDoc.setNameKey(allele.getAlleleSymbol().getFormatText() + " (" + taxon.getName() + ")");
+					}
 				}
 			} else if (allele.getAlleleSymbol() != null) {
 				searchDoc.setNameKey(allele.getAlleleSymbol().getFormatText());

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/AutoCompleteDAO.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/dao/AutoCompleteDAO.java
@@ -16,7 +16,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 public class AutoCompleteDAO extends ESDAO {
 
 	private List<String> responseFields = Arrays.asList(
-		"name", "symbol", "curie", "primaryKey", "category", "go_type", "name_key", "nameKey"
+		"name", "symbol", "curie", "primaryKey", "category", "go_type", "nameKey"
 	);
 
 	public SearchResponse performQuery(QueryBuilder query) {

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/document/SearchableItemDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/document/SearchableItemDocument.java
@@ -8,7 +8,6 @@ import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.es.index.site.doclet.CrossReferenceDoclet;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -34,7 +33,6 @@ public class SearchableItemDocument extends ESDocument {
 	String href; //GO terms use this rather than modCrossRefCompleteUrl
 	String localId;
 	String name;
-	@JsonProperty("name_key")
 	String nameKey;
 	String nameText;
 	String modCrossRefCompleteUrl;

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
@@ -170,8 +170,7 @@ public class Mapping extends Builder {
 
 		new FieldBuilder(builder, "name", "text").symbol().autocomplete().keyword().keywordAutocomplete().htmlSmoosh().standardBigrams().build(); // allele, gene, model, go, dataset, disease
 		new FieldBuilder(builder, "nameText", "text").keyword().standardText().build(); // model
-		new FieldBuilder(builder, "name_key", "text").analyzer("symbols").autocomplete().keyword().keywordAutocomplete().htmlSmoosh().standardBigrams().build(); // allele, gene, model, dataset, disease
-		new FieldBuilder(builder, "nameKey", "text").analyzer("symbols").autocomplete().keyword().keywordAutocomplete().htmlSmoosh().standardBigrams().build(); // go_search_result
+		new FieldBuilder(builder, "nameKey", "text").analyzer("symbols").autocomplete().keyword().keywordAutocomplete().htmlSmoosh().standardBigrams().build(); // allele, gene, model, dataset, disease, go_search_result
 
 
 		new FieldBuilder(builder, "subject.alleleSymbol.displayText", "text").keyword().sort().build(); // allele_disease_annotation

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/VariantMapping.java
@@ -15,7 +15,7 @@ public class VariantMapping extends Mapping {
 			builder.startObject("properties");
 			new FieldBuilder(builder, "category", "keyword").symbol().autocomplete().keyword().build();
 			new FieldBuilder(builder, "name", "keyword").build();
-			new FieldBuilder(builder, "name_key", "keyword").build();
+			new FieldBuilder(builder, "nameKey", "keyword").build();
 			new FieldBuilder(builder, "alterationType", "text").keyword().build();
 			new FieldBuilder(builder, "genes", "text").keyword().build();
 			new FieldBuilder(builder, "geneIds", "keyword").build();

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
@@ -6,8 +6,6 @@ import java.util.Set;
 import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.es.model.search.RelatedDataLink;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -23,7 +21,6 @@ public class AlleleSearchResultDocument extends ESDocument {
 	private String symbol;
 	private String symbolText;
 	private String name;
-	@JsonProperty("name_key")
 	private String nameKey;
 	private String primaryKey;
 	private String species;

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/VariantSearchResultDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/VariantSearchResultDocument.java
@@ -2,7 +2,6 @@ package org.alliancegenome.es.model;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import org.alliancegenome.curation_api.model.document.es.ESDocument;
@@ -22,7 +21,6 @@ public class VariantSearchResultDocument extends ESDocument {
 
 	private boolean searchable;
 	private String name;
-	@JsonProperty("name_key")
 	private String nameKey;
 	private String primaryKey;
 	private String species;

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/search/RelatedDataLink.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/search/RelatedDataLink.java
@@ -1,9 +1,8 @@
 package org.alliancegenome.es.model.search;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
-@Getter @Setter
+@Data
 public class RelatedDataLink {
 
 	private String category;

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.47.14</curation.version>
+		<curation.version>v0.47.15</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary

- **Use Species entity for allele search results**: Update AlleleSearchResultConverter to use `Species.fullName` for the species field and `Species.abbreviation` for the nameKey suffix (e.g. "allele (Mmu)") instead of the raw NCBITaxonTerm name. Falls back to taxon name if Species is not available.
- **Rename `name_key` to `nameKey` everywhere**: Remove all snake_case `name_key` references in favor of camelCase `nameKey` for consistency with curation API document serialization. This includes ES mappings, search queries, boost functions, autocomplete, response fields, document models (`@JsonProperty` annotations removed), and test assertions.

## Files changed
- **AlleleSearchResultConverter** — species/nameKey logic updated to use Species entity
- **Mapping.java / VariantMapping.java** — ES field renamed from `name_key` to `nameKey`
- **SearchableItemDocument, AlleleSearchResultDocument, VariantSearchResultDocument** — removed `@JsonProperty("name_key")` annotations and unused imports
- **SearchHelper, SearchService, AutoCompleteService, AutoCompleteDAO** — all query/field references updated
- **RelatedDataLink** — simplified to `@Data`
- **QueryRankIntegrationSpec** — test assertions updated

## Test plan
- [ ] Rebuild indices after deploy (mapping change from `name_key` to `nameKey`)
- [ ] Verify allele search results show Species fullName for species field
- [ ] Verify nameKey displays with Species abbreviation suffix
- [ ] Verify search autocomplete and boost scoring still work correctly