### PR TITLE
SCRUM-5980 Variant search: add gene cross-refs, secondary IDs, List to Set cleanup

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/AlleleSearchResultConverter.java
@@ -57,10 +57,10 @@ public class AlleleSearchResultConverter {
 			}
 
 			if (CollectionUtils.isNotEmpty(allele.getAlleleSynonyms())) {
-				List<String> synonyms = allele.getAlleleSynonyms().stream()
+				Set<String> synonyms = allele.getAlleleSynonyms().stream()
 					.map(NameSlotAnnotation::getDisplayText)
 					.filter(Objects::nonNull)
-					.collect(Collectors.toList());
+					.collect(Collectors.toSet());
 				if (!synonyms.isEmpty()) {
 					searchDoc.setSynonyms(synonyms);
 				}
@@ -76,7 +76,7 @@ public class AlleleSearchResultConverter {
 						geneSymbol = geneSymbol + " (" + taxon.getName() + ")";
 					}
 				}
-				searchDoc.setGenes(List.of(geneSymbol));
+				searchDoc.setGenes(Set.of(geneSymbol));
 			}
 
 			if (doc.getGeneSynonyms() != null && !doc.getGeneSynonyms().isEmpty()) {
@@ -104,17 +104,17 @@ public class AlleleSearchResultConverter {
 			}
 
 			if (doc.getDiseases() != null && !doc.getDiseases().isEmpty()) {
-				searchDoc.setDiseases(new ArrayList<>(doc.getDiseases()));
+				searchDoc.setDiseases(new HashSet<>(doc.getDiseases()));
 			}
 			if (doc.getDiseasesAgrSlim() != null && !doc.getDiseasesAgrSlim().isEmpty()) {
-				searchDoc.setDiseasesAgrSlim(new ArrayList<>(doc.getDiseasesAgrSlim()));
+				searchDoc.setDiseasesAgrSlim(new HashSet<>(doc.getDiseasesAgrSlim()));
 			}
 			if (doc.getDiseasesWithParents() != null && !doc.getDiseasesWithParents().isEmpty()) {
-				searchDoc.setDiseasesWithParents(new ArrayList<>(doc.getDiseasesWithParents()));
+				searchDoc.setDiseasesWithParents(new HashSet<>(doc.getDiseasesWithParents()));
 			}
 
 			if (doc.getPhenotypeStatements() != null && !doc.getPhenotypeStatements().isEmpty()) {
-				searchDoc.setPhenotypeStatements(new ArrayList<>(doc.getPhenotypeStatements()));
+				searchDoc.setPhenotypeStatements(new HashSet<>(doc.getPhenotypeStatements()));
 			}
 
 			if (doc.getConstructs() != null && !doc.getConstructs().isEmpty()) {
@@ -134,11 +134,11 @@ public class AlleleSearchResultConverter {
 			}
 
 			if (CollectionUtils.isNotEmpty(doc.getVariantList())) {
-				List<String> variantTypes = doc.getVariantList().stream()
+				Set<String> variantTypes = doc.getVariantList().stream()
 					.filter(v -> v.getVariantType() != null && v.getVariantType().getName() != null)
 					.map(v -> v.getVariantType().getName())
 					.distinct()
-					.toList();
+					.collect(Collectors.toSet());
 				if (!variantTypes.isEmpty()) {
 					searchDoc.setVariantType(variantTypes);
 				}

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
@@ -4,12 +4,14 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.alliancegenome.curation_api.model.document.es.VariantSummaryDocument;
 import org.alliancegenome.curation_api.model.entities.PredictedVariantConsequence;
 import org.alliancegenome.curation_api.model.entities.associations.CuratedVariantGenomicLocationAssociation;
 import org.alliancegenome.curation_api.model.entities.associations.TranscriptGeneAssociation;
+import org.alliancegenome.curation_api.model.entities.slotAnnotations.NameSlotAnnotation;
 import org.alliancegenome.es.model.VariantSearchResultDocument;
 
 public class VariantSearchResultConverter {
@@ -68,10 +70,24 @@ public class VariantSearchResultConverter {
 				if (!geneNames.isEmpty()) {
 					vsd.setGenes(geneNames);
 				}
+
+				Set<String> geneSynonyms = variantLocation.getPredictedVariantConsequences().stream()
+					.filter(pvc -> pvc.getVariantTranscript() != null && pvc.getVariantTranscript().getTranscriptGeneAssociations() != null)
+					.flatMap(pvc -> pvc.getVariantTranscript().getTranscriptGeneAssociations().stream())
+					.map(TranscriptGeneAssociation::getTranscriptGeneAssociationObject)
+					.filter(Objects::nonNull)
+					.filter(gene -> gene.getGeneSynonyms() != null)
+					.flatMap(gene -> gene.getGeneSynonyms().stream())
+					.map(NameSlotAnnotation::getFormatText)
+					.filter(Objects::nonNull)
+					.collect(Collectors.toSet());
+				if (!geneSynonyms.isEmpty()) {
+					vsd.setGeneSynonyms(geneSynonyms);
+				}
 			}
 
 			if (variantLocation.getVariantAssociationSubject() != null && variantLocation.getVariantAssociationSubject().getCrossReferences() != null) {
-				List<String> crossRefs = new ArrayList<>();
+				Set<String> crossRefs = new HashSet<>();
 				for (var xref : variantLocation.getVariantAssociationSubject().getCrossReferences()) {
 					crossRefs.add(xref.getDisplayName());
 				}
@@ -81,7 +97,7 @@ public class VariantSearchResultConverter {
 			}
 
 			if (variantLocation.getPredictedVariantConsequences() != null) {
-				HashSet<String> consequences = new HashSet<>();
+				Set<String> consequences = new HashSet<>();
 				for (PredictedVariantConsequence pvc : variantLocation.getPredictedVariantConsequences()) {
 					if (pvc.getVepConsequences() != null) {
 						for (var soTerm : pvc.getVepConsequences()) {
@@ -90,7 +106,7 @@ public class VariantSearchResultConverter {
 					}
 				}
 				if (!consequences.isEmpty()) {
-					vsd.setMolecularConsequence(new ArrayList<>(consequences));
+					vsd.setMolecularConsequence(consequences);
 				}
 			}
 

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
@@ -37,14 +37,14 @@ public class VariantSearchResultConverter {
 					vsd.setSpecies(variantLocation.getVariantAssociationSubject().getTaxon().getSpecies().getFullName());
 				}
 				if (variantLocation.getVariantAssociationSubject().getVariantType() != null && variantLocation.getVariantAssociationSubject().getVariantType().getName() != null) {
-					vsd.setVariantType(List.of(variantLocation.getVariantAssociationSubject().getVariantType().getName()));
+					vsd.setVariantType(Set.of(variantLocation.getVariantAssociationSubject().getVariantType().getName()));
 				}
 			}
 
 			vsd.setPopularity(0.0);
 
 			if (variantLocation.getPredictedVariantConsequences() != null) {
-				List<String> geneNames = variantLocation.getPredictedVariantConsequences().stream()
+				Set<String> geneNames = variantLocation.getPredictedVariantConsequences().stream()
 					.filter(pvc -> pvc.getVariantTranscript() != null && pvc.getVariantTranscript().getTranscriptGeneAssociations() != null)
 					.flatMap(pvc -> pvc.getVariantTranscript().getTranscriptGeneAssociations().stream())
 					.map(TranscriptGeneAssociation::getTranscriptGeneAssociationObject)
@@ -65,8 +65,7 @@ public class VariantSearchResultConverter {
 					})
 					.filter(Objects::nonNull)
 					.distinct()
-					.sorted()
-					.collect(Collectors.toList());
+					.collect(Collectors.toSet());
 				if (!geneNames.isEmpty()) {
 					vsd.setGenes(geneNames);
 				}

--- a/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/variant/converters/VariantSearchResultConverter.java
@@ -83,6 +83,34 @@ public class VariantSearchResultConverter {
 				if (!geneSynonyms.isEmpty()) {
 					vsd.setGeneSynonyms(geneSynonyms);
 				}
+
+				Set<String> geneCrossRefs = variantLocation.getPredictedVariantConsequences().stream()
+					.filter(pvc -> pvc.getVariantTranscript() != null && pvc.getVariantTranscript().getTranscriptGeneAssociations() != null)
+					.flatMap(pvc -> pvc.getVariantTranscript().getTranscriptGeneAssociations().stream())
+					.map(TranscriptGeneAssociation::getTranscriptGeneAssociationObject)
+					.filter(Objects::nonNull)
+					.filter(gene -> gene.getCrossReferences() != null)
+					.flatMap(gene -> gene.getCrossReferences().stream())
+					.map(xref -> xref.getReferencedCurie())
+					.filter(Objects::nonNull)
+					.collect(Collectors.toSet());
+				if (!geneCrossRefs.isEmpty()) {
+					vsd.setGeneCrossReferences(geneCrossRefs);
+				}
+
+				Set<String> secondaryIds = variantLocation.getPredictedVariantConsequences().stream()
+					.filter(pvc -> pvc.getVariantTranscript() != null && pvc.getVariantTranscript().getTranscriptGeneAssociations() != null)
+					.flatMap(pvc -> pvc.getVariantTranscript().getTranscriptGeneAssociations().stream())
+					.map(TranscriptGeneAssociation::getTranscriptGeneAssociationObject)
+					.filter(Objects::nonNull)
+					.filter(gene -> gene.getGeneSecondaryIds() != null)
+					.flatMap(gene -> gene.getGeneSecondaryIds().stream())
+					.map(sid -> sid.getSecondaryId())
+					.filter(Objects::nonNull)
+					.collect(Collectors.toSet());
+				if (!secondaryIds.isEmpty()) {
+					vsd.setSecondaryIds(secondaryIds);
+				}
 			}
 
 			if (variantLocation.getVariantAssociationSubject() != null && variantLocation.getVariantAssociationSubject().getCrossReferences() != null) {

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/AlleleSearchResultDocument.java
@@ -25,7 +25,11 @@ public class AlleleSearchResultDocument extends ESDocument {
 	private String species;
 	private Double popularity;
 	private String alterationType;
-	private List<String> variantType;
+	private String globalId;
+	private String localId;
+	private String modCrossRefCompleteUrl;
+	
+	private Set<String> variantType;
 	private Set<String> molecularConsequence;
 	private Set<String> variants;
 	private Set<String> constructs;
@@ -33,16 +37,13 @@ public class AlleleSearchResultDocument extends ESDocument {
 	private Set<String> constructRegulatoryRegion;
 	private Set<String> constructKnockdownComponent;
 	private Set<String> crossReferences;
-	private List<String> synonyms;
+	private Set<String> synonyms;
 	private Set<String> geneSynonyms;
-	private List<String> secondaryIds;
-	private List<String> genes;
-	private List<String> diseases;
-	private List<String> diseasesAgrSlim;
-	private List<String> diseasesWithParents;
-	private List<String> phenotypeStatements;
-	private String globalId;
-	private String localId;
-	private String modCrossRefCompleteUrl;
+	private Set<String> secondaryIds;
+	private Set<String> genes;
+	private Set<String> diseases;
+	private Set<String> diseasesAgrSlim;
+	private Set<String> diseasesWithParents;
+	private Set<String> phenotypeStatements;
 
 }

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/VariantSearchResultDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/VariantSearchResultDocument.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.es.model;
 
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonView;
 
@@ -27,9 +28,10 @@ public class VariantSearchResultDocument extends ESDocument {
 	private Double popularity;
 	private List<String> alleles;
 	private List<String> genes;
+	private Set<String> geneSynonyms;
 	private String alterationType;
 	private List<String> variantType;
-	private List<String> molecularConsequence;
-	private List<String> crossReferences;
+	private Set<String> molecularConsequence;
+	private Set<String> crossReferences;
 
 }

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/VariantSearchResultDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/VariantSearchResultDocument.java
@@ -26,11 +26,12 @@ public class VariantSearchResultDocument extends ESDocument {
 	private String primaryKey;
 	private String species;
 	private Double popularity;
-	private List<String> alleles;
-	private List<String> genes;
-	private Set<String> geneSynonyms;
 	private String alterationType;
-	private List<String> variantType;
+	
+	private Set<String> alleles;
+	private Set<String> genes;
+	private Set<String> geneSynonyms;
+	private Set<String> variantType;
 	private Set<String> molecularConsequence;
 	private Set<String> crossReferences;
 

--- a/agr_java_core/src/main/java/org/alliancegenome/es/model/VariantSearchResultDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/es/model/VariantSearchResultDocument.java
@@ -31,6 +31,8 @@ public class VariantSearchResultDocument extends ESDocument {
 	private Set<String> alleles;
 	private Set<String> genes;
 	private Set<String> geneSynonyms;
+	private Set<String> geneCrossReferences;
+	private Set<String> secondaryIds;
 	private Set<String> variantType;
 	private Set<String> molecularConsequence;
 	private Set<String> crossReferences;


### PR DESCRIPTION
## Summary
- Convert search result document fields from `List<String>` to `Set<String>` for deduplication (AlleleSearchResultDocument, VariantSearchResultDocument, and their converters)
- Add `geneCrossReferences` and `secondaryIds` fields to `VariantSearchResultDocument`
- Extract gene cross-references (`referencedCurie`) and secondary IDs from variant transcript gene associations for search support
- Add `globalId`, `localId`, `modCrossRefCompleteUrl` to `AlleleSearchResultDocument`

## Test plan
- [ ] Run indexer on stage, verify variant search results include gene cross-references and secondary IDs
- [ ] Search for a gene cross-reference (e.g., "NCBI_Gene:7157") and confirm HTP Variant results appear
- [ ] Search for a gene synonym and confirm HTP Variant results appear
- [ ] Verify no duplicate values in search facet fields