### PR TITLE
SCRUM-2758 Use taxon.species.fullName for species filtering

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
@@ -85,9 +85,9 @@ public class DiseaseController implements DiseaseRESTInterface {
 			sortBy = SortingField.DISEASE_ALLELE_DEFAULT.toString();
 		}
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
-		pagination.addFilterOption("subject.taxon.name.keyword", species);
+		pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
 		pagination.addFilterOption("subject.alleleSymbol.displayText", alleleName);
-		pagination.addFilterOption("subject.taxon.name.keyword", species);
+		pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
 		pagination.addFilterOption("evidenceCodes.abbreviation", evidenceCode);
 		pagination.addFilterOption("generatedRelationString.keyword", associationType);
 		pagination.addFilterOption("diseaseQualifiers.keyword", diseaseQualifier);
@@ -256,7 +256,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 			pagination.addFilterOption("subject.curie", geneID);
 		}
 		if (species != null) {
-			pagination.addFilterOption("subject.taxon.species.name.keyword", species);
+			pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
 		}
 
 
@@ -300,7 +300,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("subject.agmFullName.displayText", modelName);
-		pagination.addFilterOption("subject.taxon.name.keyword", species);
+		pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
 		pagination.addFilterOption("evidenceCodes.abbreviation", evidenceCode);
 		pagination.addFilterOption("generatedRelationString.keyword", associationType);
 		pagination.addFilterOption("conditionModifierAggregated", conditionModifier);
@@ -414,14 +414,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 		pagination.addFilterOption("primaryAnnotations.with.geneSymbol.displayText", basedOnGeneSymbol);
 		pagination.addFilterOption("primaryAnnotations.dataProvider.abbreviation OR primaryAnnotations.secondaryDataProvider.abbreviation", filterSource);
 
-		// TODO: remove when SC data is fixed:
-		if (filterSpecies != null) {
-			if (filterSpecies.equals("Saccharomyces cerevisiae")) {
-				pagination.addFilterOption("subject.taxon.name.keyword", "Saccharomyces cerevisiae S288C");
-			} else {
-				pagination.addFilterOption("subject.taxon.name.keyword", filterSpecies);
-			}
-		}
+		pagination.addFilterOption("subject.taxon.species.fullName.keyword", filterSpecies);
 
 		if (pagination.hasErrors()) {
 			RestErrorMessage message = new RestErrorMessage();

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
@@ -87,7 +87,6 @@ public class DiseaseController implements DiseaseRESTInterface {
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
 		pagination.addFilterOption("subject.alleleSymbol.displayText", alleleName);
-		pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
 		pagination.addFilterOption("evidenceCodes.abbreviation", evidenceCode);
 		pagination.addFilterOption("generatedRelationString.keyword", associationType);
 		pagination.addFilterOption("diseaseQualifiers.keyword", diseaseQualifier);

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/ExpressionController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/ExpressionController.java
@@ -78,7 +78,7 @@ public class ExpressionController implements ExpressionRESTInterface {
 	private JsonResultResponse<GeneExpressionDocument> getExpressionDetailJsonResultResponse(List<String> geneIDs, String termID, String focusTaxonId, String filterSpecies, String filterGene, String filterStage, String filterAssay, String filterReference, String filterLocation, String filterSource, Integer limit, Integer page, String sortBy, String asc) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
-		pagination.addFilterOption("geneExpressionAnnotation.expressionAnnotationSubject.taxon.name", filterSpecies);
+		pagination.addFilterOption("geneExpressionAnnotation.expressionAnnotationSubject.taxon.species.fullName.keyword", filterSpecies);
 		pagination.addFilterOption("geneExpressionAnnotation.expressionAnnotationSubject.geneSymbol.displayText", filterGene);
 		pagination.addFilterOption("geneExpressionAnnotation.whereExpressedStatement", filterLocation);
 		pagination.addFilterOption("geneExpressionAnnotation.whenExpressedStageName", filterStage);

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
@@ -226,13 +226,7 @@ public class GeneController implements GeneRESTInterface {
 		pagination.addFilterOption("geneGeneticInteraction.interactorBGeneticPerturbation.alleleSymbol.displayText", interactorGeneticPerturbation);
 		pagination.addFilterOption("geneGeneticInteraction.phenotypesOrTraits", phenotypes);
 		pagination.addFilterOption("geneGeneticInteraction.interactionType.name.keyword", interactionType);
-		if (interactorSpecies != null) {
-			if (interactorSpecies.equals("Saccharomyces cerevisiae")) {
-				pagination.addFilterOption("geneGeneticInteraction.geneGeneAssociationObject.taxon.name.keyword", "Saccharomyces cerevisiae S288C");
-			} else {
-				pagination.addFilterOption("geneGeneticInteraction.geneGeneAssociationObject.taxon.name.keyword", interactorSpecies);
-			}
-		}
+		pagination.addFilterOption("geneGeneticInteraction.geneGeneAssociationObject.taxon.species.fullName.keyword", interactorSpecies);
 		// Todo: needs to be made generic
 		// pagination.validateFilterValues(info.getQueryParameters());
 		if (pagination.hasErrors()) {
@@ -269,13 +263,7 @@ public class GeneController implements GeneRESTInterface {
 		pagination.addFilterOption("geneGeneticInteraction.interactorBGeneticPerturbation.alleleSymbol.displayText", interactorGeneticPerturbation);
 		pagination.addFilterOption("geneGeneticInteraction.phenotypesOrTraits", phenotypes);
 		pagination.addFilterOption("geneGeneticInteraction.interactionType.name.keyword", interactionType);
-		if (interactorSpecies != null) {
-			if (interactorSpecies.equals("Saccharomyces cerevisiae")) {
-				pagination.addFilterOption("geneGeneticInteraction.geneGeneAssociationObject.taxon.name.keyword", "Saccharomyces cerevisiae S288C");
-			} else {
-				pagination.addFilterOption("geneGeneticInteraction.geneGeneAssociationObject.taxon.name.keyword", interactorSpecies);
-			}
-		}
+		pagination.addFilterOption("geneGeneticInteraction.geneGeneAssociationObject.taxon.species.fullName.keyword", interactorSpecies);
 
 		JsonResultResponse<GeneGeneticInteractionDocument> interactions = geneService.getGeneticInteractions(id, pagination);
 
@@ -298,13 +286,7 @@ public class GeneController implements GeneRESTInterface {
 		pagination.addFilterOption("geneMolecularInteraction.evidence.referenceID", reference);
 		pagination.addFilterOption("geneMolecularInteraction.interactorBType.name.keyword", interactorMoleculeType);
 		pagination.addFilterOption("geneMolecularInteraction.detectionMethod.name.keyword", detectionMethod);
-		if (interactorSpecies != null) {
-			if (interactorSpecies.equals("Saccharomyces cerevisiae")) {
-				pagination.addFilterOption("geneMolecularInteraction.geneGeneAssociationObject.taxon.name.keyword", "Saccharomyces cerevisiae S288C");
-			} else {
-				pagination.addFilterOption("geneMolecularInteraction.geneGeneAssociationObject.taxon.name.keyword", interactorSpecies);
-			}
-		}
+		pagination.addFilterOption("geneMolecularInteraction.geneGeneAssociationObject.taxon.species.fullName.keyword", interactorSpecies);
 		// Todo: needs to be made generic
 		// pagination.validateFilterValues(info.getQueryParameters());
 		if (pagination.hasErrors()) {
@@ -337,13 +319,7 @@ public class GeneController implements GeneRESTInterface {
 		pagination.addFilterOption("geneMolecularInteraction.evidence.referenceID", reference);
 		pagination.addFilterOption("geneMolecularInteraction.interactorBType.name.keyword", interactorMoleculeType);
 		pagination.addFilterOption("geneMolecularInteraction.detectionMethod.name.keyword", detectionMethod);
-		if (interactorSpecies != null) {
-			if (interactorSpecies.equals("Saccharomyces cerevisiae")) {
-				pagination.addFilterOption("geneMolecularInteraction.geneGeneAssociationObject.taxon.name.keyword", "Saccharomyces cerevisiae S288C");
-			} else {
-				pagination.addFilterOption("geneMolecularInteraction.geneGeneAssociationObject.taxon.name.keyword", interactorSpecies);
-			}
-		}
+		pagination.addFilterOption("geneMolecularInteraction.geneGeneAssociationObject.taxon.species.fullName.keyword", interactorSpecies);
 		JsonResultResponse<GeneMolecularInteractionDocument> interactions = geneService.getMolecularInteractions(id, pagination);
 
 		Response.ResponseBuilder responseBuilder = Response.ok(molecularInteractionTranslator.getAllRows(interactions.getResults()));
@@ -482,7 +458,7 @@ public class GeneController implements GeneRESTInterface {
 			sortBy = "transgenicAllele";
 		}
 		Pagination pagination = new Pagination(page, limit, sortBy, null);
-		pagination.addFilterOption("alleleDocument.allele.taxon.name", species);
+		pagination.addFilterOption("alleleDocument.allele.taxon.species.fullName.keyword", species);
 		pagination.addFilterOption("alleleDocument.allele.alleleSymbol.formatText", alleleSymbol);
 		pagination.addFilterOption("alleleDocument.transgenicAlleleConstructs.construct.constructSymbol.formatText", constructSymbol);
 		pagination.addFilterOption("alleleDocument.transgenicAlleleConstructs.regulatoryGenes.geneSymbol.formatText", constructRegulatedGene);

--- a/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
@@ -109,7 +109,7 @@ public class DiseaseESService extends ESService {
 		// create histogram of select columns of unfiltered query
 		Map<String, String> aggregationFields = new HashMap<>();
 		if (useSpeciesAggregation) {
-			aggregationFields.put("subject.taxon.name.keyword", "species");
+			aggregationFields.put("subject.taxon.species.fullName.keyword", "species");
 		}
 		aggregationFields.put("generatedRelationString.keyword", "associationType");
 		aggregationFields.put("diseaseQualifiers.keyword", "diseaseQualifiers");
@@ -277,7 +277,7 @@ public class DiseaseESService extends ESService {
 		sortingSetMap.put("default", List.of("viaOrthologyOrder", "phylogeneticSortingIndex", "subject.geneSymbol.displayText.sort"));
 		sortingSetMap.put("gene", List.of("subject.geneSymbol.displayText.sort", "phylogeneticSortingIndex"));
 		sortingSetMap.put("disease", List.of("object.name.sort", "phylogeneticSortingIndex", "subject.geneSymbol.displayText.sort"));
-		sortingSetMap.put("species", List.of("subject.taxon.name.keyword", "subject.geneSymbol.displayText.sort"));
+		sortingSetMap.put("species", List.of("subject.taxon.species.fullName.keyword", "subject.geneSymbol.displayText.sort"));
 
 		LinkedHashMap<String, SortOrder> sortingMap = new LinkedHashMap<>();
 
@@ -324,7 +324,7 @@ public class DiseaseESService extends ESService {
 		sortingSetMap.put("default", List.of("phylogeneticSortingIndex", "subject.name.sort"));
 		sortingSetMap.put("model", List.of("subject.name.sort", "phylogeneticSortingIndex"));
 		sortingSetMap.put("disease", List.of("object.name.sort", "phylogeneticSortingIndex", "subject.name.sort"));
-		sortingSetMap.put("species", List.of("subject.taxon.name.keyword", "subject.name.sort"));
+		sortingSetMap.put("species", List.of("subject.taxon.species.fullName.keyword", "subject.name.sort"));
 
 		LinkedHashMap<String, SortOrder> sortingMap = new LinkedHashMap<>();
 
@@ -372,7 +372,7 @@ public class DiseaseESService extends ESService {
 		sortingSetMap.put("default", List.of("phylogeneticSortingIndex", "subject.alleleSymbol.displayText.sort"));
 		sortingSetMap.put("allele", List.of("subject.alleleSymbol.displayText.sort", "phylogeneticSortingIndex"));
 		sortingSetMap.put("disease", List.of("object.name.sort", "phylogeneticSortingIndex", "subject.alleleSymbol.displayText.sort"));
-		sortingSetMap.put("species", List.of("subject.taxon.name.keyword", "subject.alleleSymbol.displayText.sort"));
+		sortingSetMap.put("species", List.of("subject.taxon.species.fullName.keyword", "subject.alleleSymbol.displayText.sort"));
 
 		LinkedHashMap<String, SortOrder> sortingMap = new LinkedHashMap<>();
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ExpressionESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ExpressionESService.java
@@ -73,7 +73,7 @@ public class ExpressionESService extends ESService {
 		LinkedHashMap<String, SortOrder> sortingMap = new LinkedHashMap<>();
 		LinkedHashMap<String, String> sortingSetMap = new LinkedHashMap<>();
 
-		sortingSetMap.put("species", "geneExpressionAnnotation.expressionAnnotationSubject.taxon.name.keyword");
+		sortingSetMap.put("species", "geneExpressionAnnotation.expressionAnnotationSubject.taxon.species.fullName.keyword");
 		sortingSetMap.put("gene", "geneExpressionAnnotation.expressionAnnotationSubject.geneSymbol.displayText.sort");
 		sortingSetMap.put("location", "geneExpressionAnnotation.whereExpressedStatement.sort");
 		sortingSetMap.put("stage", "geneExpressionAnnotation.whenExpressedStageName.sort");
@@ -131,7 +131,7 @@ public class ExpressionESService extends ESService {
 	private Map<String, Object> getSupplementalData(BoolQueryBuilder unfilteredQuery) {
 
 		Map<String, String> aggregationFields = new HashMap<>();
-		aggregationFields.put("geneExpressionAnnotation.expressionAnnotationSubject.taxon.name.keyword", "species");
+		aggregationFields.put("geneExpressionAnnotation.expressionAnnotationSubject.taxon.species.fullName.keyword", "species");
 		aggregationFields.put("geneExpressionAnnotation.whereExpressedStatement.keyword", "location");
 		aggregationFields.put("geneExpressionAnnotation.whenExpressedStageName.keyword", "stage");
 		aggregationFields.put("geneExpressionAnnotation.expressionAssayUsed.name.keyword", "assay");

--- a/agr_api/src/main/java/org/alliancegenome/api/service/GeneService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/GeneService.java
@@ -156,7 +156,7 @@ public class GeneService {
 		aggregationFields.put("geneGeneticInteraction.interactorARole.name.keyword", "filter.role");
 		aggregationFields.put("geneGeneticInteraction.interactorBRole.name.keyword", "filter.interactorRole");
 		aggregationFields.put("geneGeneticInteraction.interactionType.name.keyword", "filter.interactionType");
-		aggregationFields.put("geneGeneticInteraction.geneGeneAssociationObject.taxon.name.keyword", "filter.interactorSpecies");
+		aggregationFields.put("geneGeneticInteraction.geneGeneAssociationObject.taxon.species.fullName.keyword", "filter.interactorSpecies");
 		return getInteractionSupplementalData(aggregationFields, unfilteredQuery);
 	}
 
@@ -165,7 +165,7 @@ public class GeneService {
 		aggregationFields.put("geneMolecularInteraction.interactorBType.name.keyword", "filter.interactorMoleculeType");
 		aggregationFields.put("geneMolecularInteraction.interactorAType.name.keyword", "filter.moleculeType");
 		aggregationFields.put("geneMolecularInteraction.detectionMethod.name.keyword", "filter.detectionMethod");
-		aggregationFields.put("geneMolecularInteraction.geneGeneAssociationObject.taxon.name.keyword", "filter.interactorSpecies");
+		aggregationFields.put("geneMolecularInteraction.geneGeneAssociationObject.taxon.species.fullName.keyword", "filter.interactorSpecies");
 		return getInteractionSupplementalData(aggregationFields, unfilteredQuery);
 	}
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/TransgenicAlleleESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/TransgenicAlleleESService.java
@@ -27,7 +27,7 @@ public class TransgenicAlleleESService extends ESService {
 		BoolQueryBuilder query = getBaseModelQuery(List.of(geneId), false, "transgenic_allele_annotations");
 
 		JsonResultResponse<GeneTransgenicAlleleSummaryDocument> ret = new JsonResultResponse<>();
-		Map<String, String> aggregationFields = Map.of("alleleDocument.allele.taxon.name.keyword", "species");
+		Map<String, String> aggregationFields = Map.of("alleleDocument.allele.taxon.species.fullName.keyword", "species");
 		ret.setSupplementalData(getSupplementalData(geneId, true, debug, query, aggregationFields));
 
 		// add table filter

--- a/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/index/site/schema/Mapping.java
@@ -137,6 +137,7 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "object.name", "text").keyword().sort().build(); // gene_disease_annotation, allele_disease_annotation, agm_disease_annotation
 		new FieldBuilder(builder, "object.curie", "text").keyword().sort().build(); // gene_disease_annotation, allele_disease_annotation, agm_disease_annotation
 		new FieldBuilder(builder, "subject.primaryExternalId", "text").keyword().sort().build(); // gene_disease_annotation, allele_disease_annotation, agm_disease_annotation
+		new FieldBuilder(builder, "subject.taxon.species.fullName", "text").keyword().sort().build(); // gene_disease_annotation, allele_disease_annotation, agm_disease_annotation
 
 		new FieldBuilder(builder, "anatomicalExpressionSlim", "text").keyword().build(); // gene, dataset
 		new FieldBuilder(builder, "whereExpressed", "text").keyword().build(); // gene, dataset
@@ -148,6 +149,7 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "model.agmFullName.displayText", "text").keyword().sort().build(); //
 		new FieldBuilder(builder, "model.agmFullName.formatText", "text").keyword().sort().build(); //
 		new FieldBuilder(builder, "alleleDocument.allele.alleleSymbol.formatText", "text").keyword().sort().build(); //
+		new FieldBuilder(builder, "alleleDocument.allele.taxon.species.fullName", "text").keyword().sort().build(); //
 		new FieldBuilder(builder, "alleleDocument.phylogeneticSortingIndex", "long").keyword().sort().build(); //
 		new FieldBuilder(builder, "definition", "text").standardText().build(); // go, disease
 
@@ -193,6 +195,7 @@ public class Mapping extends Builder {
 		builder.endObject();
 		new FieldBuilder(builder, "geneMolecularInteraction.geneGeneAssociationObject.geneSymbol.displayText", "text").keyword().sort().build();
 		new FieldBuilder(builder, "geneMolecularInteraction.geneGeneAssociationObject.taxon.name", "text").keyword().sort().build();
+		new FieldBuilder(builder, "geneMolecularInteraction.geneGeneAssociationObject.taxon.species.fullName", "text").keyword().sort().build();
 		new FieldBuilder(builder, "geneMolecularInteraction.geneAssociationSubject.curie", "text").keyword().build();
 		new FieldBuilder(builder, "geneMolecularInteraction.geneAssociationSubject.primaryExternalId", "text").keyword().build();
 		new FieldBuilder(builder, "geneMolecularInteraction.interactorAType.name", "text").keyword().sort().build();
@@ -211,6 +214,7 @@ public class Mapping extends Builder {
 		builder.endObject();
 		new FieldBuilder(builder, "geneGeneticInteraction.geneGeneAssociationObject.geneSymbol.displayText", "text").keyword().sort().build();
 		new FieldBuilder(builder, "geneGeneticInteraction.geneGeneAssociationObject.taxon.name", "text").keyword().sort().build();
+		new FieldBuilder(builder, "geneGeneticInteraction.geneGeneAssociationObject.taxon.species.fullName", "text").keyword().sort().build();
 		new FieldBuilder(builder, "geneGeneticInteraction.geneAssociationSubject.curie", "text").keyword().build();
 		new FieldBuilder(builder, "geneGeneticInteraction.geneAssociationSubject.primaryExternalId", "text").keyword().build();
 		new FieldBuilder(builder, "geneGeneticInteraction.interactorARole.name", "text").keyword().build();
@@ -255,6 +259,7 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "geneExpressionAnnotation.expressionAnnotationSubject.geneSymbol.displayText", "text").keyword().sort().build();
 		new FieldBuilder(builder, "geneExpressionAnnotation.expressionAnnotationSubject.primaryExternalId", "text").keyword().build();
 		new FieldBuilder(builder, "geneExpressionAnnotation.expressionAnnotationSubject.taxon.name", "text").keyword().sort().build();
+		new FieldBuilder(builder, "geneExpressionAnnotation.expressionAnnotationSubject.taxon.species.fullName", "text").keyword().sort().build();
 		new FieldBuilder(builder, "geneExpressionAnnotation.whereExpressedStatement", "text").keyword().sort().build();
 		new FieldBuilder(builder, "geneExpressionAnnotation.whenExpressedStageName", "text").keyword().sort().build();
 		new FieldBuilder(builder, "geneExpressionAnnotation.expressionAssayUsed.name", "text").keyword().sort().build();

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.47.21</curation.version>
+		<curation.version>v0.47.24</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary
- Remove S288C workaround (Saccharomyces cerevisiae -> S288C conversion) from disease and interaction controllers
- Switch all species filter/sort/aggregation fields from `taxon.name.keyword` to `taxon.species.fullName.keyword`
- Add explicit ES mappings for the new field paths in all document types

**Depends on:** alliance-genome/agr_curation#2617 (curation library must be released first, then bump `curation.version` in pom.xml)

## Test plan
- [ ] Bump curation version after v0.47.23 release
- [ ] Deploy to stage and run indexer
- [ ] Verify species filters work on disease, interaction, expression, and transgenic allele detail pages
- [ ] Verify yeast shows as "Saccharomyces cerevisiae" (not S288C) in species filter dropdowns