### PR TITLE
SCRUM-4816: rename anatomicalExpression to anatomicalExpressionSlim

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
@@ -50,7 +50,7 @@ public class SearchHelper {
 					add("species");
 					add("tags");
 					add("assays");
-					add("anatomicalExpression");
+					add("anatomicalExpressionSlim");
 					add("sex");
 //					  add("stage"); will be implemented in the future
 				}
@@ -97,7 +97,7 @@ public class SearchHelper {
 
 	public Map<String, String> highlightCollapseMap = new HashMap<>() {
 		{
-			put("anatomicalExpression", "expression");
+			put("anatomicalExpressionSlim", "expression");
 			put("anatomicalExpressionWithParents", "expression");
 			put("cellularComponentExpression", "expression");
 			put("cellularComponentExpressionWithParents", "expression");
@@ -131,8 +131,8 @@ public class SearchHelper {
 			add("alleles");
 			add("alleles.text");
 			add("alleles.autocomplete");
-			add("anatomicalExpression");
-			add("anatomicalExpression.keyword");
+			add("anatomicalExpressionSlim");
+			add("anatomicalExpressionSlim.keyword");
 			add("anatomicalExpressionWithParents");
 			add("anatomicalExpressionWithParents.keyword");
 			add("associatedSpecies");

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
@@ -138,7 +138,7 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "object.curie", "text").keyword().sort().build(); // gene_disease_annotation, allele_disease_annotation, agm_disease_annotation
 		new FieldBuilder(builder, "subject.primaryExternalId", "text").keyword().sort().build(); // gene_disease_annotation, allele_disease_annotation, agm_disease_annotation
 
-		new FieldBuilder(builder, "anatomicalExpression", "text").keyword().build(); // gene, dataset
+		new FieldBuilder(builder, "anatomicalExpressionSlim", "text").keyword().build(); // gene, dataset
 		new FieldBuilder(builder, "whereExpressed", "text").keyword().build(); // gene, dataset
 
 		new FieldBuilder(builder, "associatedSpecies", "text").keyword().synonym().sort().build(); // go, disease

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.47.16</curation.version>
+		<curation.version>v0.47.17</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary
- Rename `anatomicalExpression` to `anatomicalExpressionSlim` in ES mapping and SearchHelper
- Aligns field name with its purpose (UBERON slim terms)

## Coordinated with
- agr_curation PR #2605 (release/v0.47.17)
- agr_ui PR (SCRUM-4816)