### PR TITLE
SCRUM-5964 Gene download files — review feedback round 2

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -141,7 +141,7 @@ public enum FileGeneratorConfig {
 	private static Map<String, String> variantAlleleFieldMap() {
 		Map<String, String> m = new LinkedHashMap<>();
 		m.put("Taxon", "allele.taxon.curie");
-		m.put("SpeciesName", "allele.taxon.name");
+		m.put("SpeciesName", "allele.taxon.species.fullName");
 		m.put("AlleleId", "allele.primaryExternalId");
 		m.put("AlleleSymbol", "allele.alleleSymbol.displayText");
 		m.put("AlleleSynonyms", "_alleleSynonyms");
@@ -205,7 +205,7 @@ public enum FileGeneratorConfig {
 	private static Map<String, String> geneFieldMap() {
 		Map<String, String> m = new LinkedHashMap<>();
 		m.put("Taxon", "gene.taxon.curie");
-		m.put("SpeciesName", "gene.taxon.name");
+		m.put("SpeciesName", "gene.taxon.species.fullName");
 		m.put("GeneId", "gene.primaryExternalId");
 		m.put("GeneSymbol", "gene.geneSymbol.displayText");
 		m.put("GeneSynonyms", "_geneSynonyms");
@@ -285,7 +285,7 @@ public enum FileGeneratorConfig {
 	 */
 	private static Map<String, String> expressionFieldMap() {
 		Map<String, String> m = new LinkedHashMap<>();
-		m.put("Species", "geneExpressionAnnotation.expressionAnnotationSubject.taxon.name");
+		m.put("Species", "geneExpressionAnnotation.expressionAnnotationSubject.taxon.species.fullName");
 		m.put("SpeciesID", "geneExpressionAnnotation.expressionAnnotationSubject.taxon.curie");
 		m.put("GeneID", "geneExpressionAnnotation.expressionAnnotationSubject.primaryExternalId");
 		m.put("GeneSymbol", "geneExpressionAnnotation.expressionAnnotationSubject.geneSymbol.displayText");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.alliancegenome.filegenerator.generators.DiseaseFileGenerator;
 import org.alliancegenome.filegenerator.generators.ExpressionFileGenerator;
 import org.alliancegenome.filegenerator.generators.FileGenerator;
-import org.alliancegenome.filegenerator.generators.GeneDescriptionFileGenerator;
 import org.alliancegenome.filegenerator.generators.GeneFileGenerator;
 import org.alliancegenome.filegenerator.generators.OrthologyFileGenerator;
 import org.alliancegenome.filegenerator.generators.PhenotypeFileGenerator;

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -3,6 +3,7 @@ package org.alliancegenome.filegenerator.generators;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -65,7 +66,7 @@ public class DiseaseFileGenerator extends FileGenerator {
 			ObjectNode row = JsonNodeFactory.instance.objectNode();
 
 			row.put("_taxon", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.curie"));
-			row.put("_speciesName", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.name"));
+			row.put("_speciesName", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.species.fullName"));
 
 			String paType = JsonPath.resolveString(pa, "type");
 			String dbObjectType;
@@ -169,7 +170,9 @@ public class DiseaseFileGenerator extends FileGenerator {
 				ids.add(id);
 			}
 		}
-		return String.join("|", ids);
+		List<String> sorted = new ArrayList<>(ids);
+		Collections.sort(sorted);
+		return String.join("|", sorted);
 	}
 
 	private static String isoToYyyyMmDd(String iso) {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/GeneFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/GeneFileGenerator.java
@@ -88,7 +88,9 @@ public class GeneFileGenerator extends FileGenerator {
 	}
 
 	/**
-	 * Bar-separated list of crossReferences[].referencedCurie. The gene's own primaryExternalId is filtered out, and the single GCRP cross reference (gene.gcrpCrossReference.referencedCurie) is always emitted with a " (GCRP)" suffix — appended if it was not already present in the crossReferences list, or tagged in-place if it was. Output is de-duplicated and sorted alphabetically; the GCRP entry sorts naturally amongst the other UniProt IDs.
+	 * Bar-separated list of crossReferences[].referencedCurie, with the gene's own primaryExternalId filtered out.
+	 * The single GCRP cross reference (gene.gcrpCrossReference.referencedCurie) is always emitted with a " (GCRP)" suffix — appended if it was not already present in the crossReferences list, or tagged in-place if it was.
+	 * Output is de-duplicated and sorted alphabetically; the GCRP entry sorts naturally amongst the other UniProt IDs.
 	 */
 	private static String buildCrossReferences(JsonNode hit) {
 		String selfId = JsonPath.resolveString(hit, "gene.primaryExternalId");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/GeneFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/GeneFileGenerator.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.filegenerator.generators;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -82,15 +83,12 @@ public class GeneFileGenerator extends FileGenerator {
 				out.add(v);
 			}
 		}
+		Collections.sort(out);
 		return String.join("|", out);
 	}
 
 	/**
-	 * Bar-separated list of crossReferences[].referencedCurie. The gene's own primaryExternalId
-	 * is filtered out, and the single GCRP cross reference (gene.gcrpCrossReference.referencedCurie)
-	 * is always emitted with a " (GCRP)" suffix — appended if it was not already present in the
-	 * crossReferences list, or tagged in-place if it was. Output is de-duplicated with a
-	 * LinkedHashSet to preserve insertion order.
+	 * Bar-separated list of crossReferences[].referencedCurie. The gene's own primaryExternalId is filtered out, and the single GCRP cross reference (gene.gcrpCrossReference.referencedCurie) is always emitted with a " (GCRP)" suffix — appended if it was not already present in the crossReferences list, or tagged in-place if it was. Output is de-duplicated and sorted alphabetically; the GCRP entry sorts naturally amongst the other UniProt IDs.
 	 */
 	private static String buildCrossReferences(JsonNode hit) {
 		String selfId = JsonPath.resolveString(hit, "gene.primaryExternalId");
@@ -115,7 +113,9 @@ public class GeneFileGenerator extends FileGenerator {
 		if (!gcrpTagged.isEmpty() && !gcrp.equals(selfId) && !out.contains(gcrpTagged)) {
 			out.add(gcrpTagged);
 		}
-		return String.join("|", new LinkedHashSet<>(out));
+		List<String> deduped = new ArrayList<>(new LinkedHashSet<>(out));
+		Collections.sort(deduped);
+		return String.join("|", deduped);
 	}
 
 	private static String findNoteText(JsonNode hit, String noteTypeName) {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/OrthologyFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/OrthologyFileGenerator.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.filegenerator.generators;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -85,9 +86,11 @@ public class OrthologyFileGenerator extends FileGenerator {
 		List<String> matched = collectNames(hit, "geneToGeneOrthologyGenerated.predictionMethodsMatched");
 		List<String> notMatched = collectNames(hit, "geneToGeneOrthologyGenerated.predictionMethodsNotMatched");
 
-		// Algorithms is the pipe-delimited list of MATCHED methods, deduplicated and order-preserved.
+		// Algorithms is the pipe-delimited list of MATCHED methods, deduplicated and alphabetized.
 		Set<String> matchedDedup = new LinkedHashSet<>(matched);
-		obj.put("_algorithms", String.join("|", matchedDedup));
+		List<String> matchedSorted = new ArrayList<>(matchedDedup);
+		Collections.sort(matchedSorted);
+		obj.put("_algorithms", String.join("|", matchedSorted));
 
 		// AlgorithmsMatch is the count of distinct matched methods.
 		obj.put("_algorithmsMatch", String.valueOf(matchedDedup.size()));

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.filegenerator.generators;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -221,6 +222,7 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 				out.add(v);
 			}
 		}
+		Collections.sort(out);
 		return String.join("|", out);
 	}
 

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
@@ -41,7 +41,7 @@ public class VariantVcfFileGenerator extends FileGenerator {
 
 	private static final String CHROM_PATH = "variantList.curatedVariantGenomicLocations.variantGenomicLocationAssociationObject.name";
 	private static final String ASSEMBLY_PATH = "variantList.curatedVariantGenomicLocations.variantGenomicLocationAssociationObject.genomeAssembly.primaryExternalId";
-	private static final String SPECIES_PATH = "allele.taxon.name";
+	private static final String SPECIES_PATH = "allele.taxon.species.fullName";
 
 	private final Map<String, String> contigLinesByMod = new LinkedHashMap<>();
 


### PR DESCRIPTION
## Summary

Addresses Chris's review comments on [SCRUM-5964](https://agr-jira.atlassian.net/browse/SCRUM-5964):

- **SpeciesName field switch** — all generators (Gene, VariantAllele, Expression, Disease, VariantVCF) now read `taxon.species.fullName` instead of `taxon.name`. Fixes SGD SpeciesName carrying the "S288C" strain suffix; aligns with the pattern Orthology already uses.
- **Alphabetize non-positional TSV list fields** — Gene synonyms / secondary IDs / cross references (GCRP entry sorts naturally amongst other UniProt IDs), allele synonyms, disease with-orthologs, orthology algorithms.
- Positional/parallel list columns (VariantAllele's variantList-derived columns, within-reference MOD-curie+PMID ordering) intentionally left unsorted.

Also includes a prior commit on this branch: SCRUM-6009 — point Orthology JSON readme at the LinkML schema URL.

## Test plan

- [ ] Spot-check SGD Gene TSV: SpeciesName column shows "Saccharomyces cerevisiae" (no S288C suffix)
- [ ] Spot-check Gene TSV list columns are alphabetized; GCRP UniProt entry is sorted in place
- [ ] Spot-check VariantAllele TSV: variantList-derived columns remain positionally aligned
- [ ] Spot-check Disease TSV, Orthology TSV list columns are alphabetized

[SCRUM-5964]: https://agr-jira.atlassian.net/browse/SCRUM-5964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ