### PR TITLE
Remove Neo4j ID set filtering from curation indexers

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/GeneToGeneOrthologyIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/GeneToGeneOrthologyIndexer.java
@@ -1,6 +1,5 @@
 package org.alliancegenome.indexer.indexers.curation;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +17,6 @@ import org.alliancegenome.es.util.ProcessDisplayHelper;
 import org.alliancegenome.exceptional.client.ExceptionCatcher;
 import org.alliancegenome.indexer.config.IndexerConfig;
 import org.alliancegenome.indexer.indexers.Indexer;
-import org.alliancegenome.indexer.indexers.curation.service.BaseService;
 import org.apache.commons.collections4.CollectionUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,7 +31,6 @@ public class GeneToGeneOrthologyIndexer extends Indexer {
 	private final GeneExpressionAnnotationCrudInterface geneExpressionApi = RestProxyFactory.createProxy(GeneExpressionAnnotationCrudInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
 	private final GeneDiseaseAnnotationCrudInterface geneDiseaseApi = RestProxyFactory.createProxy(GeneDiseaseAnnotationCrudInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
 
-	private Set<String> allNeoGeneIDs;
 	private Set<String> geneExpressionSet;
 	private Set<String> geneAnnotationSet;
 
@@ -45,8 +42,6 @@ public class GeneToGeneOrthologyIndexer extends Indexer {
 
 	@Override
 	public void index(ProcessDisplayHelper display) {
-		BaseService baseService = new BaseService();
-		allNeoGeneIDs = baseService.getAllNeoGeneIDs();
 		geneExpressionSet = new HashSet<>(geneExpressionApi.annotatedGeneList().getEntities());
 		geneAnnotationSet = new HashSet<>(geneDiseaseApi.annotatedGeneList().getEntities());
 
@@ -99,8 +94,7 @@ public class GeneToGeneOrthologyIndexer extends Indexer {
 					}
 				}
 
-				List<GeneToGeneOrthologyDocument> filteredResults = filterValidResults(results);
-				indexDocuments(filteredResults);
+				indexDocuments(results);
 			} catch (Exception e) {
 				log.error("Error while indexing...", e);
 				ExceptionCatcher.report(e);
@@ -115,14 +109,4 @@ public class GeneToGeneOrthologyIndexer extends Indexer {
 		return RestConfig.config.getJacksonObjectMapperFactory().createObjectMapper();
 	}
 
-	private List<GeneToGeneOrthologyDocument> filterValidResults(List<GeneToGeneOrthologyDocument> docs) {
-		List<GeneToGeneOrthologyDocument> result = new ArrayList<>();
-		for (GeneToGeneOrthologyDocument doc : docs) {
-			String curie = doc.getGeneToGeneOrthologyGenerated().getObjectGene().getIdentifier();
-			if (allNeoGeneIDs.contains(curie)) {
-				result.add(doc);
-			}
-		}
-		return result;
-	}
 }

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/SiteMapAccessionCurationIndexer.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/SiteMapAccessionCurationIndexer.java
@@ -12,7 +12,6 @@ import org.alliancegenome.es.util.ProcessDisplayHelper;
 import org.alliancegenome.exceptional.client.ExceptionCatcher;
 import org.alliancegenome.indexer.config.IndexerConfig;
 import org.alliancegenome.indexer.indexers.Indexer;
-import org.alliancegenome.indexer.indexers.curation.service.BaseService;
 import org.alliancegenome.indexer.indexers.document.SiteMapIdDocument;
 
 import si.mazi.rescu.RestProxyFactory;
@@ -33,10 +32,6 @@ public class SiteMapAccessionCurationIndexer extends Indexer {
 
 			Map<String, List<String>> map = document.getIdsByType();
 
-			BaseService base = new BaseService();
-
-			map.get("allele").retainAll(base.getAllNeoAlleleIDs());
-
 			List<List<String>> alleleIdLists = partition(map.get("allele"), 15000);
 
 			for (int i = 0; i < alleleIdLists.size(); i++) {
@@ -48,8 +43,6 @@ public class SiteMapAccessionCurationIndexer extends Indexer {
 				doc.setSiteMapIds(alleleIdLists.get(i));
 				indexDocument(doc);
 			}
-
-			map.get("gene").retainAll(base.getAllNeoGeneIDs());
 
 			List<List<String>> geneIdLists = partition(map.get("gene"), 15000);
 

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/AGMPhenotypeAnnotationService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/AGMPhenotypeAnnotationService.java
@@ -109,9 +109,7 @@ public class AGMPhenotypeAnnotationService extends BaseDiseaseAnnotationService 
 
 					SearchResponse<AGMPhenotypeAnnotation> response = agmApi.findForPublic(page, bufferSize, params);
 					for (AGMPhenotypeAnnotation pa : response.getResults()) {
-						if (isValidNeoEntity(getAllNeoModelIDs(), pa.getPhenotypeAnnotationSubject().getIdentifier())) {
-							fullList.offer(pa);
-						}
+						fullList.offer(pa);
 						display.progressProcess();
 					}
 

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/AllelePhenotypeAnnotationService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/AllelePhenotypeAnnotationService.java
@@ -107,9 +107,7 @@ public class AllelePhenotypeAnnotationService extends BaseDiseaseAnnotationServi
 
 					SearchResponse<AllelePhenotypeAnnotation> response = alleleApi.findForPublic(page, bufferSize, params);
 					for (AllelePhenotypeAnnotation pa : response.getResults()) {
-						if (isValidNeoEntity(getAllNeoAlleleIDs(), pa.getPhenotypeAnnotationSubject().getIdentifier())) {
-							fullList.offer(pa);
-						}
+						fullList.offer(pa);
 						display.progressProcess();
 					}
 

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/BaseInteractionService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/BaseInteractionService.java
@@ -38,20 +38,6 @@ public class BaseInteractionService extends BaseService {
 		return hasNoExcludedEntities(entitiesToBeValidated);
 	}
 
-	protected <E extends GeneInteraction> boolean hasInteractingGenesInNeo(E interaction) {
-		if (interaction.getGeneAssociationSubject() != null) {
-			if (!isValidNeoEntity(getAllNeoGeneIDs(), interaction.getGeneAssociationSubject().getIdentifier())) {
-				return false;
-			}
-		}
-		if (interaction.getGeneGeneAssociationObject() != null) {
-			if (!isValidNeoEntity(getAllNeoGeneIDs(), interaction.getGeneGeneAssociationObject().getIdentifier())) {
-				return false;
-			}
-		}
-		return true;
-	}
-
 	protected <E extends GeneInteraction> E reverseInteraction(E forwardInteraction, E reverseInteraction) {
 		if (forwardInteraction.getGeneAssociationSubject() == null || forwardInteraction.getGeneGeneAssociationObject() == null) {
 			return null;

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/BaseService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/BaseService.java
@@ -1,97 +1,16 @@
 package org.alliancegenome.indexer.indexers.curation.service;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.alliancegenome.curation_api.model.entities.base.AuditedObject;
-import org.alliancegenome.neo4j.repository.AlleleRepository;
-import org.alliancegenome.neo4j.repository.GeneRepository;
-import org.alliancegenome.neo4j.repository.VariantRepository;
-import org.apache.commons.collections4.CollectionUtils;
 
 import lombok.extern.log4j.Log4j2;
 import net.nilosplace.process_display.util.ObjectFileStorage;
 
 @Log4j2
 public class BaseService {
-
-	private static HashSet<String> allNeoAlleleIDs;
-	private static HashSet<String> allNeoGeneIDs;
-	private static HashSet<String> allNeoModelIDs;
-	private static HashSet<String> allNeoVariantIDs;
-
-	public HashSet<String> getAllNeoAlleleIDs() {
-		if (allNeoAlleleIDs == null) {
-			String alleleIdsFileName = "allele_ids.gz";
-			List<String> alleleList = readFromCache(alleleIdsFileName, List.class);
-
-			if (CollectionUtils.isNotEmpty(alleleList)) {
-				allNeoAlleleIDs = new HashSet<>(alleleList);
-			} else {
-				AlleleRepository alleleRepository = new AlleleRepository();
-				allNeoAlleleIDs = new HashSet<>(alleleRepository.getAllAlleleIDs());
-				alleleRepository.close();
-				writeToCache(alleleIdsFileName, new ArrayList<>(allNeoAlleleIDs));
-			}
-		}
-		return allNeoAlleleIDs;
-	}
-
-	public HashSet<String> getAllNeoGeneIDs() {
-
-		if (allNeoGeneIDs == null) {
-			String geneIdsFileName = "gene_ids.gz";
-			List<String> geneList = readFromCache(geneIdsFileName, List.class);
-
-			if (CollectionUtils.isNotEmpty(geneList)) {
-				allNeoGeneIDs = new HashSet<>(geneList);
-			} else {
-				GeneRepository geneRepository = new GeneRepository();
-				allNeoGeneIDs = new HashSet<>(geneRepository.getAllGeneKeys());
-				geneRepository.close();
-				writeToCache(geneIdsFileName, new ArrayList<>(allNeoGeneIDs));
-			}
-		}
-
-		return allNeoGeneIDs;
-	}
-
-	public HashSet<String> getAllNeoModelIDs() {
-		if (allNeoModelIDs == null) {
-			String modelIdsFileName = "model_ids.gz";
-			List<String> modelList = readFromCache(modelIdsFileName, List.class);
-
-			if (CollectionUtils.isNotEmpty(modelList)) {
-				allNeoModelIDs = new HashSet<>(modelList);
-			} else {
-				AlleleRepository alleleRepository = new AlleleRepository();
-				allNeoModelIDs = new HashSet<>(alleleRepository.getAllModelKeys());
-				alleleRepository.close();
-				writeToCache(modelIdsFileName, new ArrayList<>(allNeoModelIDs));
-			}
-		}
-		return allNeoModelIDs;
-	}
-
-	public HashSet<String> getAllNeoVariantIDs() {
-		if (allNeoVariantIDs == null) {
-			String variantIdsFileName = "variant_ids.gz";
-			List<String> variantList = readFromCache(variantIdsFileName, List.class);
-
-			if (CollectionUtils.isNotEmpty(variantList)) {
-				allNeoVariantIDs = new HashSet<>(variantList);
-			} else {
-				VariantRepository variantRepository = new VariantRepository();
-				allNeoVariantIDs = new HashSet<>(variantRepository.getAllVariantKeys());
-				variantRepository.close();
-				writeToCache(variantIdsFileName, new ArrayList<>(allNeoVariantIDs));
-			}
-		}
-		return allNeoVariantIDs;
-	}
 
 	protected <E> E readFromCache(String fileName, Class<E> clazz) {
 		try {
@@ -126,10 +45,6 @@ public class BaseService {
 			}
 		}
 		return hasNoExcludedEntities.get();
-	}
-
-	protected static boolean isValidNeoEntity(HashSet<String> neoEntityIds, String curie) {
-		return neoEntityIds.contains(curie);
 	}
 
 }

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/GeneGeneticInteractionService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/GeneGeneticInteractionService.java
@@ -13,38 +13,20 @@ public class GeneGeneticInteractionService extends BaseInteractionService {
 		List<GeneGeneticInteraction> validInteractions = new ArrayList<>();
 		
 		for (GeneGeneticInteraction interaction: forwardInteractions) {
-			if (hasPerturbatingAllelesInNeo(interaction)) {
-				if (hasInteractingGenesInNeo(interaction)) {
-					if (hasNoObsoletedOrInternalEntities(interaction)) {
-						validInteractions.add(interaction);
-						try {
-							GeneGeneticInteraction reverseInteraction = generateReverseInteraction(interaction);
-							if (reverseInteraction != null) {
-								validInteractions.add(reverseInteraction);
-							}
-						} catch (IOException e) {
-							e.printStackTrace();
-						}
+			if (hasNoObsoletedOrInternalEntities(interaction)) {
+				validInteractions.add(interaction);
+				try {
+					GeneGeneticInteraction reverseInteraction = generateReverseInteraction(interaction);
+					if (reverseInteraction != null) {
+						validInteractions.add(reverseInteraction);
 					}
+				} catch (IOException e) {
+					e.printStackTrace();
 				}
 			}
 		}
 
 		return validInteractions;
-	}
-
-	private boolean hasPerturbatingAllelesInNeo(GeneGeneticInteraction interaction) {
-		if (interaction.getInteractorAGeneticPerturbation() != null) {
-			if (!isValidNeoEntity(getAllNeoAlleleIDs(), interaction.getInteractorAGeneticPerturbation().getIdentifier())) {
-				return false;
-			}
-		}
-		if (interaction.getInteractorBGeneticPerturbation() != null) {
-			if (!isValidNeoEntity(getAllNeoAlleleIDs(), interaction.getInteractorBGeneticPerturbation().getIdentifier())) {
-				return false;
-			}
-		}
-		return true;
 	}
 
 	private GeneGeneticInteraction generateReverseInteraction(GeneGeneticInteraction forwardInteraction) throws IOException {

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/GeneMolecularInteractionService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/GeneMolecularInteractionService.java
@@ -13,17 +13,15 @@ public class GeneMolecularInteractionService extends BaseInteractionService {
 		List<GeneMolecularInteraction> validInteractions = new ArrayList<>();
 		
 		for (GeneMolecularInteraction interaction: forwardInteractions) {
-			if (hasInteractingGenesInNeo(interaction)) {
-				if (hasNoObsoletedOrInternalEntities(interaction)) {
-					validInteractions.add(interaction);
-					try {
-						GeneMolecularInteraction reverseInteraction = generateReverseInteraction(interaction);
-						if (reverseInteraction != null) {
-							validInteractions.add(reverseInteraction);
-						}
-					} catch (IOException e) {
-						e.printStackTrace();
+			if (hasNoObsoletedOrInternalEntities(interaction)) {
+				validInteractions.add(interaction);
+				try {
+					GeneMolecularInteraction reverseInteraction = generateReverseInteraction(interaction);
+					if (reverseInteraction != null) {
+						validInteractions.add(reverseInteraction);
 					}
+				} catch (IOException e) {
+					e.printStackTrace();
 				}
 			}
 		}

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/GenePhenotypeAnnotationService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/indexers/curation/service/GenePhenotypeAnnotationService.java
@@ -108,9 +108,7 @@ public class GenePhenotypeAnnotationService extends BaseDiseaseAnnotationService
 
 					SearchResponse<GenePhenotypeAnnotation> response = geneApi.findForPublic(page, bufferSize, "PhenotypeAnnotationView", params);
 					for (GenePhenotypeAnnotation pa : response.getResults()) {
-						if (isValidNeoEntity(getAllNeoGeneIDs(), pa.getPhenotypeAnnotationSubject().getIdentifier())) {
-							fullList.offer(pa);
-						}
+						fullList.offer(pa);
 						display.progressProcess();
 					}
 


### PR DESCRIPTION
## Summary
- Remove legacy Neo4j ID cross-reference filtering from all curation-sourced indexers
- The curation API is now the authoritative data source; the Neo4j ID intersection was filtering out valid curation entities that hadn't been loaded into Neo4j
- Existing obsolete/internal entity checks remain as the data quality filter
- `BaseService` no longer has any Neo4j dependencies (removed `AlleleRepository`, `GeneRepository`, `VariantRepository` usage)

### Indexers updated
- `GeneToGeneOrthologyIndexer` — removed objectGene Neo4j filter
- `GeneMolecularInteractionService` — removed interacting genes Neo4j filter
- `GeneGeneticInteractionService` — removed genes + perturbating alleles Neo4j filter
- `GenePhenotypeAnnotationService` — removed subject gene Neo4j filter
- `AllelePhenotypeAnnotationService` — removed subject allele Neo4j filter
- `AGMPhenotypeAnnotationService` — removed subject AGM Neo4j filter
- `SiteMapAccessionCurationIndexer` — removed `retainAll()` intersection with Neo4j gene/allele ID sets

## Test plan
- [ ] Deploy to stage and run a full indexer pass
- [ ] Verify indexed document counts are >= previous counts (more entities expected since Neo4j filter no longer drops valid curation entities)
- [ ] Spot-check orthology, interaction, phenotype, and sitemap results in the stage UI