### PR TITLE
SCRUM-5987 raise filter dropdown cap above ES default of 10

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/ESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ESService.java
@@ -195,6 +195,7 @@ public class ESService {
 			TermsAggregationBuilder aggregationBuilder = AggregationBuilders.terms(fieldNameAgg);
 			aggregationBuilder.bucketCardinality();
 			aggregationBuilder.field(field);
+			aggregationBuilder.size(40);
 			aggBuilders.add(aggregationBuilder);
 		});
 


### PR DESCRIPTION
## Summary
- The Molecular Consequence filter dropdown on the gene page Alleles and Variants table was missing many real values (e.g. `stop_lost`, `start_lost`, `splice_donor_variant`).
- Root cause: `ESService.getAggregations` built terms aggregations without ever calling `.size(...)`, so Elasticsearch returned its default of 10 buckets. Added `aggregationBuilder.size(40)` — large enough to surface all realistic distinct values, small enough to not overwhelm the dropdown UI.
- Also lifts the same cap on other tables that share `ESService.getAggregations` (e.g. expression annotations).

## Test plan
- [ ] Verify the Molecular Consequence filter on https://stage.alliancegenome.org/gene/HGNC:620#alleles-and-variants now lists all consequence values present in the table data (e.g. `stop_lost`, `start_lost`, `splice_donor_variant`, etc.)
- [ ] Verify other filters on the same table (Category, Variant type) still render correctly
- [ ] Verify expression annotation filters on the gene page still render correctly