### PR TITLE
SCRUM-6007 Expression FMS file: fix Reference column and wire up 12 whereExpressed columns

### DIFF
--- a/agr_file_generator/SCRUM-6007.md
+++ b/agr_file_generator/SCRUM-6007.md
@@ -9,102 +9,42 @@ The TSV column set matches the FMS Expression file produced by the legacy Python
 
 ## Column coverage (TSV)
 
-23 columns total. **11 populated from ES, 12 are blank** because the source data isn't currently
-indexed.
+All 23 columns are populated from ES once the curation-side JsonView change lands and the index is rebuilt (see "Curation-side dependency" below). 17 columns map straight off the doc; the 6 qualifier columns are pipe-joined inside `ExpressionFileGenerator.customizeRow()` into synthetic `_*` fields.
 
-| FMS column | ES path | Status |
-|---|---|---|
-| Species | `geneExpressionAnnotation.expressionAnnotationSubject.taxon.name` | OK |
-| SpeciesID | `geneExpressionAnnotation.expressionAnnotationSubject.taxon.curie` | OK |
-| GeneID | `geneExpressionAnnotation.expressionAnnotationSubject.primaryExternalId` | OK |
-| GeneSymbol | `geneExpressionAnnotation.expressionAnnotationSubject.geneSymbol.displayText` | OK |
-| Location | `geneExpressionAnnotation.whereExpressedStatement` | OK |
-| StageTerm | `geneExpressionAnnotation.whenExpressedStageName` | OK |
-| AssayID | `geneExpressionAnnotation.expressionAssayUsed.curie` | OK |
-| AssayTermName | `geneExpressionAnnotation.expressionAssayUsed.name` | OK |
-| SourceURL | computed in `customizeRow` from `crossReferences[0]` (`urlTemplate` + `referencedCurie` local part → synthetic `_sourceUrl` field) | OK |
-| Source | `geneExpressionAnnotation.dataProvider.abbreviation` | OK |
-| Reference | `referenceId[0]` | OK — top-level `referenceId` array on the doc holds the MOD pub curie (e.g. `FB:FBrf0219073`), which matches the FMS `Reference` column. The previous AGRKB-curie path was wrong; the curation API's `GeneExpressionDocumentBuilder` populates `referenceId` from `evidenceItem.referenceID` for exactly this purpose. |
-| CellularComponentID | — | **Gap** |
-| CellularComponentTerm | — | **Gap** |
-| CellularComponentQualifierIDs | — | **Gap** |
-| CellularComponentQualifierTermNames | — | **Gap** |
-| SubStructureID | — | **Gap** |
-| SubStructureName | — | **Gap** |
-| SubStructureQualifierIDs | — | **Gap** |
-| SubStructureQualifierTermNames | — | **Gap** |
-| AnatomyTermID | — | **Gap** |
-| AnatomyTermName | — | **Gap** |
-| AnatomyTermQualifierIDs | — | **Gap** |
-| AnatomyTermQualifierTermNames | — | **Gap** |
+| FMS column | ES path |
+|---|---|
+| Species | `geneExpressionAnnotation.expressionAnnotationSubject.taxon.name` |
+| SpeciesID | `geneExpressionAnnotation.expressionAnnotationSubject.taxon.curie` |
+| GeneID | `geneExpressionAnnotation.expressionAnnotationSubject.primaryExternalId` |
+| GeneSymbol | `geneExpressionAnnotation.expressionAnnotationSubject.geneSymbol.displayText` |
+| Location | `geneExpressionAnnotation.whereExpressedStatement` |
+| StageTerm | `geneExpressionAnnotation.whenExpressedStageName` |
+| AssayID | `geneExpressionAnnotation.expressionAssayUsed.curie` |
+| AssayTermName | `geneExpressionAnnotation.expressionAssayUsed.name` (display synonym, intentional curation-side override in `GeneExpressionDocumentBuilder`) |
+| CellularComponentID | `geneExpressionAnnotation.expressionPattern.whereExpressed.cellularComponentTerm.curie` |
+| CellularComponentTerm | `geneExpressionAnnotation.expressionPattern.whereExpressed.cellularComponentTerm.name` |
+| CellularComponentQualifierIDs | `_cellularComponentQualifierIds` (pipe-joined from `cellularComponentQualifiers[*].curie`) |
+| CellularComponentQualifierTermNames | `_cellularComponentQualifierNames` (pipe-joined from `cellularComponentQualifiers[*].name`) |
+| SubStructureID | `geneExpressionAnnotation.expressionPattern.whereExpressed.anatomicalSubstructure.curie` |
+| SubStructureName | `geneExpressionAnnotation.expressionPattern.whereExpressed.anatomicalSubstructure.name` |
+| SubStructureQualifierIDs | `_subStructureQualifierIds` (pipe-joined from `anatomicalSubstructureQualifiers[*].curie`) |
+| SubStructureQualifierTermNames | `_subStructureQualifierNames` (pipe-joined from `anatomicalSubstructureQualifiers[*].name`) |
+| AnatomyTermID | `geneExpressionAnnotation.expressionPattern.whereExpressed.anatomicalStructure.curie` |
+| AnatomyTermName | `geneExpressionAnnotation.expressionPattern.whereExpressed.anatomicalStructure.name` |
+| AnatomyTermQualifierIDs | `_anatomyQualifierIds` (pipe-joined from `anatomicalStructureQualifiers[*].curie`) |
+| AnatomyTermQualifierTermNames | `_anatomyQualifierNames` (pipe-joined from `anatomicalStructureQualifiers[*].name`) |
+| SourceURL | `_sourceUrl` (computed in `customizeRow` from `crossReferences[0]` `urlTemplate` + `referencedCurie` local part) |
+| Source | `geneExpressionAnnotation.dataProvider.abbreviation` |
+| Reference | `referenceId.0` — top-level `referenceId` array on the doc holds the MOD pub curie (e.g. `FB:FBrf0219073`), populated by the curation API's `GeneExpressionDocumentBuilder` from `evidenceItem.referenceID` |
 
-## Root cause for the 12 blank columns
+## Curation-side dependency
 
-These fields live on the underlying entity at:
+The `whereExpressed` subtree was historically dropped from the indexed doc because `ExpressionPattern.whereExpressed` and the six fields under `AnatomicalSite` were not on `CurationView.GeneExpressionDocument`. agr_curation `release/v0.48.18` (PR #2721, commit `8b4022c3f`) adds that view annotation to:
 
-```
-GeneExpressionAnnotation
-  └─ expressionPattern (ExpressionPattern)
-        └─ whereExpressed (AnatomicalSite)
-              ├─ anatomicalStructure (AnatomicalTerm)
-              ├─ anatomicalSubstructure (AnatomicalTerm)
-              ├─ cellularComponentTerm (GOTerm)
-              ├─ anatomicalStructureQualifiers (List<OntologyTerm>)
-              ├─ anatomicalSubstructureQualifiers (List<OntologyTerm>)
-              └─ cellularComponentQualifiers (List<OntologyTerm>)
-```
+- `ExpressionPattern.whereExpressed`
+- `AnatomicalSite.{anatomicalStructure, anatomicalSubstructure, cellularComponentTerm, anatomicalStructureQualifiers, anatomicalSubstructureQualifiers, cellularComponentQualifiers}`
 
-In `ExpressionPattern.java` (curation API entity), `whereExpressed` is annotated with:
-
-```java
-@JsonView({CurationView.FieldsOnly.class, CurationView.ForPublic.class})
-private AnatomicalSite whereExpressed;
-```
-
-It is **NOT** included in `CurationView.GeneExpressionDocument.class`. The indexer
-(`GeneExpressionAnnotationIndexer`) serializes documents with the
-`GeneExpressionDocument` view, so `whereExpressed` is dropped before the JSON ever
-reaches Elasticsearch. As a result, the entire `cellularComponent*`,
-`subStructure*`, and `anatomyTerm*` column block ends up blank in our output.
-
-The same exclusion explains why the ES `whereExpressedStatement` (a flat human-readable
-string like `"pituitary gland"` or `"C. elegans Cell and Anatomy"`) is the only
-location/anatomy-ish field we have to work with today.
-
-## Options to close the gap
-
-1. **Add `whereExpressed` to `CurationView.GeneExpressionDocument` in the curation API**
-   (`agr_curation` repo). Triggers a full reindex of `gene_expression_annotation`,
-   after which our generator will populate all 12 columns automatically — no Java change
-   here required.
-2. **Side-load anatomy data per record** by hitting the curation API
-   (`/gene-expression-annotation/{id}` or similar) for each scrolled doc. Slower, harder
-   to parallelize cleanly, but doesn't depend on a curation-API-side change.
-3. **Ship as-is** with the 12 columns blank, and document the gap (this PR). FMS rows
-   often have several of these columns blank already, so the file isn't useless — but
-   it's incomplete.
-
-Recommendation: pursue (1). It's the smallest change and keeps the file generator
-purely ES-driven.
-
-## Reference column
-
-FMS emits the MOD publication curie (e.g. `FB:FBrf0219073`), not the PMID. That same
-value is sitting on the doc as the top-level `referenceId` array — populated by the
-curation API's `GeneExpressionDocumentBuilder` from `evidenceItem.referenceID`. The
-field map now reads `referenceId.0`, which matches FMS exactly. No PMID resolution or
-side-load needed.
-
-## What the framework gets us for free
-
-When the JsonView changes land in the curation API and the index is rebuilt:
-
-- The field map in `FileGeneratorConfig.expressionFieldMap()` just needs the
-  `_unavailable` placeholders swapped for real ES paths — no other code changes.
-- `EsParallelFetcher` automatically pulls the new fields when `_source` filtering is
-  enabled (since the field map values feed the include list).
-- Combined / per-MOD splits, gzip output, header block, JSON metadata block, MOD
-  whitelist gating, parallel sliced scroll — all unchanged.
+`OntologyTerm.curie` and `OntologyTerm.name` were already on the view, so leaf data comes through automatically. After deploy + a `gene_expression_annotation` reindex, all 12 previously-blank columns will populate from ES with no further changes here.
 
 ## File layout produced
 

--- a/agr_file_generator/SCRUM-6007.md
+++ b/agr_file_generator/SCRUM-6007.md
@@ -24,7 +24,7 @@ indexed.
 | AssayTermName | `geneExpressionAnnotation.expressionAssayUsed.name` | OK |
 | SourceURL | computed in `customizeRow` from `crossReferences[0]` (`urlTemplate` + `referencedCurie` local part → synthetic `_sourceUrl` field) | OK |
 | Source | `geneExpressionAnnotation.dataProvider.abbreviation` | OK |
-| Reference | `geneExpressionAnnotation.evidenceItem.curie` | Partial — emits the AGRKB curie (e.g. `AGRKB:101000000178541`); FMS file emits the PMID. Resolution would need an indexer-side cross-reference lookup or a side-load against the curation API. |
+| Reference | `referenceId[0]` | OK — top-level `referenceId` array on the doc holds the MOD pub curie (e.g. `FB:FBrf0219073`), which matches the FMS `Reference` column. The previous AGRKB-curie path was wrong; the curation API's `GeneExpressionDocumentBuilder` populates `referenceId` from `evidenceItem.referenceID` for exactly this purpose. |
 | CellularComponentID | — | **Gap** |
 | CellularComponentTerm | — | **Gap** |
 | CellularComponentQualifierIDs | — | **Gap** |
@@ -87,13 +87,13 @@ location/anatomy-ish field we have to work with today.
 Recommendation: pursue (1). It's the smallest change and keeps the file generator
 purely ES-driven.
 
-## Reference column (PMID vs AGRKB)
+## Reference column
 
-The FMS file emits the publication PMID in the `Reference` column. ES carries only the
-AGRKB curie on `evidenceItem.curie`. The curation API's `Reference` entity has a
-`crossReferences` list that includes the PMID, but those aren't on the
-`GeneExpressionDocument` view either. Same fix path as above (add the relevant fields to
-the JsonView and reindex), or a per-record side-load.
+FMS emits the MOD publication curie (e.g. `FB:FBrf0219073`), not the PMID. That same
+value is sitting on the doc as the top-level `referenceId` array — populated by the
+curation API's `GeneExpressionDocumentBuilder` from `evidenceItem.referenceID`. The
+field map now reads `referenceId.0`, which matches FMS exactly. No PMID resolution or
+side-load needed.
 
 ## What the framework gets us for free
 

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -431,7 +431,7 @@ public enum FileGeneratorConfig {
 		// inside ExpressionFileGenerator.customizeRow(); this path resolves the synthetic field.
 		m.put("SourceURL", "_sourceUrl");
 		m.put("Source", "geneExpressionAnnotation.dataProvider.abbreviation");
-		m.put("Reference", "geneExpressionAnnotation.evidenceItem.curie");
+		m.put("Reference", "referenceId.0");
 		return m;
 	}
 }

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -397,13 +397,7 @@ public enum FileGeneratorConfig {
 	}
 
 	/**
-	 * Expression field map. Columns whose ES source is not currently indexed map to
-	 * "_unavailable" — JsonPath returns "" for that, so the cell is rendered blank.
-	 *
-	 * Known gap: cellularComponent, sub-structure, and anatomy terms live under
-	 * geneExpressionAnnotation.expressionPattern.whereExpressed.* on the entity, but the
-	 * curation API's GeneExpressionDocument JsonView does not include `whereExpressed`,
-	 * so those 12 columns can't be populated from ES today.
+	 * Expression field map. Anatomy / sub-structure / cellular-component term IDs and names come straight off whereExpressed; the six qualifier list columns are pipe-joined inside ExpressionFileGenerator.customizeRow() into synthetic fields.
 	 */
 	private static Map<String, String> expressionFieldMap() {
 		Map<String, String> m = new LinkedHashMap<>();
@@ -415,20 +409,19 @@ public enum FileGeneratorConfig {
 		m.put("StageTerm", "geneExpressionAnnotation.whenExpressedStageName");
 		m.put("AssayID", "geneExpressionAnnotation.expressionAssayUsed.curie");
 		m.put("AssayTermName", "geneExpressionAnnotation.expressionAssayUsed.name");
-		m.put("CellularComponentID", "_unavailable");
-		m.put("CellularComponentTerm", "_unavailable");
-		m.put("CellularComponentQualifierIDs", "_unavailable");
-		m.put("CellularComponentQualifierTermNames", "_unavailable");
-		m.put("SubStructureID", "_unavailable");
-		m.put("SubStructureName", "_unavailable");
-		m.put("SubStructureQualifierIDs", "_unavailable");
-		m.put("SubStructureQualifierTermNames", "_unavailable");
-		m.put("AnatomyTermID", "_unavailable");
-		m.put("AnatomyTermName", "_unavailable");
-		m.put("AnatomyTermQualifierIDs", "_unavailable");
-		m.put("AnatomyTermQualifierTermNames", "_unavailable");
-		// SourceURL is built from the first crossReference's urlTemplate + referencedCurie
-		// inside ExpressionFileGenerator.customizeRow(); this path resolves the synthetic field.
+		m.put("CellularComponentID", "geneExpressionAnnotation.expressionPattern.whereExpressed.cellularComponentTerm.curie");
+		m.put("CellularComponentTerm", "geneExpressionAnnotation.expressionPattern.whereExpressed.cellularComponentTerm.name");
+		m.put("CellularComponentQualifierIDs", "_cellularComponentQualifierIds");
+		m.put("CellularComponentQualifierTermNames", "_cellularComponentQualifierNames");
+		m.put("SubStructureID", "geneExpressionAnnotation.expressionPattern.whereExpressed.anatomicalSubstructure.curie");
+		m.put("SubStructureName", "geneExpressionAnnotation.expressionPattern.whereExpressed.anatomicalSubstructure.name");
+		m.put("SubStructureQualifierIDs", "_subStructureQualifierIds");
+		m.put("SubStructureQualifierTermNames", "_subStructureQualifierNames");
+		m.put("AnatomyTermID", "geneExpressionAnnotation.expressionPattern.whereExpressed.anatomicalStructure.curie");
+		m.put("AnatomyTermName", "geneExpressionAnnotation.expressionPattern.whereExpressed.anatomicalStructure.name");
+		m.put("AnatomyTermQualifierIDs", "_anatomyQualifierIds");
+		m.put("AnatomyTermQualifierTermNames", "_anatomyQualifierNames");
+		// SourceURL is built from the first crossReference's urlTemplate + referencedCurie inside ExpressionFileGenerator.customizeRow(); this path resolves the synthetic field.
 		m.put("SourceURL", "_sourceUrl");
 		m.put("Source", "geneExpressionAnnotation.dataProvider.abbreviation");
 		m.put("Reference", "referenceId.0");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/ExpressionFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/ExpressionFileGenerator.java
@@ -1,5 +1,7 @@
 package org.alliancegenome.filegenerator.generators;
 
+import java.util.LinkedHashSet;
+
 import org.alliancegenome.filegenerator.config.FileGeneratorConfig;
 import org.alliancegenome.filegenerator.writers.JsonPath;
 
@@ -10,6 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ExpressionFileGenerator extends FileGenerator {
+
+	private static final String QUALIFIER_DELIMITER = "|";
 
 	public ExpressionFileGenerator(FileGeneratorConfig config) {
 		super(config);
@@ -27,6 +31,11 @@ public class ExpressionFileGenerator extends FileGenerator {
 
 	@Override
 	protected JsonNode customizeRow(JsonNode hit) {
+		if (!hit.isObject()) {
+			return hit;
+		}
+		ObjectNode obj = (ObjectNode) hit;
+
 		// Build the SourceURL from the first crossReference's urlTemplate + referencedCurie.
 		JsonNode xrefs = JsonPath.resolve(hit, "geneExpressionAnnotation.crossReferences");
 		if (xrefs != null && xrefs.isArray() && xrefs.size() > 0) {
@@ -37,11 +46,34 @@ public class ExpressionFileGenerator extends FileGenerator {
 				int idx = curie.indexOf(':');
 				String localId = idx >= 0 ? curie.substring(idx + 1) : curie;
 				String url = urlTemplate.replace("[%s]", localId);
-				if (hit.isObject()) {
-					((ObjectNode) hit).put("_sourceUrl", url);
-				}
+				obj.put("_sourceUrl", url);
 			}
 		}
+
+		// Pipe-join the three qualifier lists under whereExpressed into synthetic ID + name fields.
+		String wherePath = "geneExpressionAnnotation.expressionPattern.whereExpressed";
+		obj.put("_anatomyQualifierIds", joinField(hit, wherePath + ".anatomicalStructureQualifiers", "curie"));
+		obj.put("_anatomyQualifierNames", joinField(hit, wherePath + ".anatomicalStructureQualifiers", "name"));
+		obj.put("_subStructureQualifierIds", joinField(hit, wherePath + ".anatomicalSubstructureQualifiers", "curie"));
+		obj.put("_subStructureQualifierNames", joinField(hit, wherePath + ".anatomicalSubstructureQualifiers", "name"));
+		obj.put("_cellularComponentQualifierIds", joinField(hit, wherePath + ".cellularComponentQualifiers", "curie"));
+		obj.put("_cellularComponentQualifierNames", joinField(hit, wherePath + ".cellularComponentQualifiers", "name"));
+
 		return hit;
+	}
+
+	private static String joinField(JsonNode root, String arrayPath, String fieldName) {
+		JsonNode array = JsonPath.resolve(root, arrayPath);
+		if (array == null || !array.isArray() || array.size() == 0) {
+			return "";
+		}
+		LinkedHashSet<String> values = new LinkedHashSet<>();
+		for (JsonNode element : array) {
+			String value = element.path(fieldName).asText("");
+			if (!value.isEmpty()) {
+				values.add(value);
+			}
+		}
+		return String.join(QUALIFIER_DELIMITER, values);
 	}
 }


### PR DESCRIPTION
## Summary
- Switch `Reference` column from the AGRKB curie (`evidenceItem.curie`) to the MOD pub curie at `referenceId[0]` (e.g. `FB:FBrf0219073`), matching the legacy FMS Expression file
- Wire up the 12 anatomy / sub-structure / cellular-component term ID, name, and qualifier columns under `geneExpressionAnnotation.expressionPattern.whereExpressed`
- Update `SCRUM-6007.md` to reflect full 23/23 column coverage

## Context

### Reference column
The legacy FMS Expression file emits the MOD publication curie, not the AGRKB curie or PMID. That value is sitting on the doc as the top-level `referenceId` array — populated by the curation API's `GeneExpressionDocumentBuilder` from `evidenceItem.referenceID`. The field map now reads `referenceId.0`, which matches FMS exactly without any side-load.

### whereExpressed columns
The 12 anatomy / sub-structure / cellular-component columns were previously blank because `ExpressionPattern.whereExpressed` was not on `CurationView.GeneExpressionDocument` and got dropped before the doc reached ES. Six columns are direct paths off the now-exposed subtree; the six qualifier columns are pipe-joined inside `ExpressionFileGenerator.customizeRow()` into synthetic `_*QualifierIds` / `_*QualifierNames` fields. Pipe delimiter matches the SCRUM-6007 spec ("bar-separators for within cell/field lists") and the existing Disease `WithOrtholog` join.

## Depends on
agr_curation **PR #2721** (`release/v0.48.18`, commit `8b4022c3f`) — exposes `whereExpressed` and the six `AnatomicalSite` fields on `CurationView.GeneExpressionDocument`. The 12 new columns will populate from ES once that ships and `gene_expression_annotation` is reindexed.

## Test plan
- [ ] Build passes on PR
- [ ] After agr_curation PR #2721 deploys + reindex, run the Expression generator on stage and confirm the 12 previously-blank columns populate with the expected curies / names
- [ ] Spot-check at least one row with multiple qualifiers in the underlying entity to verify the pipe-join produces the expected `id1|id2|...` / `name1|name2|...` cell content
- [ ] Verify the `Reference` column on a sample row contains the MOD pub curie (e.g. `FB:FBrf...`, `MGI:...`, `ZDB-PUB-...`) and not an AGRKB curie