### PR TITLE
SCRUM-1953 Fix TSV evidence-code consolidation

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -105,13 +105,18 @@ public class DiseaseFileGenerator extends FileGenerator {
 			row.put("_withOrtholog", joinWithOrthologs(pa));
 
 			JsonNode evCodes = pa.path("evidenceCodes");
-			if (evCodes.isArray() && evCodes.size() > 0) {
-				row.put("_evidenceCode", evCodes.get(0).path("curie").asText(""));
-				row.put("_evidenceCodeName", evCodes.get(0).path("name").asText(""));
-			} else {
-				row.put("_evidenceCode", "");
-				row.put("_evidenceCodeName", "");
+			List<String> curies = new ArrayList<>();
+			List<String> names = new ArrayList<>();
+			if (evCodes.isArray()) {
+				for (JsonNode ec : evCodes) {
+					String c = ec.path("curie").asText("");
+					String n = ec.path("name").asText("");
+					if (!c.isEmpty()) curies.add(c);
+					if (!n.isEmpty()) names.add(n);
+				}
 			}
+			row.put("_evidenceCode", String.join("|", curies));
+			row.put("_evidenceCodeName", String.join("|", names));
 
 			// Per-annotation reference is a single evidenceItem (not a references[] array). Prefer the PMID-style referenceID over the AGRKB curie, matching how the parent-rooted code used to choose references[0].referenceID first.
 			String reference = JsonPath.resolveString(pa, "evidenceItem.referenceID");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -111,8 +111,12 @@ public class DiseaseFileGenerator extends FileGenerator {
 				for (JsonNode ec : evCodes) {
 					String c = ec.path("curie").asText("");
 					String n = ec.path("name").asText("");
-					if (!c.isEmpty()) curies.add(c);
-					if (!n.isEmpty()) names.add(n);
+					if (!c.isEmpty()) {
+						curies.add(c);
+					}
+					if (!n.isEmpty()) {
+						names.add(n);
+					}
 				}
 			}
 			row.put("_evidenceCode", String.join("|", curies));


### PR DESCRIPTION
## Summary
- Fix disease download TSV file dropping all but the first evidence code for annotations with multiple evidence codes
- Evidence codes and names are now pipe-joined (`|`) in a single cell, matching the gene page download convention (e.g. `ECO:0000250|ECO:0000316`)
- Previously `evCodes.get(0)` hard-coded only the first code; now all codes are iterated and joined

## Test plan
- [ ] Regenerate disease download files and verify SGD:S000002812 (RPB7) row contains both `ECO:0000250` and `ECO:0000316` pipe-separated
- [ ] Verify WB:WBGene00006944 (wrn-1) annotations include all evidence codes
- [ ] Confirm annotations with a single evidence code still render correctly (no trailing pipe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)