### PR TITLE
SCRUM-6011 stableURL should be a full URL, not a path

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/DownloadController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/DownloadController.java
@@ -9,8 +9,11 @@ import org.alliancegenome.api.service.DownloadService;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import lombok.extern.slf4j.Slf4j;
 
 @RequestScoped
@@ -18,6 +21,9 @@ import lombok.extern.slf4j.Slf4j;
 public class DownloadController implements DownloadRESTInterface {
 
 	@Inject DownloadService downloadService;
+
+	@Context UriInfo uriInfo;
+	@Context HttpHeaders headers;
 
 	@Override
 	public Response download(String filename) {
@@ -38,11 +44,24 @@ public class DownloadController implements DownloadRESTInterface {
 	public List<DownloadFile> listDownloads() {
 		try {
 			String release = downloadService.getCurrentRelease();
-			return downloadService.listDownloads(release);
+			return downloadService.listDownloads(release, resolvePublicBaseUrl());
 		} catch (Exception e) {
 			log.error("Failed to list downloads", e);
 			throw new RuntimeException(e);
 		}
+	}
+
+	/** Build the public scheme://host[:port] honouring X-Forwarded-{Proto,Host} so the URL behind a load balancer is correct. */
+	private String resolvePublicBaseUrl() {
+		String scheme = headers.getHeaderString("X-Forwarded-Proto");
+		String host = headers.getHeaderString("X-Forwarded-Host");
+		if (scheme == null || scheme.isEmpty()) {
+			scheme = uriInfo.getBaseUri().getScheme();
+		}
+		if (host == null || host.isEmpty()) {
+			host = uriInfo.getBaseUri().getAuthority();
+		}
+		return scheme + "://" + host;
 	}
 
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/service/DownloadService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/DownloadService.java
@@ -41,7 +41,7 @@ public class DownloadService {
 		return new URL(url).openStream();
 	}
 
-	public List<DownloadFile> listDownloads(String release) throws Exception {
+	public List<DownloadFile> listDownloads(String release, String publicBaseUrl) throws Exception {
 		String prefix = release + "/downloads/";
 		String url = DOWNLOAD_HOST + "/?list-type=2&prefix=" + URLEncoder.encode(prefix, "UTF-8") + "&delimiter=%2F&max-keys=1000";
 		log.info("Listing downloads: {}", url);
@@ -64,7 +64,7 @@ public class DownloadService {
 				f.setFilename(filename);
 				f.setS3Path(key);
 				f.setS3Url(DOWNLOAD_HOST + "/" + key);
-				f.setStableURL("/download/" + filename);
+				f.setStableURL(publicBaseUrl + "/download/" + filename);
 				f.setReleaseVersion(release);
 				f.setLastModified(textOf(c, "LastModified"));
 				String size = textOf(c, "Size");


### PR DESCRIPTION
Inject UriInfo + HttpHeaders into DownloadController and build the public scheme://host from X-Forwarded-Proto / X-Forwarded-Host (falling back to UriInfo when those aren't set). Pass that base URL into DownloadService.listDownloads so each entry's stableURL is a fully qualified URL the UI can hand to <a href> directly:

  stableURL: "https://www.alliancegenome.org/download/<filename>"

instead of the previous bare path "/download/<filename>".