### PR TITLE
SCRUM-5964 / SCRUM-6009 fix Gene + Orthology download file issues

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -17,7 +17,7 @@ import org.alliancegenome.filegenerator.generators.VariantVcfFileGenerator;
 public enum FileGeneratorConfig {
 
 	Gene("Gene", "GENE", List.of("gene_summary"), List.of(new OutputSpec(Format.TSV, SplitMode.TAXON), new OutputSpec(Format.TSV, SplitMode.COMBINED), new OutputSpec(Format.JSON_RAW, SplitMode.TAXON), new OutputSpec(Format.JSON_RAW, SplitMode.COMBINED)),
-		List.of("FB", "MGI", "RGD", "SGD", "WB", "XBXL", "XBXT", "ZFIN"), geneFieldMap(), "readmes/gene.txt", GeneFileGenerator.class, 1000, 8),
+		List.of("FB", "HUMAN", "MGI", "RGD", "SGD", "WB", "XBXL", "XBXT", "ZFIN"), geneFieldMap(), "readmes/gene.txt", GeneFileGenerator.class, 1000, 8),
 
 	Disease("Disease", "DISEASE-ALLIANCE", List.of("gene_disease_annotation", "allele_disease_annotation", "agm_disease_annotation"),
 		List.of(new OutputSpec(Format.TSV, SplitMode.TAXON), new OutputSpec(Format.TSV, SplitMode.COMBINED), new OutputSpec(Format.JSON_RAW, SplitMode.TAXON), new OutputSpec(Format.JSON_RAW, SplitMode.COMBINED)), List.of("FB", "HUMAN", "MGI", "RGD", "SGD", "WB", "XBXL", "XBXT", "ZFIN"),
@@ -214,7 +214,8 @@ public enum FileGeneratorConfig {
 		m.put("GeneCrossReferences", "_geneCrossReferences");
 		m.put("GeneBioTypeId", "gene.geneType.curie");
 		m.put("GeneBioTypeName", "gene.geneType.name");
-		m.put("GeneAutomatedDescription", "_automatedDescription");
+		m.put("GeneAllianceAutomatedDescription", "_allianceAutomatedDescription");
+		m.put("GeneMODAutomatedDescription", "_modAutomatedDescription");
 		m.put("GeneMODDescription", "_modDescription");
 		m.put("Assembly", "_assembly");
 		m.put("Chromosome", "gene.geneGenomicLocationAssociations.0.geneGenomicLocationAssociationObject.name");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/FileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/FileGenerator.java
@@ -281,6 +281,11 @@ public abstract class FileGenerator extends Thread {
 		return null;
 	}
 
+	/** Override the `readme` field used in JSON metadata headers. Default returns null, which means use the TSV readme text. Generators that publish a LinkML schema URL (e.g. Gene) override this. */
+	protected String jsonReadmeOverride() {
+		return null;
+	}
+
 	/** Extra `# ...` lines to inject into the text header block (TSV / TXT) between Help Desk and Taxon IDs. Default empty. Orthology overrides to emit `Orthology Filter: Stringent` to match FMS. */
 	protected List<String> extraHeaderLines() {
 		return List.of();
@@ -336,11 +341,13 @@ public abstract class FileGenerator extends Thread {
 				return new TxtWriter(path, header, config.getFieldMap());
 			}
 			case JSON_RAW: {
-				Map<String, Object> meta = HeaderBuilder.buildJsonMetadata(config.getFiletypeLabel(), spec.format(), readme, taxonCuries, species, stringencyFilter(), speciesNameResolver());
+				String jsonReadme = jsonReadmeOverride() != null ? jsonReadmeOverride() : readme;
+				Map<String, Object> meta = HeaderBuilder.buildJsonMetadata(config.getFiletypeLabel(), spec.format(), jsonReadme, taxonCuries, species, stringencyFilter(), speciesNameResolver());
 				return new JsonRawWriter(path, meta);
 			}
 			case JSON_MAPPED: {
-				Map<String, Object> meta = HeaderBuilder.buildJsonMetadata(config.getFiletypeLabel(), spec.format(), readme, taxonCuries, species, stringencyFilter(), speciesNameResolver());
+				String jsonReadme = jsonReadmeOverride() != null ? jsonReadmeOverride() : readme;
+				Map<String, Object> meta = HeaderBuilder.buildJsonMetadata(config.getFiletypeLabel(), spec.format(), jsonReadme, taxonCuries, species, stringencyFilter(), speciesNameResolver());
 				return new JsonMappedWriter(path, meta, config.getFieldMap());
 			}
 			case VCF: {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/GeneFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/GeneFileGenerator.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.filegenerator.generators;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import org.alliancegenome.filegenerator.config.FileGeneratorConfig;
@@ -15,8 +16,10 @@ import lombok.extern.slf4j.Slf4j;
 public class GeneFileGenerator extends FileGenerator {
 
 	private static final String AUTOMATED_NOTE_TYPE = "automated_gene_description";
+	private static final String MOD_AUTOMATED_NOTE_TYPE = "MOD_provided_automated_gene_description";
 	private static final String MOD_NOTE_TYPE = "MOD_provided_gene_description";
 	private static final String UNIPROT_PREFIX = "UniProtKB:";
+	private static final String LINKML_README_URL = "https://alliance-genome.github.io/agr_curation_schema/Gene/";
 
 	public GeneFileGenerator(FileGeneratorConfig config) {
 		super(config);
@@ -25,6 +28,11 @@ public class GeneFileGenerator extends FileGenerator {
 	@Override
 	protected void generate() throws Exception {
 		scrollAndWrite();
+	}
+
+	@Override
+	protected String jsonReadmeOverride() {
+		return LINKML_README_URL;
 	}
 
 	@Override
@@ -54,9 +62,10 @@ public class GeneFileGenerator extends FileGenerator {
 		obj.put("_geneSynonyms", joinNodeStrings(hit, "gene.geneSynonyms", "displayText"));
 		obj.put("_geneSecondaryIds", joinNodeStrings(hit, "gene.geneSecondaryIds", "secondaryId"));
 		obj.put("_geneCrossReferences", buildCrossReferences(hit));
-		obj.put("_automatedDescription", findNoteText(hit, AUTOMATED_NOTE_TYPE));
+		obj.put("_allianceAutomatedDescription", findNoteText(hit, AUTOMATED_NOTE_TYPE));
+		obj.put("_modAutomatedDescription", findNoteText(hit, MOD_AUTOMATED_NOTE_TYPE));
 		obj.put("_modDescription", findNoteText(hit, MOD_NOTE_TYPE));
-		obj.put("_assembly", JsonPath.resolveString(hit, "gene.geneGenomicLocationAssociations.0.geneGenomicLocationAssociationObject.taxon.species.assembly_curie"));
+		obj.put("_assembly", JsonPath.resolveString(hit, "gene.taxon.species.assembly_curie"));
 
 		return hit;
 	}
@@ -77,30 +86,36 @@ public class GeneFileGenerator extends FileGenerator {
 	}
 
 	/**
-	 * Bar-separated list of every crossReferences[].referencedCurie. The single GCRP cross
-	 * reference (gene.gcrpCrossReference.referencedCurie) is matched against the list and that
-	 * entry is suffixed with " (GCRP)" so consumers can identify which UniProtKB curie is the
-	 * canonical Gene-Centric Reference Proteome entry.
+	 * Bar-separated list of crossReferences[].referencedCurie. The gene's own primaryExternalId
+	 * is filtered out, and the single GCRP cross reference (gene.gcrpCrossReference.referencedCurie)
+	 * is always emitted with a " (GCRP)" suffix — appended if it was not already present in the
+	 * crossReferences list, or tagged in-place if it was. Output is de-duplicated with a
+	 * LinkedHashSet to preserve insertion order.
 	 */
 	private static String buildCrossReferences(JsonNode hit) {
-		JsonNode arr = JsonPath.resolve(hit, "gene.crossReferences");
-		if (arr == null || !arr.isArray()) {
-			return "";
-		}
+		String selfId = JsonPath.resolveString(hit, "gene.primaryExternalId");
 		String gcrp = JsonPath.resolveString(hit, "gene.gcrpCrossReference.referencedCurie");
+		String gcrpTagged = gcrp.isEmpty() ? "" : gcrp + " (GCRP)";
+
 		List<String> out = new ArrayList<>();
-		for (JsonNode entry : arr) {
-			String curie = entry.path("referencedCurie").asText("");
-			if (curie.isEmpty()) {
-				continue;
-			}
-			if (!gcrp.isEmpty() && curie.startsWith(UNIPROT_PREFIX) && curie.equals(gcrp)) {
-				out.add(curie + " (GCRP)");
-			} else {
-				out.add(curie);
+		JsonNode arr = JsonPath.resolve(hit, "gene.crossReferences");
+		if (arr != null && arr.isArray()) {
+			for (JsonNode entry : arr) {
+				String curie = entry.path("referencedCurie").asText("");
+				if (curie.isEmpty() || curie.equals(selfId)) {
+					continue;
+				}
+				if (!gcrp.isEmpty() && curie.startsWith(UNIPROT_PREFIX) && curie.equals(gcrp)) {
+					out.add(gcrpTagged);
+				} else {
+					out.add(curie);
+				}
 			}
 		}
-		return String.join("|", out);
+		if (!gcrpTagged.isEmpty() && !gcrp.equals(selfId) && !out.contains(gcrpTagged)) {
+			out.add(gcrpTagged);
+		}
+		return String.join("|", new LinkedHashSet<>(out));
 	}
 
 	private static String findNoteText(JsonNode hit, String noteTypeName) {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/OrthologyFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/OrthologyFileGenerator.java
@@ -16,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class OrthologyFileGenerator extends FileGenerator {
 
+	private static final String LINKML_README_URL = "https://alliance-genome.github.io/agr_curation_schema/GeneToGeneOrthologyGenerated/";
+
 	public OrthologyFileGenerator(FileGeneratorConfig config) {
 		super(config);
 	}
@@ -23,6 +25,11 @@ public class OrthologyFileGenerator extends FileGenerator {
 	@Override
 	protected void generate() throws Exception {
 		scrollAndWrite();
+	}
+
+	@Override
+	protected String jsonReadmeOverride() {
+		return LINKML_README_URL;
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

Addresses Chris Grove's review feedback on the new ES-sourced download files for Gene ([SCRUM-5964](https://agr-jira.atlassian.net/browse/SCRUM-5964)) and Orthology ([SCRUM-6009](https://agr-jira.atlassian.net/browse/SCRUM-6009)).

### SCRUM-5964 (Gene download)

- Add `HUMAN` to Gene's mods whitelist so HUMAN TSV / JSON files are emitted (44,644 docs were already in ES; generator was skipping them).
- Correct `_assembly` JsonPath to `gene.taxon.species.assembly_curie` so SGD (`R64-5-1`), FB (`R6`), etc. are populated.
- Always emit the GCRP UniProtKB curie with `" (GCRP)"` suffix — appended if not already in `crossReferences`, tagged in-place if it was.
- Drop the gene's own `primaryExternalId` from `GeneCrossReferences` and dedupe with `LinkedHashSet`.
- New `jsonReadmeOverride()` hook on `FileGenerator`. Gene returns `https://alliance-genome.github.io/agr_curation_schema/Gene/` so JSON `metadata.readme` no longer duplicates the TSV readme. TSV header unaffected.
- Rename column `GeneAutomatedDescription` → `GeneAllianceAutomatedDescription`; insert new `GeneMODAutomatedDescription` between Alliance and MOD-provided (sourced from `relatedNotes.noteType.name == MOD_provided_automated_gene_description`).

### SCRUM-6009 (Orthology download)

- `OrthologyFileGenerator` overrides `jsonReadmeOverride()` to return the LinkML URL `https://alliance-genome.github.io/agr_curation_schema/GeneToGeneOrthologyGenerated/`. TSV readme unchanged.

## Test plan

- [ ] LoaderSoftwareStage build green on the merge commit
- [ ] Next FileGeneratorStage run produces HUMAN Gene TSV + JSON
- [ ] Sample SGD gene row in Gene TSV shows `R64-5-1` in the Assembly column
- [ ] Gene cross-reference cells contain `UniProtKB:... (GCRP)` and exclude the gene's own ID; no duplicates
- [ ] Three description columns present, in order: `GeneAllianceAutomatedDescription`, `GeneMODAutomatedDescription`, `GeneMODDescription`
- [ ] `jq '.metadata.readme'` on the Gene JSON returns the Gene LinkML URL
- [ ] `jq '.metadata.readme'` on the Orthology JSON returns the GeneToGeneOrthologyGenerated LinkML URL

[SCRUM-5964]: https://agr-jira.atlassian.net/browse/SCRUM-5964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCRUM-6009]: https://agr-jira.atlassian.net/browse/SCRUM-6009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ