### PR TITLE
SCRUM-5933 SCRUM-5966 fix speciesOrder sorting and add species to variant search

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/TestSpeciesOrder.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/TestSpeciesOrder.java
@@ -57,8 +57,9 @@ public class TestSpeciesOrder {
 	private static HashMap<String, Integer> buildSpeciesOrder(Map<String, Integer> speciesOrderLookup, String taxonCurie) {
 		HashMap<String, Integer> order = new HashMap<>();
 		String subjectTaxonIdPart = taxonCurie.replace("NCBITaxon:", "");
-		for (Map.Entry<String, Integer> entry : speciesOrderLookup.entrySet()) {
-			order.put(entry.getKey(), entry.getValue());
+		Integer subjectOrder = speciesOrderLookup.getOrDefault(subjectTaxonIdPart, 0);
+		for (String key : speciesOrderLookup.keySet()) {
+			order.put(key, subjectOrder);
 		}
 		order.put(subjectTaxonIdPart, 0);
 		return order;

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/Indexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/Indexer.java
@@ -11,12 +11,18 @@ import java.util.Map;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
+import org.alliancegenome.core.config.ConfigHelper;
 import org.alliancegenome.core.util.StatsCollector;
 import org.alliancegenome.curation_api.model.document.es.ESDocument;
+import org.alliancegenome.curation_api.model.entities.Species;
+import org.alliancegenome.es.rest.RestConfig;
 import org.alliancegenome.es.util.EsClientFactory;
 import org.alliancegenome.es.util.ProcessDisplayHelper;
 import org.alliancegenome.exceptional.client.ExceptionCatcher;
 import org.alliancegenome.indexer.config.IndexerConfig;
+import org.alliancegenome.indexer.indexers.curation.interfaces.SpeciesInterface;
+
+import si.mazi.rescu.RestProxyFactory;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkProcessor;
@@ -43,6 +49,10 @@ public abstract class Indexer extends Thread {
 	public static String indexName;
 	protected IndexerConfig indexerConfig;
 	private RestHighLevelClient searchClient;
+
+	private final SpeciesInterface speciesApi = RestProxyFactory.createProxy(SpeciesInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
+	// taxonIdPart (e.g. "9606") -> phylogeneticOrder
+	protected Map<String, Integer> speciesOrderLookup;
 	protected Runtime runtime = Runtime.getRuntime();
 	protected DecimalFormat df = new DecimalFormat("#");
 	protected ObjectMapper om = new ObjectMapper();
@@ -228,6 +238,51 @@ public abstract class Indexer extends Thread {
 			}
 		}
 		return parts;
+	}
+
+	protected void loadSpeciesOrderLookup() {
+		speciesOrderLookup = new HashMap<>();
+		List<Species> allSpecies = speciesApi.findForPublic(0, 100, "FieldsOnly", new HashMap<>()).getResults();
+		for (Species species : allSpecies) {
+			if (species.getTaxon() != null && species.getPhylogeneticOrder() != null) {
+				String taxonIdPart = species.getTaxon().getCurie().replace("NCBITaxon:", "");
+				speciesOrderLookup.put(taxonIdPart, species.getPhylogeneticOrder());
+			}
+		}
+		log.info("Loaded " + speciesOrderLookup.size() + " species for speciesOrder lookup");
+	}
+
+	/**
+	 * Builds a speciesOrder map for an ES document based on its subject's taxon.
+	 *
+	 * The returned map has one entry per species, keyed by NCBI taxon ID part (e.g. "9606").
+	 * The subject's own species is set to 0; all other species are set to the subject's
+	 * phylogenetic order value. This allows the API to sort by speciesOrder.<focusTaxonId>
+	 * and get the focus species first (0), with all other species sorted by their own
+	 * phylogenetic position — because each species' documents carry that species' own
+	 * phylogenetic order as the non-self value.
+	 *
+	 * Example for a Rat document (phylogeneticOrder=20):
+	 *   { "9606": 20, "10116": 0, "10090": 20, "7955": 20, ... }
+	 *
+	 * Example for a Human document (phylogeneticOrder=10):
+	 *   { "9606": 0, "10116": 10, "10090": 10, "7955": 10, ... }
+	 *
+	 * When the API sorts by speciesOrder.10090 (mouse gene page), documents sort as:
+	 *   Mouse=0, Human=10, Rat=20, Zebrafish=40, ... (each species has a unique value)
+	 */
+	protected HashMap<String, Integer> buildSpeciesOrder(String taxonCurie) {
+		if (speciesOrderLookup == null) {
+			loadSpeciesOrderLookup();
+		}
+		HashMap<String, Integer> order = new HashMap<>();
+		String subjectTaxonIdPart = taxonCurie.replace("NCBITaxon:", "");
+		Integer subjectOrder = speciesOrderLookup.getOrDefault(subjectTaxonIdPart, 0);
+		for (String key : speciesOrderLookup.keySet()) {
+			order.put(key, subjectOrder);
+		}
+		order.put(subjectTaxonIdPart, 0);
+		return order;
 	}
 
 	protected abstract void index(ProcessDisplayHelper display);

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/DiseaseAnnotationCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/DiseaseAnnotationCurationIndexer.java
@@ -20,7 +20,6 @@ import org.alliancegenome.api.entity.AlleleDiseaseAnnotationDocument;
 import org.alliancegenome.api.entity.DiseaseAnnotationDocument;
 import org.alliancegenome.api.entity.GeneDiseaseAnnotationDocument;
 import org.alliancegenome.core.helpers.DiseaseAnnotationHelper;
-import org.alliancegenome.core.config.ConfigHelper;
 import org.alliancegenome.curation_api.model.entities.AGMDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.entities.AffectedGenomicModel;
 import org.alliancegenome.curation_api.model.entities.Allele;
@@ -32,7 +31,6 @@ import org.alliancegenome.curation_api.model.entities.ExperimentalCondition;
 import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.curation_api.model.entities.GeneDiseaseAnnotation;
 import org.alliancegenome.curation_api.model.entities.Reference;
-import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.model.entities.VocabularyTerm;
 import org.alliancegenome.curation_api.model.entities.base.SubmittedObject;
 import org.alliancegenome.curation_api.model.entities.ontology.DOTerm;
@@ -42,13 +40,11 @@ import org.alliancegenome.es.rest.RestConfig;
 import org.alliancegenome.es.util.ProcessDisplayHelper;
 import org.alliancegenome.indexer.config.IndexerConfig;
 import org.alliancegenome.indexer.indexers.Indexer;
-import org.alliancegenome.indexer.indexers.curation.interfaces.SpeciesInterface;
 import org.alliancegenome.indexer.indexers.curation.service.AGMDiseaseAnnotationService;
 import org.alliancegenome.indexer.indexers.curation.service.AlleleDiseaseAnnotationService;
 import org.alliancegenome.indexer.indexers.curation.service.GeneDiseaseAnnotationService;
 import org.alliancegenome.indexer.indexers.curation.service.VocabularyTermService;
 
-import si.mazi.rescu.RestProxyFactory;
 import org.alliancegenome.neo4j.repository.DiseaseRepository;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -60,15 +56,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DiseaseAnnotationCurationIndexer extends Indexer {
 
-	private final SpeciesInterface speciesApi = RestProxyFactory.createProxy(SpeciesInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
-
 	private GeneDiseaseAnnotationService geneService;
 	private AlleleDiseaseAnnotationService alleleService;
 	private AGMDiseaseAnnotationService agmService;
 	private VocabularyTermService vocabTermService;
-
-	// taxonIdPart (e.g. "9606") -> phylogeneticOrder
-	private Map<String, Integer> speciesOrderLookup;
 
 	private Map<String, Set<String>> closureMap;
 	private Map<String, Pair<Gene, ArrayList<DiseaseAnnotation>>> geneMap = new HashMap<>();
@@ -103,16 +94,6 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 		vocabTermService = new VocabularyTermService();
 		DiseaseRepository diseaseRepository = new DiseaseRepository();
 		closureMap = diseaseRepository.getDOClosureChildMapping();
-
-		speciesOrderLookup = new HashMap<>();
-		List<Species> allSpecies = speciesApi.findForPublic(0, 100, "FieldsOnly", new HashMap<>()).getResults();
-		for (Species species : allSpecies) {
-			if (species.getTaxon() != null && species.getPhylogeneticOrder() != null) {
-				String taxonIdPart = species.getTaxon().getCurie().replace("NCBITaxon:", "");
-				speciesOrderLookup.put(taxonIdPart, species.getPhylogeneticOrder());
-			}
-		}
-		log.info("Loaded " + speciesOrderLookup.size() + " species for speciesOrder lookup");
 
 		indexGenes();
 		indexAlleles();
@@ -388,16 +369,6 @@ public class DiseaseAnnotationCurationIndexer extends Indexer {
 		}
 		ph.finishProcess();
 		return ret;
-	}
-
-	private HashMap<String, Integer> buildSpeciesOrder(String taxonCurie) {
-		HashMap<String, Integer> order = new HashMap<>();
-		String subjectTaxonIdPart = taxonCurie.replace("NCBITaxon:", "");
-		for (Map.Entry<String, Integer> entry : speciesOrderLookup.entrySet()) {
-			order.put(entry.getKey(), entry.getValue());
-		}
-		order.put(subjectTaxonIdPart, 0);
-		return order;
 	}
 
 	private void populateBaseDiseaseAnnotationDocument(BiologicalEntity biologicalEntity, DiseaseAnnotation da, DiseaseAnnotationDocument dad) {

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/GeneExpressionAnnotationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/GeneExpressionAnnotationIndexer.java
@@ -1,21 +1,17 @@
 package org.alliancegenome.indexer.indexers.curation;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import org.alliancegenome.core.config.ConfigHelper;
 import org.alliancegenome.curation_api.interfaces.document.GeneExpressionDocumentInterface;
 import org.alliancegenome.curation_api.model.document.es.GeneExpressionDocument;
-import org.alliancegenome.curation_api.model.entities.Species;
 import org.alliancegenome.curation_api.response.SearchResponse;
 import org.alliancegenome.es.rest.RestConfig;
 import org.alliancegenome.es.util.ProcessDisplayHelper;
 import org.alliancegenome.exceptional.client.ExceptionCatcher;
 import org.alliancegenome.indexer.config.IndexerConfig;
 import org.alliancegenome.indexer.indexers.Indexer;
-import org.alliancegenome.indexer.indexers.curation.interfaces.SpeciesInterface;
 import org.apache.commons.collections.CollectionUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,12 +23,8 @@ import si.mazi.rescu.RestProxyFactory;
 public class GeneExpressionAnnotationIndexer extends Indexer {
 
 	private final GeneExpressionDocumentInterface geneExpressionApi = RestProxyFactory.createProxy(GeneExpressionDocumentInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
-	private final SpeciesInterface speciesApi = RestProxyFactory.createProxy(SpeciesInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
 
 	private List<List<String>> idBatches;
-
-	// taxonIdPart (e.g. "9606") -> phylogeneticOrder
-	private Map<String, Integer> speciesOrderLookup;
 
 	public GeneExpressionAnnotationIndexer(IndexerConfig indexerConfig) {
 		super(indexerConfig);
@@ -41,16 +33,6 @@ public class GeneExpressionAnnotationIndexer extends Indexer {
 	@Override
 	protected void index(ProcessDisplayHelper display) {
 		try {
-			speciesOrderLookup = new HashMap<>();
-			List<Species> allSpecies = speciesApi.findForPublic(0, 100, "FieldsOnly", new HashMap<>()).getResults();
-			for (Species species : allSpecies) {
-				if (species.getTaxon() != null && species.getPhylogeneticOrder() != null) {
-					String taxonIdPart = species.getTaxon().getCurie().replace("NCBITaxon:", "");
-					speciesOrderLookup.put(taxonIdPart, species.getPhylogeneticOrder());
-				}
-			}
-			log.info("Loaded {} species for speciesOrder lookup", speciesOrderLookup.size());
-
 			log.info("Fetching all gene IDs...");
 			SearchResponse<String> idsResponse = geneExpressionApi.getGeneIds();
 
@@ -101,16 +83,6 @@ public class GeneExpressionAnnotationIndexer extends Indexer {
 				return;
 			}
 		}
-	}
-
-	private HashMap<String, Integer> buildSpeciesOrder(String taxonCurie) {
-		HashMap<String, Integer> order = new HashMap<>();
-		String subjectTaxonIdPart = taxonCurie.replace("NCBITaxon:", "");
-		for (Map.Entry<String, Integer> entry : speciesOrderLookup.entrySet()) {
-			order.put(entry.getKey(), entry.getValue());
-		}
-		order.put(subjectTaxonIdPart, 0);
-		return order;
 	}
 
 	@Override

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
@@ -117,6 +117,7 @@ public class VariantSummaryConverter {
 			taxon.setName(speciesType.getName());
 			taxon.setCurie(speciesType.getTaxonID());
 			Species species = new Species();
+			species.setFullName(speciesType.getName());
 			species.setAbbreviation(speciesType.getAbbreviation());
 			taxon.setSpecies(species);
 		}


### PR DESCRIPTION
## Summary
- Fix `buildSpeciesOrder` in disease and expression indexers to set non-self species keys to the subject's own phylogenetic order instead of copying each species' individual order
- This gives each species a unique `speciesOrder.<taxonId>` value, preventing interleaving when sorting annotations on gene page tables (e.g., rat annotations appearing in the middle of human annotations)
- Same fix applied to `TestSpeciesOrder` utility class
- Set `species.fullName` on variant search result documents so the species facet has values (SCRUM-5966)

## Context
On gene page disease/expression tables, sorting by `speciesOrder.<focusTaxonId>` should group the focus species first (value 0), then other species in phylogenetic order. The old code copied the full lookup map, so all non-self documents had the same value for a given focus taxon key (e.g., both human and rat docs had `speciesOrder.10090 = 30`), causing them to interleave by disease name.

The variant search category was missing a species facet because `VariantSummaryConverter` never set `fullName` on the `Species` object, so `VariantSearchResultConverter` serialized `species: null` for all ~50M variant documents.

Jira: https://agr-jira.atlassian.net/browse/SCRUM-5933
Jira: https://agr-jira.atlassian.net/browse/SCRUM-5966

## Test plan
- [ ] Reindex disease and expression annotations on stage
- [ ] Verify gene page disease table for MGI:109583 (Pten) — mouse annotations should appear first, then human grouped together, then rat grouped together
- [ ] Verify gene page expression table species grouping
- [ ] Re-run variant indexer on stage
- [ ] Verify variant search category has a working species facet