### PR TITLE
SCRUM-4937: Run all indexers in parallel and fix allele gene species display

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/Main.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/Main.java
@@ -68,18 +68,7 @@ public class Main {
 			log.info("Args[" + i + "]: " + args[i]);
 		}
 
-		ExecutorService parallelExecutor = Executors.newFixedThreadPool(10);
 		ExecutorService sequentialExecutor = Executors.newFixedThreadPool(1);
-
-		for (String type : parallelMap.keySet()) {
-			if (argumentSet.size() == 0 || argumentSet.contains(type)) {
-				log.info("Running Parallel for: " + type);
-				parallelExecutor.execute(indexers.get(type));
-				//indexers.get(type).start();
-			} else {
-				log.info("Not Starting: " + type);
-			}
-		}
 		
 		for (String type : sequentialMap.keySet()) {
 			if (argumentSet.size() == 0 || argumentSet.contains(type)) {
@@ -90,17 +79,6 @@ public class Main {
 				log.info("Not Starting: " + type);
 			}
 		}
-
-		parallelExecutor.shutdown();
-		while (!parallelExecutor.isTerminated()) {
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException e) {
-				ExceptionCatcher.report(e);
-				e.printStackTrace();
-			}
-		}
-		log.info("Finished Running Curation Indexers");
 		sequentialExecutor.shutdown();
 		while (!sequentialExecutor.isTerminated()) {
 			try {
@@ -110,9 +88,32 @@ public class Main {
 				e.printStackTrace();
 			}
 		}
-		log.info("Finished Running Neo4j Indexers");
+		log.info("Finished Running Sequential Indexers");
+		
+		
+		ExecutorService parallelExecutor = Executors.newFixedThreadPool(10);
+		
+		for (String type : parallelMap.keySet()) {
+			if (argumentSet.size() == 0 || argumentSet.contains(type)) {
+				log.info("Running Parallel for: " + type);
+				parallelExecutor.execute(indexers.get(type));
+				//indexers.get(type).start();
+			} else {
+				log.info("Not Starting: " + type);
+			}
+		}
+		parallelExecutor.shutdown();
+		while (!parallelExecutor.isTerminated()) {
+			try {
+				Thread.sleep(1000);
+			} catch (InterruptedException e) {
+				ExceptionCatcher.report(e);
+				e.printStackTrace();
+			}
+		}
+		log.info("Finished Running Parallel Indexers");
 
-		log.debug("Waiting for Indexers to finish");
+		log.debug("Waiting for ALL Indexers to finish");
 		for (Indexer i : indexers.values()) {
 			try {
 				if (i.isAlive()) {

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/TestSpeciesOrder.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/TestSpeciesOrder.java
@@ -30,7 +30,7 @@ public class TestSpeciesOrder {
 			String taxonCurie = species.getTaxon() != null ? species.getTaxon().getCurie() : "null";
 			Integer order = species.getPhylogeneticOrder();
 			String fullName = species.getFullName();
-			System.out.println("  " + fullName + " | taxon: " + taxonCurie + " | phylogeneticOrder: " + order);
+			System.out.println(fullName + " | taxon: " + taxonCurie + " | phylogeneticOrder: " + order);
 
 			if (species.getTaxon() != null && order != null) {
 				String taxonIdPart = taxonCurie.replace("NCBITaxon:", "");
@@ -41,7 +41,7 @@ public class TestSpeciesOrder {
 		System.out.println("\n=== Species order lookup map ===");
 		speciesOrderLookup.entrySet().stream()
 			.sorted(Map.Entry.comparingByValue())
-			.forEach(e -> System.out.println("  " + e.getKey() + " -> " + e.getValue()));
+			.forEach(e -> System.out.println(e.getKey() + " -> " + e.getValue()));
 
 		// Test buildSpeciesOrder for a specific taxon (e.g. Xenopus laevis 8355)
 		String testTaxon = args.length > 0 ? args[0] : "NCBITaxon:8355";
@@ -49,7 +49,7 @@ public class TestSpeciesOrder {
 		HashMap<String, Integer> speciesOrder = buildSpeciesOrder(speciesOrderLookup, testTaxon);
 		speciesOrder.entrySet().stream()
 			.sorted(Map.Entry.comparingByValue())
-			.forEach(e -> System.out.println("  " + e.getKey() + " -> " + e.getValue()));
+			.forEach(e -> System.out.println(e.getKey() + " -> " + e.getValue()));
 
 		System.out.println("\nDone.");
 	}

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/config/IndexerConfig.java
@@ -30,6 +30,9 @@ public enum IndexerConfig {
 
 	// Curation Indexers
 
+	// Run Sequentially -- typically take a lot of RAM or do consolidation in memory
+	ReleaseInfoIndexer("release", ReleaseInfoIndexer.class, 1, 1, 1, 1, 1, false),
+	
 	// Run Parallelly
 	ParalogyIndexer("paralogy", GeneToGeneParalogyIndexer.class, 4, 5000, 5000, 8, 1, true),
 	AffectedGenomicModelAnnotationIndexer("agmAnnotation", AGMAnnotationCurationIndexer.class, 4, 1500, 1500, 8, 1, true),
@@ -44,16 +47,13 @@ public enum IndexerConfig {
 	DiseaseSummaryIndexer("diseaseSummary", DiseaseSummaryCurationIndexer.class, 4, 1500, 1500, 4, 1, true),
 	TransgenicAlleleIndexer("transgenicAlleles", TransgenicAlleleCurationIndexer.class, 1, 3000, 1500, 8, 1, true),
 	GeneExpressionRibbonSummaryIndexer("geneExpressionRibbonSummary", GeneExpressionRibbonSummaryIndexer.class, 1, 1, 1, 1, 1, true),
-	ReleaseInfoIndexer("release", ReleaseInfoIndexer.class, 1, 1, 1, 1, 1, true),
-
-	// Run Sequentially -- typically take a lot of RAM or do consolidation in memory
-	DiseaseSearchResultIndexer("diseaseSearchResult", DiseaseSearchResultCurationIndexer.class, 8, 50, 50, 4, 1, false),
-	GOSearchResultCurationIndexer("goSearchResult", GOSearchResultCurationIndexer.class, 4, 1500, 1500, 4, 1, false),
-	AlleleSummaryIndexer("alleleSummary", AlleleSummaryCurationIndexer.class, 4, 1500, 1500, 4, 1, false),
-	GeneToGeneOrthologyIndexer("geneToGeneOrthology", GeneToGeneOrthologyIndexer.class, 4, 2500, 2500, 8, 1, false),
-	GeneMolecularInteractionIndexers("geneMolecularInteraction", GeneMolecularInteractionCurationIndexer.class, 4, 1500, 1500, 2, 1, false),
-	PhenotypeAnnotationIndexer("phenotypeAnnotation", PhenotypeAnnotationCurationIndexer.class, 4, 1500, 1500, 2, 1, false),
-	DiseaseAnnotationIndexer("diseaseAnnotation", DiseaseAnnotationCurationIndexer.class, 1, 1500, 1500, 2, 1, false),
+	DiseaseSearchResultIndexer("diseaseSearchResult", DiseaseSearchResultCurationIndexer.class, 8, 50, 50, 4, 1, true),
+	GOSearchResultCurationIndexer("goSearchResult", GOSearchResultCurationIndexer.class, 4, 1500, 1500, 4, 1, true),
+	AlleleSummaryIndexer("alleleSummary", AlleleSummaryCurationIndexer.class, 4, 1500, 1500, 4, 1, true),
+	GeneToGeneOrthologyIndexer("geneToGeneOrthology", GeneToGeneOrthologyIndexer.class, 4, 2500, 2500, 8, 1, true),
+	GeneMolecularInteractionIndexers("geneMolecularInteraction", GeneMolecularInteractionCurationIndexer.class, 4, 1500, 1500, 2, 1, true),
+	PhenotypeAnnotationIndexer("phenotypeAnnotation", PhenotypeAnnotationCurationIndexer.class, 4, 1500, 1500, 2, 1, true),
+	DiseaseAnnotationIndexer("diseaseAnnotation", DiseaseAnnotationCurationIndexer.class, 1, 1500, 1500, 2, 1, true),
 	;
 
 	private String typeName;

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
@@ -67,7 +67,7 @@ public class AlleleSearchResultConverter {
 			}
 
 			if (doc.getAlleleOfGene() != null && doc.getAlleleOfGene().getGeneSymbol() != null) {
-				String geneSymbol = doc.getAlleleOfGene().getGeneSymbol().getDisplayText();
+				String geneSymbol = doc.getAlleleOfGene().getGeneSymbol().getFormatText();
 				if (taxon != null) {
 					Species geneSpecies = taxon.getSpecies();
 					if (geneSpecies != null) {

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
@@ -69,7 +69,12 @@ public class AlleleSearchResultConverter {
 			if (doc.getAlleleOfGene() != null && doc.getAlleleOfGene().getGeneSymbol() != null) {
 				String geneSymbol = doc.getAlleleOfGene().getGeneSymbol().getDisplayText();
 				if (taxon != null) {
-					geneSymbol = geneSymbol + " (" + taxon.getName() + ")";
+					Species geneSpecies = taxon.getSpecies();
+					if (geneSpecies != null) {
+						geneSymbol = geneSymbol + " (" + geneSpecies.getAbbreviation() + ")";
+					} else {
+						geneSymbol = geneSymbol + " (" + taxon.getName() + ")";
+					}
 				}
 				searchDoc.setGenes(List.of(geneSymbol));
 			}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.47.20</curation.version>
+		<curation.version>v0.47.21</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary

- **Run all indexers in parallel**: Moved previously sequential indexers (disease annotation, phenotype annotation, orthology, GO search result, allele summary, disease search result, molecular interaction) to the parallel execution pool. Only ReleaseInfoIndexer remains sequential and now runs first before all parallel indexers start.
- **Fix allele gene species display**: Use species abbreviation instead of full taxon name in the allele search result `genes` field (e.g. "Hsa" instead of "Homo sapiens"), with a fallback to taxon name if species is unavailable.
- Minor cleanup of test output formatting in `TestSpeciesOrder`.

## Test plan
- [ ] Verify indexer runs complete successfully with all indexers in parallel
- [ ] Confirm allele search results show species abbreviation in genes field
- [ ] Check ReleaseInfoIndexer runs and completes before parallel indexers start