### PR TITLE
fix: set species fullName on variant search result documents (SCRUM-5966)

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
@@ -117,6 +117,7 @@ public class VariantSummaryConverter {
 			taxon.setName(speciesType.getName());
 			taxon.setCurie(speciesType.getTaxonID());
 			Species species = new Species();
+			species.setFullName(speciesType.getName());
 			species.setAbbreviation(speciesType.getAbbreviation());
 			taxon.setSpecies(species);
 		}


### PR DESCRIPTION
## Summary
- The `VariantSummaryConverter` creates a `Species` object when building variant documents from VCF data, but only sets `abbreviation` -- not `fullName`
- The `VariantSearchResultConverter` calls `getSpecies().getFullName()` to populate the `species` field on `variant_search_result` documents, which returns `null` because `fullName` was never set
- This one-line fix sets `species.setFullName(speciesType.getName())` so variant search result documents get the species name (e.g. "Homo sapiens"), enabling the species facet to work

## Test plan
- [ ] Rebuild the variant index on stage
- [ ] Verify `variant_search_result` documents now have a populated `species` field
- [ ] Verify the species facet shows values at `https://stage.alliancegenome.org/search?category=variant_search_result`