### PR TITLE
SCRUM-5967 Replace Neo4j gene cache with curation API

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSummaryConverter.java
@@ -28,7 +28,6 @@ import org.alliancegenome.curation_api.model.entities.associations.TranscriptGen
 import org.alliancegenome.curation_api.model.entities.ontology.NCBITaxonTerm;
 import org.alliancegenome.curation_api.model.entities.ontology.SOTerm;
 import org.alliancegenome.curation_api.model.entities.slotAnnotations.GeneSymbolSlotAnnotation;
-import org.alliancegenome.es.index.site.cache.GeneDocumentCache;
 import org.alliancegenome.neo4j.entity.SpeciesType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -45,7 +44,7 @@ public class VariantSummaryConverter {
 
 	// Header index positions (initialized once per header)
 	private String[] header;
-	private GeneDocumentCache geneCache;
+	private Map<String, Gene> geneCache;
 	private Map<String, Integer> severityRanking;
 	private Map<String, SOTerm> soTermCache = new ConcurrentHashMap<>();
 	private Map<String, VocabularyTerm> vocabularyTermCache = new ConcurrentHashMap<>();
@@ -73,7 +72,7 @@ public class VariantSummaryConverter {
 	private int proteinPosIdx = -1;
 	private int hgvsgIdx = -1;
 
-	public VariantSummaryConverter(String[] header, GeneDocumentCache geneCache, Map<String, Integer> severityRanking) {
+	public VariantSummaryConverter(String[] header, Map<String, Gene> geneCache, Map<String, Integer> severityRanking) {
 		this.header = header;
 		this.geneCache = geneCache;
 		this.severityRanking = severityRanking;
@@ -387,20 +386,17 @@ public class VariantSummaryConverter {
 						geneSymbol.setDisplayText(infos[geneSymbolIdx]);
 						gene.setGeneSymbol(geneSymbol);
 						if (geneCache != null) {
-							// Set genome location from cache
-							org.alliancegenome.neo4j.entity.node.Gene cachedGene = geneCache.getGeneMap().get(gene.getCurie());
-							if (cachedGene != null && cachedGene.getGenomeLocations() != null && !cachedGene.getGenomeLocations().isEmpty()) {
-								List<GeneGenomicLocationAssociation> geneLocations = new ArrayList<>();
-								for (org.alliancegenome.neo4j.entity.relationship.GenomeLocation loc : cachedGene.getGenomeLocations()) {
-									GeneGenomicLocationAssociation geneLocation = new GeneGenomicLocationAssociation();
-									geneLocation.setStart(loc.getStart() != null ? loc.getStart().intValue() : null);
-									geneLocation.setEnd(loc.getEnd() != null ? loc.getEnd().intValue() : null);
-									AssemblyComponent geneChromosome = new AssemblyComponent();
-									geneChromosome.setName(loc.getChromosome());
-									geneLocation.setGeneGenomicLocationAssociationObject(geneChromosome);
-									geneLocations.add(geneLocation);
+							Gene cachedGene = geneCache.get(gene.getCurie());
+							if (cachedGene != null) {
+								if (cachedGene.getGeneGenomicLocationAssociations() != null) {
+									gene.setGeneGenomicLocationAssociations(cachedGene.getGeneGenomicLocationAssociations());
 								}
-								gene.setGeneGenomicLocationAssociations(geneLocations);
+								if (cachedGene.getGeneSynonyms() != null) {
+									gene.setGeneSynonyms(cachedGene.getGeneSynonyms());
+								}
+								if (cachedGene.getCrossReferences() != null) {
+									gene.setCrossReferences(cachedGene.getCrossReferences());
+								}
 							}
 						}
 					}

--- a/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/GeneCacheService.java
+++ b/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/GeneCacheService.java
@@ -1,0 +1,84 @@
+package org.alliancegenome.indexer.variant.es.managers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import org.alliancegenome.core.config.ConfigHelper;
+import org.alliancegenome.curation_api.interfaces.document.GeneDocumentInterface;
+import org.alliancegenome.curation_api.model.document.es.GeneSummaryDocument;
+import org.alliancegenome.curation_api.model.entities.Gene;
+import org.alliancegenome.curation_api.response.SearchResponse;
+import org.alliancegenome.es.rest.RestConfig;
+import org.alliancegenome.es.util.ProcessDisplayHelper;
+
+import lombok.extern.slf4j.Slf4j;
+import si.mazi.rescu.RestProxyFactory;
+
+@Slf4j
+public class GeneCacheService {
+
+	private static final int BATCH_SIZE = 1000;
+	private static final int THREAD_COUNT = 8;
+
+	public Map<String, Gene> loadGeneCache() {
+		log.info("Fetching gene IDs from curation API...");
+		GeneDocumentInterface geneApi = RestProxyFactory.createProxy(GeneDocumentInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
+		SearchResponse<Long> idsResponse = geneApi.getAllIds();
+		List<Long> allIds = idsResponse.getResults();
+		log.info("Fetched {} gene IDs", allIds.size());
+
+		List<List<Long>> batches = new ArrayList<>();
+		for (int i = 0; i < allIds.size(); i += BATCH_SIZE) {
+			batches.add(new ArrayList<>(allIds.subList(i, Math.min(i + BATCH_SIZE, allIds.size()))));
+		}
+
+		LinkedBlockingDeque<List<Long>> queue = new LinkedBlockingDeque<>(batches);
+		Map<String, Gene> geneCacheMap = new ConcurrentHashMap<>();
+
+		ProcessDisplayHelper ph = new ProcessDisplayHelper();
+		ph.startProcess("Loading Gene Cache", allIds.size());
+
+		log.info("Loading gene cache: {} batches of {} across {} threads", batches.size(), BATCH_SIZE, THREAD_COUNT);
+		List<Thread> threads = new ArrayList<>();
+		for (int t = 0; t < THREAD_COUNT; t++) {
+			Thread thread = new Thread(() -> {
+				GeneDocumentInterface threadApi = RestProxyFactory.createProxy(GeneDocumentInterface.class, ConfigHelper.getCurationApiUrl(), RestConfig.config);
+				while (true) {
+					List<Long> batch = queue.poll();
+					if (batch == null) {
+						return;
+					}
+					SearchResponse<GeneSummaryDocument> response = threadApi.findCacheByIds(batch);
+					if (response != null && response.getResults() != null) {
+						for (GeneSummaryDocument doc : response.getResults()) {
+							Gene gene = doc.getGene();
+							if (gene != null && gene.getPrimaryExternalId() != null) {
+								geneCacheMap.put(gene.getPrimaryExternalId(), gene);
+							}
+							ph.progressProcess();
+						}
+					}
+				}
+			});
+			thread.start();
+			threads.add(thread);
+		}
+
+		for (Thread thread : threads) {
+			try {
+				thread.join();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		ph.finishProcess();
+		log.info("Gene cache loaded: {} genes", geneCacheMap.size());
+
+		return geneCacheMap;
+	}
+
+}

--- a/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreation.java
+++ b/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreation.java
@@ -17,7 +17,7 @@ import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.curation_api.model.document.es.SequenceSummaryDocument;
 import org.alliancegenome.curation_api.model.document.es.VariantSummaryDocument;
 import org.alliancegenome.curation_api.view.CurationView;
-import org.alliancegenome.es.index.site.cache.GeneDocumentCache;
+import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.es.model.VariantSearchResultDocument;
 import org.alliancegenome.es.rest.RestConfig;
 import org.alliancegenome.es.util.ProcessDisplayHelper;
@@ -37,7 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SourceDocumentCreation extends Thread {
 
-	private final GeneDocumentCache geneCache;
+	private final Map<String, Gene> geneCache;
 	private final HashSet<String> variantsCache;
 	private final Map<String, Integer> severityRanking;
 	private String downloadPath;
@@ -61,7 +61,7 @@ public class SourceDocumentCreation extends Thread {
 
 	private String messageHeader = "";
 
-	public SourceDocumentCreation(String downloadPath, DownloadSource source, GeneDocumentCache geneCache, HashSet<String> variantsCache, Map<String, Integer> severityRanking, LinkedBlockingDeque<List<byte[]>> jsonQueue) {
+	public SourceDocumentCreation(String downloadPath, DownloadSource source, Map<String, Gene> geneCache, HashSet<String> variantsCache, Map<String, Integer> severityRanking, LinkedBlockingDeque<List<byte[]>> jsonQueue) {
 		this.downloadPath = downloadPath;
 		this.source = source;
 		this.geneCache = geneCache;

--- a/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreationManager.java
+++ b/agr_variant_indexer/src/main/java/org/alliancegenome/indexer/variant/es/managers/SourceDocumentCreationManager.java
@@ -13,12 +13,11 @@ import org.alliancegenome.core.filedownload.model.DownloadSource;
 import org.alliancegenome.core.variant.config.VariantConfigHelper;
 import org.alliancegenome.curation_api.interfaces.crud.ontology.SoTermCrudInterface;
 import org.alliancegenome.curation_api.interfaces.document.VariantDocumentInterface;
-import org.alliancegenome.es.index.site.cache.GeneDocumentCache;
+import org.alliancegenome.curation_api.model.entities.Gene;
 import org.alliancegenome.es.rest.RestConfig;
 import org.alliancegenome.es.util.ElasticSearchInterface;
 import org.alliancegenome.es.util.ProcessDisplayHelper;
 import org.alliancegenome.exceptional.client.ExceptionCatcher;
-import org.alliancegenome.neo4j.repository.indexer.GeneIndexerRepository;
 
 import lombok.extern.slf4j.Slf4j;
 import net.nilosplace.process_display.util.ObjectFileStorage;
@@ -41,9 +40,8 @@ public class SourceDocumentCreationManager extends Thread {
 
 		try {
 
-			GeneIndexerRepository geneRepo = new GeneIndexerRepository();
-			GeneDocumentCache geneCache = geneRepo.getGeneCacheCrossReferencesSynonyms();
-			geneRepo.close();
+			GeneCacheService geneCacheService = new GeneCacheService();
+			Map<String, Gene> geneCacheMap = geneCacheService.loadGeneCache();
 
 			ObjectFileStorage<HashSet<String>> variantsCacheFileStorage = new ObjectFileStorage<>();
 
@@ -90,7 +88,7 @@ public class SourceDocumentCreationManager extends Thread {
 			List<SourceDocumentCreation> creators = new ArrayList<>();
 			for (DownloadSource source : downloadSet.getDownloadFileSources()) {
 				if (source.getActive()) {
-					SourceDocumentCreation creator = new SourceDocumentCreation(downloadSet.getDownloadPath(), source, geneCache, variantsCache, severityRanking, jsonQueue);
+					SourceDocumentCreation creator = new SourceDocumentCreation(downloadSet.getDownloadPath(), source, geneCacheMap, variantsCache, severityRanking, jsonQueue);
 					creator.start();
 					creators.add(creator);
 				}

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.47.40</curation.version>
+		<curation.version>v0.48.1</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary
- Extract gene cache loading into `GeneCacheService` with multi-threaded batched fetching from curation API (`findCacheByIds` endpoint, 8 threads, batches of 1000)
- Replace `GeneDocumentCache` / `GeneIndexerRepository` (Neo4j) with `Map<String, Gene>` backed by curation API data
- `VariantSummaryConverter` now copies genomic locations, synonyms, and cross-references directly from cached curation Gene entities — no more Neo4j type conversion

## Dependencies
- Requires agr_curation v0.48.1 (alliance-genome/agr_curation#2671) for `findCacheByIds` endpoint and `GeneCacheDocument` view

## Test plan
- [ ] Verify gene cache loads from curation API at variant indexer startup
- [ ] Run SGD species indexing and verify variant documents contain gene genomic locations
- [ ] Confirm no Neo4j connection attempted for gene data