### PR TITLE
SCRUM-6008 Gene Descriptions: stringencyFilter header + hard-fail on slice errors

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/es/EsParallelFetcher.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/es/EsParallelFetcher.java
@@ -60,10 +60,17 @@ public class EsParallelFetcher {
 		log.debug("Starting sliced scroll on {} for categories {} with {} slices, bufferSize={}, sourceIncludes={}",
 				index, categories, threadCount, bufferSize, sourceIncludes);
 
+		// Crash hard rather than throw — t.join() does not propagate worker exceptions, and a partial file must remain broken so it cannot be uploaded.
+		Thread.UncaughtExceptionHandler ueh = (thread, ex) -> {
+			log.error("Slice worker {} died with uncaught exception: {}", thread.getName(), ex.getMessage(), ex);
+			System.exit(-1);
+		};
+
 		List<Thread> threads = new ArrayList<>();
 		for (int i = 0; i < threadCount; i++) {
 			final int sliceId = i;
 			Thread t = new Thread(() -> worker(sliceId, threadCount, baseBody, consumer), "es-slice-" + i);
+			t.setUncaughtExceptionHandler(ueh);
 			threads.add(t);
 			t.start();
 		}
@@ -71,8 +78,8 @@ public class EsParallelFetcher {
 			try {
 				t.join();
 			} catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				throw new RuntimeException("Interrupted while waiting for slice threads", e);
+				log.error("Interrupted while waiting for slice threads on index {} for categories {}", index, categories, e);
+				System.exit(-1);
 			}
 		}
 	}
@@ -110,8 +117,9 @@ public class EsParallelFetcher {
 			}
 			log.debug("Slice {}/{} done: {} hits", sliceId, sliceMax, sliceCount);
 		} catch (Exception e) {
-			log.error("Slice {} failed: {}", sliceId, e.getMessage(), e);
-			throw new RuntimeException(e);
+			// Crash hard — t.join() does not propagate worker exceptions, and a partial file must remain broken so it cannot be uploaded.
+			log.error("Slice {}/{} failed on index {} for categories {}: {}", sliceId, sliceMax, index, categories, e.getMessage(), e);
+			System.exit(-1);
 		}
 	}
 

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/FileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/FileGenerator.java
@@ -182,8 +182,10 @@ public abstract class FileGenerator extends Thread {
 				}
 			}
 			display.progressProcess();
-		} catch (IOException e) {
-			throw new RuntimeException("Write failure", e);
+		} catch (Exception e) {
+			// Crash hard on any per-row failure — a single bad row invalidates the run, and the partial gzip on disk must be left broken so it cannot be uploaded.
+			log.error("{}: dispatch failed for row {} — exiting hard. Cause: {}", getClass().getSimpleName(), hit, e.getMessage(), e);
+			System.exit(-1);
 		}
 	}
 
@@ -241,6 +243,11 @@ public abstract class FileGenerator extends Thread {
 		return List.of();
 	}
 
+	/** Stringency filter value for the JSON metadata header. Null means "not applicable" for this generator. */
+	protected String stringencyFilter() {
+		return null;
+	}
+
 	/**
 	 * Builds the ES _source include list from the field map, taxon path, and any extras. Returns
 	 * null when any output requires the full source (JSON_RAW, VCF, GFF) — null tells the fetcher
@@ -291,11 +298,11 @@ public abstract class FileGenerator extends Thread {
 				return new PsiMiTabWriter(path, header, config.getFieldMap());
 			}
 			case JSON_RAW: {
-				Map<String, Object> meta = HeaderBuilder.buildJsonMetadata(config.getFiletypeLabel(), spec.format(), readme, taxonCuries, species);
+				Map<String, Object> meta = HeaderBuilder.buildJsonMetadata(config.getFiletypeLabel(), spec.format(), readme, taxonCuries, species, stringencyFilter());
 				return new JsonRawWriter(path, meta);
 			}
 			case JSON_MAPPED: {
-				Map<String, Object> meta = HeaderBuilder.buildJsonMetadata(config.getFiletypeLabel(), spec.format(), readme, taxonCuries, species);
+				Map<String, Object> meta = HeaderBuilder.buildJsonMetadata(config.getFiletypeLabel(), spec.format(), readme, taxonCuries, species, stringencyFilter());
 				return new JsonMappedWriter(path, meta, config.getFieldMap());
 			}
 			case VCF: {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/OrthologyFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/OrthologyFileGenerator.java
@@ -42,11 +42,18 @@ public class OrthologyFileGenerator extends FileGenerator {
 		return objCurie == null || objCurie.isEmpty() ? List.of() : List.of(objCurie);
 	}
 
+	private static final String STRINGENCY = "stringent";
+
 	/** FMS only emits stringent orthologs. */
 	@Override
 	protected boolean shouldEmit(JsonNode hit) {
 		String stringency = JsonPath.resolveString(hit, "stringencyFilter");
-		return "stringent".equalsIgnoreCase(stringency);
+		return STRINGENCY.equalsIgnoreCase(stringency);
+	}
+
+	@Override
+	protected String stringencyFilter() {
+		return STRINGENCY;
 	}
 
 	/** Pull the entire orthology subtree — synthetic field names in the field map would otherwise strip it. */

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/header/HeaderBuilder.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/header/HeaderBuilder.java
@@ -83,12 +83,17 @@ public class HeaderBuilder {
 	}
 
 	public static Map<String, Object> buildJsonMetadata(String filetypeLabel, Format format, String readmeText, Collection<String> taxonCuries, SpeciesLookup species) {
+		return buildJsonMetadata(filetypeLabel, format, readmeText, taxonCuries, species, null);
+	}
+
+	public static Map<String, Object> buildJsonMetadata(String filetypeLabel, Format format, String readmeText, Collection<String> taxonCuries, SpeciesLookup species, String stringencyFilter) {
 		Map<String, Object> metadata = new LinkedHashMap<>();
 		metadata.put("filetype", filetypeLabel);
 		metadata.put("databaseVersion", databaseVersion());
 		metadata.put("sourceURL", SOURCE_URL);
 		metadata.put("genTime", ZonedDateTime.now(ZoneOffset.UTC).format(GEN_TIME_FMT));
 		metadata.put("dataFormat", format.getDataFormatLabel());
+		metadata.put("stringencyFilter", stringencyFilter);
 		metadata.put("readme", readmeText == null ? "" : readmeText);
 		List<Map<String, String>> speciesList = new ArrayList<>();
 		for (String curie : taxonCuries) {


### PR DESCRIPTION
## Summary

Two fixes against PR review feedback on the agr_file_generator Gene Descriptions output ([SCRUM-6008](https://agr-jira.atlassian.net/browse/SCRUM-6008)):

- **`stringencyFilter` JSON header field** — added to `HeaderBuilder` metadata block, defaults to `null`. `OrthologyFileGenerator` returns `"stringent"` via a new `stringencyFilter()` hook on `FileGenerator` (refactored from a hardcoded literal). All other generators get `null`. Keeps the public download files consistent with other Alliance JSON downloads.
- **Hard-fail on ES slice-worker failure** — root cause of the ~4,000 fly genes missing from the prod Gene Descriptions output. `EsParallelFetcher.forEach()` was silently swallowing slice-worker exceptions: `t.join()` returned normally even when the worker died mid-scroll, and the partial hits were written to disk + uploaded to S3. Now an `UncaughtExceptionHandler` is installed on each slice thread and the worker's catch block calls `System.exit(-1)` directly. `FileGenerator.dispatch(...)` does the same on any per-row exception. The intent is "full good run or nothing" — a partial gzip stays mid-stream on disk and the JVM dies before the upload step.

Verified by comparing fresh local output (31,507 fly genes — full count) vs the production-deployed output dated 2026-05-06 06:05 UTC (27,507 fly genes — exactly one slice short of 1/8 × 31,507 ≈ 3,938). Logs from the same run also show FB Disease-Alliance dropped from 48,582 to 41,664 (~6,918) — multiple sliced scrolls hit the same ES hiccup. With this PR, that condition crashes the run and prevents bad output from ever reaching `download.alliancegenome.org`.

## Test plan

- [ ] Trigger a stage run and verify the Gene Descriptions output matches the curation persistent store gene count for every species.
- [ ] Verify the `stringencyFilter` field appears in every JSON header (null for all generators except orthology, `"stringent"` for orthology).
- [ ] Sanity-check that a deliberately broken ES query (or a low scroll timeout) causes the generator to exit non-zero rather than write a truncated gzip.

[SCRUM-6008]: https://agr-jira.atlassian.net/browse/SCRUM-6008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ