### PR TITLE
SCRUM-1953 dedup primaryAnnotations by uniqueId in disease/phenotype FGs

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -5,6 +5,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.alliancegenome.filegenerator.config.FileGeneratorConfig;
 import org.alliancegenome.filegenerator.writers.JsonPath;
@@ -20,6 +22,9 @@ public class DiseaseFileGenerator extends FileGenerator {
 
 	private static final String FILE_GENERATION_DATE =
 			LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE); // YYYYMMDD
+
+	// Same primaryAnnotation appears across many consolidated docs (gene/allele/agm rollups + via_orthology fan-out). Dedup by the canonical Annotation.uniqueId so each annotation is emitted once per run. dispatch() runs from the parallel scroll pool, so this must be a concurrent set.
+	private final Set<String> seenUniqueIds = ConcurrentHashMap.newKeySet();
 
 	public DiseaseFileGenerator(FileGeneratorConfig config) {
 		super(config);
@@ -51,6 +56,12 @@ public class DiseaseFileGenerator extends FileGenerator {
 		}
 		List<JsonNode> rows = new ArrayList<>(primary.size());
 		for (JsonNode pa : primary) {
+			// Annotation.uniqueId is the canonical dedup key computed by AnnotationUniqueIdHelper in curation. Skip empty values so the generator keeps working before the curation-side @JsonView change has been deployed and reindexed; once it lands, this becomes a real dedup.
+			String uniqueId = JsonPath.resolveString(pa, "uniqueId");
+			if (!uniqueId.isEmpty() && !seenUniqueIds.add(uniqueId)) {
+				continue;
+			}
+
 			ObjectNode row = JsonNodeFactory.instance.objectNode();
 
 			row.put("_taxon", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.curie"));

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/PhenotypeFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/PhenotypeFileGenerator.java
@@ -2,6 +2,8 @@ package org.alliancegenome.filegenerator.generators;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.alliancegenome.filegenerator.config.FileGeneratorConfig;
 import org.alliancegenome.filegenerator.writers.JsonPath;
@@ -14,6 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class PhenotypeFileGenerator extends FileGenerator {
+
+	// Same primaryAnnotation appears across many consolidated docs. Dedup by the canonical Annotation.uniqueId so each annotation is emitted once per run. dispatch() runs from the parallel scroll pool, so this must be a concurrent set.
+	private final Set<String> seenUniqueIds = ConcurrentHashMap.newKeySet();
 
 	public PhenotypeFileGenerator(FileGeneratorConfig config) {
 		super(config);
@@ -45,6 +50,12 @@ public class PhenotypeFileGenerator extends FileGenerator {
 		}
 		List<JsonNode> rows = new ArrayList<>(primary.size());
 		for (JsonNode pa : primary) {
+			// Annotation.uniqueId is the canonical dedup key computed by AnnotationUniqueIdHelper in curation. Skip empty values so the generator keeps working before the curation-side @JsonView change has been deployed and reindexed; once it lands, this becomes a real dedup.
+			String uniqueId = JsonPath.resolveString(pa, "uniqueId");
+			if (!uniqueId.isEmpty() && !seenUniqueIds.add(uniqueId)) {
+				continue;
+			}
+
 			ObjectNode row = JsonNodeFactory.instance.objectNode();
 
 			String phenotype = JsonPath.resolveString(pa, "phenotypeTerms.0.name");

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
 		<checkstyle.version>10.17.0</checkstyle.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<curation.version>v0.48.19</curation.version>
+		<curation.version>v0.49.1</curation.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary

- Adds a `ConcurrentHashMap`-backed seen-set keyed off `primaryAnnotations[i].uniqueId` to `DiseaseFileGenerator` and `PhenotypeFileGenerator` so each canonical annotation is emitted once per run.
- Bumps `curation.version` to `v0.49.1` (which exposes `Annotation.uniqueId` on the `ForPublic` JSON view — see agr_curation PR for that release).

## Why

The consolidated `gene_/allele_/agm_disease_annotation` (and phenotype equivalents) ES docs each carry a `primaryAnnotations[]` array. The same primary annotation appears in many of those rollups (e.g. across ortholog-gene rollups for `*_via_orthology` rows — verified: one tuple appeared identically in 6 separate `gene_disease_annotation` docs). The generators were emitting duplicate rows in the TSV / JSON_MAPPED outputs as a result.

The seen-set keys off `Annotation.uniqueId`, the canonical composite already computed by `AnnotationUniqueIdHelper.getDiseaseAnnotationUniqueId(...)` / `getPhenotypeAnnotationUniqueId(...)` in curation. We don't reproduce the key logic in the file generator — we just use what curation already maintains.

Empty/missing `uniqueId` falls through (no dedup applied), so the generator stays correct against indexes that haven't yet been reindexed with the new field.

## Test plan

- [ ] Wait for the in-flight indexer run to finish so `primaryAnnotations[i].uniqueId` is present in stage ES
- [ ] Run the Disease and Phenotype generators against stage ES
- [ ] Spot-check the TSV outputs: row count should drop relative to the previous run (particularly for `*_via_orthology` disease rows), and a known previously-duplicated tuple should appear once
- [ ] Confirm JSON_RAW output is unchanged (dedup is per-PA inside `customizeRows`, doc-format writers don't call it)
- [ ] Confirm row counts for generators OTHER than Disease/Phenotype are unchanged