### PR TITLE
SCRUM-5949: Fix facet sort, routing distribution, reduce BP threads

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
@@ -372,31 +372,8 @@ public class SearchHelper {
 		}
 	}
 
-	private static final List<String> CATEGORY_ORDER = List.of(
-		Category.ALLELE.getName(),
-		Category.GENE.getName(),
-		Category.GO.getName(),
-		Category.DISEASE.getName(),
-		Category.MODEL.getName(),
-		Category.DATASET.getName(),
-		Category.VARIANT.getName()
-	);
-
-	/**
-	 * Sort category aggregation buckets to match the desired display order.
-	 */
 	private void orderCategoryBuckets(AggResult aggResult) {
-		aggResult.getValues().sort((a, b) -> {
-			int idxA = CATEGORY_ORDER.indexOf(a.getKey());
-			int idxB = CATEGORY_ORDER.indexOf(b.getKey());
-			if (idxA < 0) {
-				idxA = CATEGORY_ORDER.size();
-			}
-			if (idxB < 0) {
-				idxB = CATEGORY_ORDER.size();
-			}
-			return Integer.compare(idxA, idxB);
-		});
+		aggResult.getValues().sort((a, b) -> Long.compare(b.getTotal(), a.getTotal()));
 	}
 
 	public boolean filterIsValid(String category, String fieldName) {

--- a/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/RoutedBulkIndexer.java
+++ b/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/RoutedBulkIndexer.java
@@ -28,7 +28,6 @@ public class RoutedBulkIndexer extends Thread {
 
 	private final LinkedBlockingDeque<List<byte[]>> jsonQueue;
 	private final String indexName;
-	private final int shardCount;
 	private final long maxBulkSizeBytes;
 	private final String label;
 
@@ -49,13 +48,11 @@ public class RoutedBulkIndexer extends Thread {
 	public RoutedBulkIndexer(
 		LinkedBlockingDeque<List<byte[]>> jsonQueue,
 		String indexName,
-		int shardCount,
 		String label,
 		ProcessDisplayHelper phGlobal
 	) {
 		this.jsonQueue = jsonQueue;
 		this.indexName = indexName;
-		this.shardCount = shardCount;
 		this.maxBulkSizeBytes = ConfigHelper.getEsBulkSizeMB() * 1024 * 1024;
 		this.label = label;
 		this.phGlobal = phGlobal;
@@ -66,6 +63,7 @@ public class RoutedBulkIndexer extends Thread {
 		boolean indexing = VariantConfigHelper.isIndexing();
 		if (indexing) {
 			client = EsClientFactory.getMustCloseSearchClient();
+			log.info(label + " ES client created: " + System.identityHashCode(client));
 		}
 		ph = new ProcessDisplayHelper(VariantConfigHelper.getDisplayInterval());
 		if (gatherStats) {
@@ -131,9 +129,11 @@ public class RoutedBulkIndexer extends Thread {
 			}
 			if (client != null) {
 				try {
+					log.info(label + " Closing ES client: " + System.identityHashCode(client));
 					client.close();
+					log.info(label + " ES client closed: " + System.identityHashCode(client));
 				} catch (IOException e) {
-					log.error(label + " Error closing ES client", e);
+					log.error(label + " Error closing ES client: " + System.identityHashCode(client), e);
 				}
 			}
 		}
@@ -143,7 +143,7 @@ public class RoutedBulkIndexer extends Thread {
 		if (gatherStats) {
 			esBatchRequestStats.addValue(docs.size());
 		}
-		String routing = Integer.toString(ThreadLocalRandom.current().nextInt(shardCount));
+		String routing = Integer.toString(ThreadLocalRandom.current().nextInt(Integer.MAX_VALUE));
 		submitWithRetry(docs, routing);
 	}
 

--- a/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreation.java
+++ b/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreation.java
@@ -114,8 +114,8 @@ public class SourceDocumentCreation extends Thread {
 
 		ph4.startProcess(messageHeader + "RoutedBulkIndexers");
 		ArrayList<RoutedBulkIndexer> indexers = new ArrayList<>();
-		for (int i = 0; i < shardCount * 4; i++) {
-			RoutedBulkIndexer indexer = new RoutedBulkIndexer(jsonQueue, indexName, shardCount, messageHeader + "BP(" + (i + 1) + ")", ph4);
+		for (int i = 0; i < shardCount * 2; i++) {
+			RoutedBulkIndexer indexer = new RoutedBulkIndexer(jsonQueue, indexName, messageHeader + "BP(" + (i + 1) + ")", ph4);
 			indexer.start();
 			indexers.add(indexer);
 		}


### PR DESCRIPTION
## Summary
- Fix category facet sort order to sort by count descending
- Fix variant indexer shard routing: use large random int instead of 0-15 range to ensure even distribution across all shards (was leaving 5 of 16 shards empty)
- Reduce RoutedBulkIndexer threads from shardCount*4 to shardCount*2 (32 per species instead of 64) to reduce ES client count and memory pressure
- Add ES client identity logging to diagnose unclosed client leak that prevents JVM exit

## Test plan
- [x] Verified empty shards caused by limited routing range on stage cluster
- [ ] Verify even shard distribution after next variant indexer run
- [ ] Verify client create/close logs match (no leaked clients)
- [ ] Verify JVM exits cleanly after indexing + snapshot completes