### PR TITLE
SCRUM-1953: Fix Disease file generator via-orthology bugs

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -380,7 +380,7 @@ public enum FileGeneratorConfig {
 		m.put("DBobjectType", "_dbObjectType");
 		m.put("DBObjectID", "subject.primaryExternalId");
 		m.put("DBObjectSymbol", "_dbObjectSymbol");
-		m.put("AssociationType", "_associationType");
+		m.put("AssociationType", "relation.name");
 		m.put("DOID", "object.curie");
 		m.put("DOtermName", "object.name");
 		m.put("WithOrtholog", "_withOrtholog");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -380,7 +380,7 @@ public enum FileGeneratorConfig {
 		m.put("DBobjectType", "_dbObjectType");
 		m.put("DBObjectID", "subject.primaryExternalId");
 		m.put("DBObjectSymbol", "_dbObjectSymbol");
-		m.put("AssociationType", "relation.name");
+		m.put("AssociationType", "_associationType");
 		m.put("DOID", "object.curie");
 		m.put("DOtermName", "object.name");
 		m.put("WithOrtholog", "_withOrtholog");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -100,11 +100,6 @@ public class DiseaseFileGenerator extends FileGenerator {
 
 		String relationName = JsonPath.resolveString(hit, "relation.name");
 		boolean isViaOrthology = relationName.contains("_via_orthology");
-		if (isViaOrthology) {
-			relationName = relationName.replaceFirst("^is_", "");
-			relationName = relationName.replace("marker_via_orthology", "biomarker_via_orthology");
-		}
-		obj.put("_associationType", relationName);
 
 		String iso = JsonPath.resolveString(hit, "primaryAnnotations.0.dateUpdated");
 		if (iso.isEmpty()) {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -1,5 +1,7 @@
 package org.alliancegenome.filegenerator.generators;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashSet;
 
 import org.alliancegenome.filegenerator.config.FileGeneratorConfig;
@@ -12,6 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class DiseaseFileGenerator extends FileGenerator {
+
+	private static final String FILE_GENERATION_DATE =
+			LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE); // YYYYMMDD
 
 	public DiseaseFileGenerator(FileGeneratorConfig config) {
 		super(config);
@@ -93,7 +98,14 @@ public class DiseaseFileGenerator extends FileGenerator {
 			obj.put("_reference", "");
 		}
 
-		// Date: format YYYYMMDD from the most relevant ISO timestamp.
+		String relationName = JsonPath.resolveString(hit, "relation.name");
+		boolean isViaOrthology = relationName.contains("_via_orthology");
+		if (isViaOrthology) {
+			relationName = relationName.replaceFirst("^is_", "");
+			relationName = relationName.replace("marker_via_orthology", "biomarker_via_orthology");
+		}
+		obj.put("_associationType", relationName);
+
 		String iso = JsonPath.resolveString(hit, "primaryAnnotations.0.dateUpdated");
 		if (iso.isEmpty()) {
 			iso = JsonPath.resolveString(hit, "primaryAnnotations.0.dateCreated");
@@ -101,10 +113,20 @@ public class DiseaseFileGenerator extends FileGenerator {
 		if (iso.isEmpty()) {
 			iso = JsonPath.resolveString(hit, "subject.dateUpdated");
 		}
-		obj.put("_date", isoToYyyyMmDd(iso));
+		String date = isoToYyyyMmDd(iso);
+		if (date.isEmpty() && isViaOrthology) {
+			date = FILE_GENERATION_DATE;
+		}
+		obj.put("_date", date);
 
-		// Source: MOD code from the subject's species displayName (e.g. "WB", "MGI").
-		obj.put("_source", JsonPath.resolveString(hit, "subject.taxon.species.displayName"));
+		if (isViaOrthology) {
+			String provider = JsonPath.resolveString(hit, "primaryAnnotations.0.dataProvider.abbreviation");
+			obj.put("_source", provider.isEmpty()
+					? JsonPath.resolveString(hit, "subject.taxon.species.displayName")
+					: provider);
+		} else {
+			obj.put("_source", JsonPath.resolveString(hit, "subject.taxon.species.displayName"));
+		}
 
 		// WithOrtholog: pipe-delimited list of primaryAnnotations[*].with[*].primaryExternalId.
 		// Populated for gene-level annotations inferred via orthology.


### PR DESCRIPTION
## Summary
- Normalise AssociationType for via-orthology rows: strip `is_` prefix and rename `marker_via_orthology` → `biomarker_via_orthology` to match FMS
- Use `primaryAnnotations[0].dataProvider.abbreviation` as Source for via-orthology rows (yields `Alliance`) instead of subject MOD code
- Fall back to file generation date (YYYYMMDD) when Date is empty on via-orthology rollup docs

## Test plan
- [ ] Run Disease file generator against stage ES and compare AssociationType values with FMS reference
- [ ] Verify Source column shows `Alliance` for via-orthology rows
- [ ] Verify Date column is populated for via-orthology rollup rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)