### PR TITLE
SCRUM-5953 Split allele_variant into separate allele and variant categories

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -242,8 +242,8 @@ public class SearchService {
 
 		// apply filters if a category has been set
 		if (StringUtils.isNotEmpty(category)) {
-			if (Category.ALLELE_VARIANT.getName().equals(category)) {
-				bool.filter(termsQuery("category", Category.ALLELE_VARIANT.getName(), Category.VARIANT.getName()));
+			if (Category.ALLELE.getName().equals(category)) {
+				bool.filter(termsQuery("category", Category.ALLELE.getName(), Category.VARIANT.getName()));
 			} else {
 				bool.filter(new TermQueryBuilder("category", category));
 			}
@@ -330,20 +330,21 @@ public class SearchService {
 
 		if (StringUtils.equals(category, Category.GENE.getName())) {
 			links.add(getRelatedDataLink(Category.DISEASE.getName(), "genes", nameKey));
-			links.add(getRelatedDataLink(Category.ALLELE_VARIANT.getName(), "genes", nameKey));
+			links.add(getRelatedDataLink(Category.ALLELE.getName(), "genes", nameKey));
+			links.add(getRelatedDataLink(Category.VARIANT.getName(), "genes", nameKey));
 			links.add(getRelatedDataLink(Category.GO.getName(), "genes", nameKey));
 			links.add(getRelatedDataLink(Category.MODEL.getName(), "genes", nameKey));
 		} else if (StringUtils.equals(category, Category.DISEASE.getName())) {
 			links.add(getRelatedDataLink(Category.GENE.getName(), "diseasesWithParents", nameKey));
-			links.add(getRelatedDataLink(Category.ALLELE_VARIANT.getName(), "diseasesWithParents", nameKey));
+			links.add(getRelatedDataLink(Category.ALLELE.getName(), "diseasesWithParents", nameKey));
 			links.add(getRelatedDataLink(Category.MODEL.getName(), "diseasesWithParents", nameKey));
-		} else if (StringUtils.equals(category, Category.ALLELE_VARIANT.getName()) && StringUtils.equals((String) result.get("alterationType"), "allele")) {
+		} else if (StringUtils.equals(category, Category.ALLELE.getName()) && StringUtils.equals((String) result.get("alterationType"), "allele")) {
 			links.add(getRelatedDataLink(Category.DISEASE.getName(), "alleles", nameKey));
 			links.add(getRelatedDataLink(Category.GENE.getName(), "alleles", nameKey));
 			links.add(getRelatedDataLink(Category.MODEL.getName(), "alleles", nameKey));
 		} else if (StringUtils.equals(category, Category.MODEL.getName())) {
 			links.add(getRelatedDataLink(Category.GENE.getName(), "models", nameKey));
-			links.add(getRelatedDataLink(Category.ALLELE_VARIANT.getName(), "models", nameKey));
+			links.add(getRelatedDataLink(Category.ALLELE.getName(), "models", nameKey));
 			links.add(getRelatedDataLink(Category.DISEASE.getName(), "models", nameKey));
 		} else if (StringUtils.equals(category, Category.GO.getName())) {
 			String goType = (String) result.get("branch");

--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
@@ -1,8 +1,13 @@
 package org.alliancegenome.api.service.helper;
 
-import jakarta.ws.rs.core.UriInfo;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.alliancegenome.es.model.search.AggDocCount;
 import org.alliancegenome.es.model.search.AggResult;
 import org.alliancegenome.es.model.search.Category;
@@ -17,7 +22,9 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 
-import java.util.*;
+import jakarta.ws.rs.core.UriInfo;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class SearchHelper {
@@ -62,7 +69,7 @@ public class SearchHelper {
 					add("associatedSpecies");
 				}
 			});
-			put(Category.ALLELE_VARIANT.getName(), new ArrayList<>() {
+			put(Category.ALLELE.getName(), new ArrayList<>() {
 				{
 					add("species");
 					add("alterationType");
@@ -348,30 +355,31 @@ public class SearchHelper {
 	}
 
 	/**
-	 * Merge the "allele_variant_search_results" and "variant_search_results" aggregation buckets into a single "allele_variant_search_results" bucket.
+	 * Merge the "allele_search_results" and "variant_search_results" aggregation buckets into a single "allele_search_results" bucket.
 	 */
 	private void mergeAlleleVariantBuckets(AggResult aggResult) {
 		long combinedCount = 0;
 		List<AggDocCount> toRemove = new ArrayList<>();
 		for (AggDocCount bucket : aggResult.getValues()) {
-			if (bucket.getKey().equals(Category.ALLELE_VARIANT.getName()) || bucket.getKey().equals(Category.VARIANT.getName())) {
+			if (bucket.getKey().equals(Category.ALLELE.getName()) || bucket.getKey().equals(Category.VARIANT.getName())) {
 				combinedCount += bucket.getTotal();
 				toRemove.add(bucket);
 			}
 		}
 		aggResult.getValues().removeAll(toRemove);
 		if (combinedCount > 0) {
-			aggResult.getValues().add(new AggDocCount(Category.ALLELE_VARIANT.getName(), combinedCount));
+			aggResult.getValues().add(new AggDocCount(Category.ALLELE.getName(), combinedCount));
 		}
 	}
 
 	private static final List<String> CATEGORY_ORDER = List.of(
-		Category.ALLELE_VARIANT.getName(),
+		Category.ALLELE.getName(),
 		Category.GENE.getName(),
 		Category.GO.getName(),
 		Category.DISEASE.getName(),
 		Category.MODEL.getName(),
-		Category.DATASET.getName()
+		Category.DATASET.getName(),
+		Category.VARIANT.getName()
 	);
 
 	/**

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/VariantSummaryCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/VariantSummaryCurationIndexer.java
@@ -1,8 +1,6 @@
 package org.alliancegenome.indexer.indexers.curation;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import org.alliancegenome.core.config.ConfigHelper;
@@ -14,7 +12,6 @@ import org.alliancegenome.es.util.ProcessDisplayHelper;
 import org.alliancegenome.exceptional.client.ExceptionCatcher;
 import org.alliancegenome.indexer.config.IndexerConfig;
 import org.alliancegenome.indexer.indexers.Indexer;
-import org.apache.commons.collections4.CollectionUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -67,29 +64,10 @@ public class VariantSummaryCurationIndexer extends Indexer {
 				}
 
 				String page = queue.takeFirst();
-				// log.info(queue.size() + " pages to process " +
-				// Thread.currentThread().getName() + " starting page: " + page);
+				
 				SearchResponse<VariantSummaryDocument> response = variantApi.findDocuments(Integer.valueOf(page), indexerConfig.getBufferSize(), params);
-
-				// log.info("Search Response: " + response);
-				List<VariantSummaryDocument> results = response.getResults();
-				if (response == null || CollectionUtils.isEmpty(results)) {
-					return;
-				}
-
-				List<VariantSummaryDocument> list = new ArrayList<>();
-				for (VariantSummaryDocument document : results) {
-					if (document == null) {
-						continue;
-					}
-					document.setAlterationType("variant");
-					document.setAlterationTypeSortOrder(4);
-					document.setHasPhenotype(false);
-					document.setHasDisease(false);
-					list.add(document);
-				}
-
-				indexDocuments(list);
+				
+				indexDocuments(response.getResults());
 			} catch (Exception e) {
 				log.error("Error while indexing...", e);
 				ExceptionCatcher.report(e);

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
@@ -48,13 +48,18 @@ public class VariantSearchResultConverter {
 					.map(TranscriptGeneAssociation::getTranscriptGeneAssociationObject)
 					.filter(Objects::nonNull)
 					.map(gene -> {
+						String name = null;
 						if (gene.getGeneSymbol() != null && gene.getGeneSymbol().getDisplayText() != null) {
-							return gene.getGeneSymbol().getDisplayText();
+							name = gene.getGeneSymbol().getDisplayText();
+						} else if (gene.getPrimaryExternalId() != null) {
+							name = gene.getPrimaryExternalId();
+						} else {
+							name = gene.getCurie();
 						}
-						if (gene.getPrimaryExternalId() != null) {
-							return gene.getPrimaryExternalId();
+						if (name != null && gene.getTaxon() != null && gene.getTaxon().getSpecies() != null) {
+							name = name + " (" + gene.getTaxon().getSpecies().getAbbreviation() + ")";
 						}
-						return gene.getCurie();
+						return name;
 					})
 					.filter(Objects::nonNull)
 					.distinct()

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
@@ -17,6 +17,7 @@ import org.alliancegenome.curation_api.model.entities.CrossReference;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.GenomeAssembly;
 import org.alliancegenome.curation_api.model.entities.PredictedVariantConsequence;
+import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.Transcript;
 import org.alliancegenome.curation_api.model.entities.Variant;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
@@ -106,11 +107,15 @@ public class VariantSummaryConverter {
 
 		List<VariantSummaryDocument> returnDocuments = new ArrayList<>();
 
+		// TODO remove speciesType altogether and use the correct Species class coming from curation
 		// Initialize taxon if not already done
 		if (taxon == null) {
 			taxon = new NCBITaxonTerm();
 			taxon.setName(speciesType.getName());
 			taxon.setCurie(speciesType.getTaxonID());
+			Species species = new Species();
+			species.setAbbreviation(speciesType.getAbbreviation());
+			taxon.setSpecies(species);
 		}
 
 		// Create variant type

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.alliancegenome.curation_api.model.document.es.ESDocument;
-import org.alliancegenome.es.model.search.RelatedDataLink;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -14,7 +13,7 @@ import lombok.Setter;
 public class AlleleSearchResultDocument extends ESDocument {
 
 	public AlleleSearchResultDocument() {
-		category = "allele_variant_search_result";
+		category = "allele_search_result";
 	}
 
 	private boolean searchable;

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/search/Category.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/search/Category.java
@@ -3,7 +3,7 @@ package org.alliancegenome.es.model.search;
 public enum Category {
 
 	ALLELE_SUMMARY("allele_summary", false),
-	ALLELE_VARIANT("allele_variant_search_result", true),
+	ALLELE("allele_search_result", true),
 	VARIANT("variant_search_result", true),
 	SEQUENCE_SUMMARY("sequence_summary", false),
 	DISEASE("disease_search_result", true),


### PR DESCRIPTION
## Summary
- Rename `Category.ALLELE_VARIANT` to `Category.ALLELE`, add `Category.VARIANT`
- Add VARIANT related data links in `SearchService.addRelatedDataLinks` for Gene, Disease, and Model
- Update `VariantSearchResultConverter` to include species abbreviation in gene names (e.g., "Brca1 (Mmu)")
- Add Species object to `NCBITaxonTerm` in `VariantSummaryConverter` for HTP variant species info

## Test plan
- [ ] Search for "brca1" and verify variant_search_result appears in relatedData on gene results
- [ ] Verify allele search results still work correctly with renamed category
- [ ] Run variant indexer and confirm gene names include species abbreviation