### PR TITLE
fix: handle ElasticsearchStatusException (429) in RoutedBulkIndexer

### DIFF
--- a/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreation.java
+++ b/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreation.java
@@ -117,7 +117,7 @@ public class SourceDocumentCreation extends Thread {
 
 		ph4.startProcess(messageHeader + "RoutedBulkIndexers");
 		ArrayList<RoutedBulkIndexer> indexers = new ArrayList<>();
-		for (int i = 0; i < shardCount * 2; i++) {
+		for (int i = 0; i < shardCount * 4; i++) {
 			RoutedBulkIndexer indexer = new RoutedBulkIndexer(jsonQueue, indexName, messageHeader + "BP(" + (i + 1) + ")", ph4);
 			indexer.start();
 			indexers.add(indexer);

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.47.30</curation.version>
+		<curation.version>v0.47.31</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
The ES coordinating memory limit causes HTTP 429 rejections which throw ElasticsearchStatusException (RuntimeException). submitWithRetry only caught IOException, so 429s killed BP threads silently. Now catches ElasticsearchStatusException with sleep+backoff and requeue instead of thread death.