### PR TITLE
SCRUM-6020 close VARIANT-ALLELE column gaps

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -319,7 +319,7 @@ public enum FileGeneratorConfig {
 		m.put("VariantId", "_variantId");
 		m.put("VariantSymbol", "_variantSymbol");
 		m.put("VariantSynonyms", "_variantSynonyms");
-		m.put("VariantCrossReferences", "_unavailable");
+		m.put("VariantCrossReferences", "allele.primaryExternalId");
 		m.put("AlleleAssociatedGeneId", "alleleOfGene.primaryExternalId");
 		m.put("AlleleAssociatedGeneSymbol", "alleleOfGene.geneSymbol.displayText");
 		m.put("VariantAffectedGeneId", "_variantAffectedGeneId");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -335,7 +335,7 @@ public enum FileGeneratorConfig {
 		m.put("SequenceOfReference", "_sequenceOfReference");
 		m.put("SequenceOfVariant", "_sequenceOfVariant");
 		m.put("MostSevereConsequenceName", "_mostSevereConsequence");
-		m.put("VariantInformationReference", "_unavailable");
+		m.put("VariantInformationReference", "_variantInformationReference");
 		m.put("HasDiseaseAnnotations", "_hasDisease");
 		m.put("HasPhenotypeAnnotations", "_hasPhenotype");
 		return m;

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
@@ -85,6 +85,7 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 		List<String> consequences = new ArrayList<>();
 		List<String> affectedGeneIds = new ArrayList<>();
 		List<String> affectedGeneSymbols = new ArrayList<>();
+		List<String> referenceCuries = new ArrayList<>();
 
 		if (variantList != null && variantList.isArray()) {
 			for (JsonNode v : variantList) {
@@ -92,6 +93,35 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 				addIfPresent(variantSymbols, v.path("variantSymbol").path("displayText").asText(""));
 				addIfPresent(variantTypeIds, v.path("variantType").path("curie").asText(""));
 				addIfPresent(variantTypeNames, v.path("variantType").path("name").asText(""));
+
+				// VariantInformationReference — for each reference, pipe-join MOD paper curie + PMID (in that order). Skips DOI / PMCID / etc.
+				JsonNode refs = v.path("references");
+				if (refs.isArray()) {
+					for (JsonNode r : refs) {
+						JsonNode xrefs = r.path("crossReferences");
+						if (xrefs.isArray()) {
+							List<String> ordered = new ArrayList<>();
+							String pmid = null;
+							for (JsonNode x : xrefs) {
+								String c = x.path("referencedCurie").asText("");
+								if (c.isEmpty()) {
+									continue;
+								}
+								if (c.startsWith("PMID:")) {
+									pmid = c;
+								} else if (isPaperCurie(c)) {
+									ordered.add(c);
+								}
+							}
+							if (pmid != null) {
+								ordered.add(pmid);
+							}
+							if (!ordered.isEmpty()) {
+								referenceCuries.add(String.join("|", ordered));
+							}
+						}
+					}
+				}
 
 				JsonNode locs = v.path("curatedVariantGenomicLocations");
 				if (locs.isArray()) {
@@ -151,12 +181,26 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 		obj.put("_mostSevereConsequence", joinList(dedup(consequences)));
 		obj.put("_variantAffectedGeneId", joinList(dedup(affectedGeneIds)));
 		obj.put("_variantAffectedGeneSymbol", joinList(dedup(affectedGeneSymbols)));
+		// Between references: comma-join (matches FMS); within a reference, MOD curie and PMID are pipe-joined.
+		List<String> uniqueRefs = dedup(referenceCuries);
+		obj.put("_variantInformationReference", uniqueRefs.isEmpty() ? "" : String.join(",", uniqueRefs));
 
 		// HasDisease / HasPhenotype: FMS uses "yes"/"-" not "true"/"false".
 		obj.put("_hasDisease", boolToYesDash(hit.path("hasDisease")));
 		obj.put("_hasPhenotype", boolToYesDash(hit.path("hasPhenotype")));
 
 		return hit;
+	}
+
+	// Cross-reference prefixes that count as a paper identifier per ReferenceConstants.primaryXrefOrder; everything else (DOI, PMCID, ISBN, ...) is skipped.
+	private static final Set<String> PAPER_PREFIXES = Set.of("PMID", "FB", "MGI", "RGD", "SGD", "WB", "XB", "ZFIN");
+
+	private static boolean isPaperCurie(String curie) {
+		int idx = curie.indexOf(':');
+		if (idx <= 0) {
+			return false;
+		}
+		return PAPER_PREFIXES.contains(curie.substring(0, idx));
 	}
 
 	private static String boolToYesDash(JsonNode v) {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
@@ -96,9 +96,19 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 				JsonNode locs = v.path("curatedVariantGenomicLocations");
 				if (locs.isArray()) {
 					for (JsonNode loc : locs) {
-						addIfPresent(hgvsNames, loc.path("hgvs").asText(""));
+						String hgvs = loc.path("hgvs").asText("");
+						String chromName = loc.path("variantGenomicLocationAssociationObject").path("name").asText("");
+						addIfPresent(hgvsNames, hgvs);
 						addIfPresent(assemblies, loc.path("variantGenomicLocationAssociationObject").path("genomeAssembly").path("primaryExternalId").asText(""));
-						addIfPresent(chromosomes, loc.path("variantGenomicLocationAssociationObject").path("name").asText(""));
+						addIfPresent(chromosomes, chromName);
+						// VariantSynonyms = RefSeq-form hgvs + chromosome-level form (RefSeq accession swapped for chromosome name).
+						if (!hgvs.isEmpty()) {
+							addIfPresent(variantSynonyms, hgvs);
+							int colonIdx = hgvs.indexOf(':');
+							if (!chromName.isEmpty() && colonIdx > 0) {
+								addIfPresent(variantSynonyms, chromName + hgvs.substring(colonIdx));
+							}
+						}
 						String s = loc.path("start").asText("");
 						String e = loc.path("end").asText("");
 						addIfPresent(startPositions, s);

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/writers/TsvWriter.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/writers/TsvWriter.java
@@ -24,7 +24,6 @@ public class TsvWriter implements RowWriter {
 		Files.createDirectories(path.getParent());
 		this.writer = new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(Files.newOutputStream(path)), StandardCharsets.UTF_8));
 		writer.write(headerText);
-		writer.write("\n");
 		writer.write(String.join("\t", fieldMap.keySet()));
 		writer.write("\n");
 	}


### PR DESCRIPTION
## Summary
- Closes the four outstanding gaps on the FMS VARIANT-ALLELE generator output
- Fixes the empty line that was being emitted between the header block and the column header
- Populates `VariantSynonyms` (RefSeq-form HGVS + chromosome-level form), `VariantCrossReferences` (allele primaryExternalId), and `VariantInformationReference` (MOD paper curie + PMID per reference, DOI/PMCID/etc. dropped) — all from `allele_summary` ES doc data already on the wire after [agr_curation#2721](https://github.com/alliance-genome/agr_curation/pull/2721) ships
- See `agr_file_generator/SCRUM-6020.md` for the full column-by-column accounting

## Commits
- `e52f73d` — fix empty line between TSV header block and column header (also affects other TSV outputs)
- `b933faf` — populate VariantSynonyms from hgvs + chromosome-level form
- `c8537d4` — populate VariantCrossReferences with allele primaryExternalId
- `9cf38f1` — populate VariantInformationReference from variant references

## Test plan
- [ ] Build passes
- [ ] After agr_curation#2721 ships and curation reindexes, run the generator: `java -jar target/agr_file_generator-jar-with-dependencies.jar VariantsAlleles`
- [ ] Confirm `VARIANT-ALLELE-TSV_{FB,MGI,RGD,SGD,WB,ZFIN}.tsv.gz` outputs:
  - No empty line at row 15
  - VariantSynonyms populated for variants with HGVS data
  - VariantCrossReferences populated with the allele curie
  - VariantInformationReference populated for alleles whose variants have references in curation