### PR TITLE
SCRUM-6020 Variants/Alleles TSV: one reference curie per ref, one row per variant

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
@@ -52,9 +52,6 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 		}
 		ObjectNode obj = (ObjectNode) hit;
 
-		String alleleTaxonCurie = JsonPath.resolveString(hit, "allele.taxon.curie");
-		String modPrefix = (alleleTaxonCurie != null && species != null) ? species.modFor(alleleTaxonCurie) : null;
-
 		// Allele synonyms — pipe-joined displayText.
 		obj.put("_alleleSynonyms", joinStrings(JsonPath.resolve(hit, "allele.alleleSynonyms"), "displayText"));
 
@@ -74,11 +71,60 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 		}
 		obj.put("_category", category);
 
-		List<String> variantIds = new ArrayList<>();
-		List<String> variantSymbols = new ArrayList<>();
+		// HasDisease / HasPhenotype: FMS uses "yes"/"-" not "true"/"false".
+		obj.put("_hasDisease", boolToYesDash(hit.path("hasDisease")));
+		obj.put("_hasPhenotype", boolToYesDash(hit.path("hasPhenotype")));
+
+		return hit;
+	}
+
+	@Override
+	protected List<JsonNode> customizeRows(JsonNode customizedHit) {
+		if (!customizedHit.isObject()) {
+			return List.of(customizedHit);
+		}
+		ObjectNode base = (ObjectNode) customizedHit;
+
+		String alleleTaxonCurie = JsonPath.resolveString(base, "allele.taxon.curie");
+		String modPrefix = (alleleTaxonCurie != null && species != null) ? species.modFor(alleleTaxonCurie) : null;
+
+		JsonNode variantList = JsonPath.resolve(base, "variantList");
+		if (variantList == null || !variantList.isArray() || variantList.size() == 0) {
+			ObjectNode row = base.deepCopy();
+			populateEmptyVariantFields(row);
+			return List.of(row);
+		}
+
+		List<JsonNode> rows = new ArrayList<>(variantList.size());
+		for (JsonNode v : variantList) {
+			ObjectNode row = base.deepCopy();
+			populateVariantFields(row, v, modPrefix);
+			rows.add(row);
+		}
+		return rows;
+	}
+
+	private static void populateEmptyVariantFields(ObjectNode row) {
+		row.put("_variantId", "");
+		row.put("_variantSymbol", "");
+		row.put("_variantSynonyms", "");
+		row.put("_variantsTypeId", "");
+		row.put("_variantsTypeName", "");
+		row.put("_variantsHgvsNames", "");
+		row.put("_assembly", "");
+		row.put("_chromosome", "");
+		row.put("_startPosition", "");
+		row.put("_endPosition", "");
+		row.put("_sequenceOfReference", "");
+		row.put("_sequenceOfVariant", "");
+		row.put("_mostSevereConsequence", "");
+		row.put("_variantAffectedGeneId", "");
+		row.put("_variantAffectedGeneSymbol", "");
+		row.put("_variantInformationReference", "");
+	}
+
+	private static void populateVariantFields(ObjectNode row, JsonNode v, String modPrefix) {
 		List<String> variantSynonyms = new ArrayList<>();
-		List<String> variantTypeIds = new ArrayList<>();
-		List<String> variantTypeNames = new ArrayList<>();
 		List<String> hgvsNames = new ArrayList<>();
 		List<String> assemblies = new ArrayList<>();
 		List<String> chromosomes = new ArrayList<>();
@@ -91,122 +137,107 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 		List<String> affectedGeneSymbols = new ArrayList<>();
 		List<String> referenceCuries = new ArrayList<>();
 
-		if (variantList != null && variantList.isArray()) {
-			for (JsonNode v : variantList) {
-				addIfPresent(variantIds, v.path("primaryExternalId").asText(""));
-				addIfPresent(variantSymbols, v.path("variantSymbol").path("displayText").asText(""));
-				addIfPresent(variantTypeIds, v.path("variantType").path("curie").asText(""));
-				addIfPresent(variantTypeNames, v.path("variantType").path("name").asText(""));
-
-				// VariantInformationReference — for each reference, emit exactly ONE curie. Priority: PMID, then MOD curie matching the file's MOD, then any paper-prefixed MOD curie. Skips DOI / PMCID / etc.
-				JsonNode refs = v.path("references");
-				if (refs.isArray()) {
-					for (JsonNode r : refs) {
-						JsonNode xrefs = r.path("crossReferences");
-						if (xrefs.isArray()) {
-							String pmid = null;
-							String modMatch = null;
-							String anyPaper = null;
-							for (JsonNode x : xrefs) {
-								String c = x.path("referencedCurie").asText("");
-								if (c.isEmpty()) {
-									continue;
-								}
-								if (c.startsWith("PMID:")) {
-									if (pmid == null) {
-										pmid = c;
-									}
-								} else if (isPaperCurie(c)) {
-									if (modPrefix != null && modMatch == null && c.startsWith(modPrefix + ":")) {
-										modMatch = c;
-									}
-									if (anyPaper == null) {
-										anyPaper = c;
-									}
-								}
+		// VariantInformationReference — for each reference, emit exactly ONE curie. Priority: PMID, then MOD curie matching the file's MOD, then any paper-prefixed MOD curie. Skips DOI / PMCID / etc.
+		JsonNode refs = v.path("references");
+		if (refs.isArray()) {
+			for (JsonNode r : refs) {
+				JsonNode xrefs = r.path("crossReferences");
+				if (xrefs.isArray()) {
+					String pmid = null;
+					String modMatch = null;
+					String anyPaper = null;
+					for (JsonNode x : xrefs) {
+						String c = x.path("referencedCurie").asText("");
+						if (c.isEmpty()) {
+							continue;
+						}
+						if (c.startsWith("PMID:")) {
+							if (pmid == null) {
+								pmid = c;
 							}
-							String chosen;
-							if (pmid != null) {
-								chosen = pmid;
-							} else if (modMatch != null) {
-								chosen = modMatch;
-							} else {
-								chosen = anyPaper;
+						} else if (isPaperCurie(c)) {
+							if (modPrefix != null && modMatch == null && c.startsWith(modPrefix + ":")) {
+								modMatch = c;
 							}
-							if (chosen != null) {
-								referenceCuries.add(chosen);
+							if (anyPaper == null) {
+								anyPaper = c;
 							}
 						}
 					}
-				}
-
-				JsonNode locs = v.path("curatedVariantGenomicLocations");
-				if (locs.isArray()) {
-					for (JsonNode loc : locs) {
-						String hgvs = loc.path("hgvs").asText("");
-						String chromName = loc.path("variantGenomicLocationAssociationObject").path("name").asText("");
-						addIfPresent(hgvsNames, hgvs);
-						addIfPresent(assemblies, loc.path("variantGenomicLocationAssociationObject").path("genomeAssembly").path("primaryExternalId").asText(""));
-						addIfPresent(chromosomes, chromName);
-						// VariantSynonyms = RefSeq-form hgvs + chromosome-level form (RefSeq accession swapped for chromosome name).
-						if (!hgvs.isEmpty()) {
-							addIfPresent(variantSynonyms, hgvs);
-							int colonIdx = hgvs.indexOf(':');
-							if (!chromName.isEmpty() && colonIdx > 0) {
-								addIfPresent(variantSynonyms, chromName + hgvs.substring(colonIdx));
-							}
-						}
-						String s = loc.path("start").asText("");
-						String e = loc.path("end").asText("");
-						addIfPresent(startPositions, s);
-						addIfPresent(endPositions, e);
-						addIfPresent(referenceSeqs, loc.path("referenceSequence").asText(""));
-						addIfPresent(variantSeqs, loc.path("variantSequence").asText(""));
-
-						JsonNode msc = loc.path("mostSevereConsequence");
-						String consequenceName = msc.path("variantConsequence").path("name").asText("");
-						if (consequenceName.isEmpty()) {
-							consequenceName = msc.path("name").asText("");
-						}
-						addIfPresent(consequences, consequenceName);
-
-						JsonNode txGenes = msc.path("variantTranscript").path("transcriptGeneAssociations");
-						if (txGenes.isArray()) {
-							for (JsonNode tg : txGenes) {
-								JsonNode g = tg.path("transcriptGeneAssociationObject");
-								addIfPresent(affectedGeneIds, g.path("primaryExternalId").asText(""));
-								addIfPresent(affectedGeneSymbols, g.path("geneSymbol").path("displayText").asText(""));
-							}
-						}
+					String chosen;
+					if (pmid != null) {
+						chosen = pmid;
+					} else if (modMatch != null) {
+						chosen = modMatch;
+					} else {
+						chosen = anyPaper;
+					}
+					if (chosen != null) {
+						referenceCuries.add(chosen);
 					}
 				}
 			}
 		}
 
-		obj.put("_variantId", joinList(variantIds));
-		obj.put("_variantSymbol", joinList(variantSymbols));
-		obj.put("_variantSynonyms", joinList(variantSynonyms));
-		obj.put("_variantsTypeId", joinList(variantTypeIds));
-		obj.put("_variantsTypeName", joinList(variantTypeNames));
-		obj.put("_variantsHgvsNames", joinList(hgvsNames));
-		obj.put("_assembly", joinList(dedup(assemblies)));
-		obj.put("_chromosome", joinList(dedup(chromosomes)));
-		obj.put("_startPosition", joinList(startPositions));
-		obj.put("_endPosition", joinList(endPositions));
-		obj.put("_sequenceOfReference", joinList(referenceSeqs));
-		obj.put("_sequenceOfVariant", joinList(variantSeqs));
-		obj.put("_mostSevereConsequence", joinList(dedup(consequences)));
-		obj.put("_variantAffectedGeneId", joinList(dedup(affectedGeneIds)));
-		obj.put("_variantAffectedGeneSymbol", joinList(dedup(affectedGeneSymbols)));
+		JsonNode locs = v.path("curatedVariantGenomicLocations");
+		if (locs.isArray()) {
+			for (JsonNode loc : locs) {
+				String hgvs = loc.path("hgvs").asText("");
+				String chromName = loc.path("variantGenomicLocationAssociationObject").path("name").asText("");
+				addIfPresent(hgvsNames, hgvs);
+				addIfPresent(assemblies, loc.path("variantGenomicLocationAssociationObject").path("genomeAssembly").path("primaryExternalId").asText(""));
+				addIfPresent(chromosomes, chromName);
+				// VariantSynonyms = RefSeq-form hgvs + chromosome-level form (RefSeq accession swapped for chromosome name).
+				if (!hgvs.isEmpty()) {
+					addIfPresent(variantSynonyms, hgvs);
+					int colonIdx = hgvs.indexOf(':');
+					if (!chromName.isEmpty() && colonIdx > 0) {
+						addIfPresent(variantSynonyms, chromName + hgvs.substring(colonIdx));
+					}
+				}
+				String s = loc.path("start").asText("");
+				String e = loc.path("end").asText("");
+				addIfPresent(startPositions, s);
+				addIfPresent(endPositions, e);
+				addIfPresent(referenceSeqs, loc.path("referenceSequence").asText(""));
+				addIfPresent(variantSeqs, loc.path("variantSequence").asText(""));
+
+				JsonNode msc = loc.path("mostSevereConsequence");
+				String consequenceName = msc.path("variantConsequence").path("name").asText("");
+				if (consequenceName.isEmpty()) {
+					consequenceName = msc.path("name").asText("");
+				}
+				addIfPresent(consequences, consequenceName);
+
+				JsonNode txGenes = msc.path("variantTranscript").path("transcriptGeneAssociations");
+				if (txGenes.isArray()) {
+					for (JsonNode tg : txGenes) {
+						JsonNode g = tg.path("transcriptGeneAssociationObject");
+						addIfPresent(affectedGeneIds, g.path("primaryExternalId").asText(""));
+						addIfPresent(affectedGeneSymbols, g.path("geneSymbol").path("displayText").asText(""));
+					}
+				}
+			}
+		}
+
+		row.put("_variantId", v.path("primaryExternalId").asText(""));
+		row.put("_variantSymbol", v.path("variantSymbol").path("displayText").asText(""));
+		row.put("_variantSynonyms", joinList(variantSynonyms));
+		row.put("_variantsTypeId", v.path("variantType").path("curie").asText(""));
+		row.put("_variantsTypeName", v.path("variantType").path("name").asText(""));
+		row.put("_variantsHgvsNames", joinList(hgvsNames));
+		row.put("_assembly", joinList(dedup(assemblies)));
+		row.put("_chromosome", joinList(dedup(chromosomes)));
+		row.put("_startPosition", joinList(startPositions));
+		row.put("_endPosition", joinList(endPositions));
+		row.put("_sequenceOfReference", joinList(referenceSeqs));
+		row.put("_sequenceOfVariant", joinList(variantSeqs));
+		row.put("_mostSevereConsequence", joinList(dedup(consequences)));
+		row.put("_variantAffectedGeneId", joinList(dedup(affectedGeneIds)));
+		row.put("_variantAffectedGeneSymbol", joinList(dedup(affectedGeneSymbols)));
 		// Between references: comma-join (matches FMS); each reference contributes exactly one curie (PMID preferred, then file-MOD curie, then any paper curie).
 		List<String> uniqueRefs = dedup(referenceCuries);
-		obj.put("_variantInformationReference", uniqueRefs.isEmpty() ? "" : String.join(",", uniqueRefs));
-
-		// HasDisease / HasPhenotype: FMS uses "yes"/"-" not "true"/"false".
-		obj.put("_hasDisease", boolToYesDash(hit.path("hasDisease")));
-		obj.put("_hasPhenotype", boolToYesDash(hit.path("hasPhenotype")));
-
-		return hit;
+		row.put("_variantInformationReference", uniqueRefs.isEmpty() ? "" : String.join(",", uniqueRefs));
 	}
 
 	// Cross-reference prefixes that count as a paper identifier per ReferenceConstants.primaryXrefOrder; everything else (DOI, PMCID, ISBN, ...) is skipped.

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
@@ -52,6 +52,9 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 		}
 		ObjectNode obj = (ObjectNode) hit;
 
+		String alleleTaxonCurie = JsonPath.resolveString(hit, "allele.taxon.curie");
+		String modPrefix = (alleleTaxonCurie != null && species != null) ? species.modFor(alleleTaxonCurie) : null;
+
 		// Allele synonyms — pipe-joined displayText.
 		obj.put("_alleleSynonyms", joinStrings(JsonPath.resolve(hit, "allele.alleleSynonyms"), "displayText"));
 
@@ -95,30 +98,43 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 				addIfPresent(variantTypeIds, v.path("variantType").path("curie").asText(""));
 				addIfPresent(variantTypeNames, v.path("variantType").path("name").asText(""));
 
-				// VariantInformationReference — for each reference, pipe-join MOD paper curie + PMID (in that order). Skips DOI / PMCID / etc.
+				// VariantInformationReference — for each reference, emit exactly ONE curie. Priority: PMID, then MOD curie matching the file's MOD, then any paper-prefixed MOD curie. Skips DOI / PMCID / etc.
 				JsonNode refs = v.path("references");
 				if (refs.isArray()) {
 					for (JsonNode r : refs) {
 						JsonNode xrefs = r.path("crossReferences");
 						if (xrefs.isArray()) {
-							List<String> ordered = new ArrayList<>();
 							String pmid = null;
+							String modMatch = null;
+							String anyPaper = null;
 							for (JsonNode x : xrefs) {
 								String c = x.path("referencedCurie").asText("");
 								if (c.isEmpty()) {
 									continue;
 								}
 								if (c.startsWith("PMID:")) {
-									pmid = c;
+									if (pmid == null) {
+										pmid = c;
+									}
 								} else if (isPaperCurie(c)) {
-									ordered.add(c);
+									if (modPrefix != null && modMatch == null && c.startsWith(modPrefix + ":")) {
+										modMatch = c;
+									}
+									if (anyPaper == null) {
+										anyPaper = c;
+									}
 								}
 							}
+							String chosen;
 							if (pmid != null) {
-								ordered.add(pmid);
+								chosen = pmid;
+							} else if (modMatch != null) {
+								chosen = modMatch;
+							} else {
+								chosen = anyPaper;
 							}
-							if (!ordered.isEmpty()) {
-								referenceCuries.add(String.join("|", ordered));
+							if (chosen != null) {
+								referenceCuries.add(chosen);
 							}
 						}
 					}
@@ -182,7 +198,7 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 		obj.put("_mostSevereConsequence", joinList(dedup(consequences)));
 		obj.put("_variantAffectedGeneId", joinList(dedup(affectedGeneIds)));
 		obj.put("_variantAffectedGeneSymbol", joinList(dedup(affectedGeneSymbols)));
-		// Between references: comma-join (matches FMS); within a reference, MOD curie and PMID are pipe-joined.
+		// Between references: comma-join (matches FMS); each reference contributes exactly one curie (PMID preferred, then file-MOD curie, then any paper curie).
 		List<String> uniqueRefs = dedup(referenceCuries);
 		obj.put("_variantInformationReference", uniqueRefs.isEmpty() ? "" : String.join(",", uniqueRefs));
 


### PR DESCRIPTION
Addresses reviewer feedback on SCRUM-6020 Variants/Alleles download files.

## Summary

**1. `VariantInformationReference` column — one curie per reference** (`bfcfa161a`)
Replaces the bar-joined `MOD|PMID` cluster per reference with a single chosen curie. Selection priority:
- PMID
- MOD curie matching the file's MOD/species
- Any paper-prefixed MOD curie

References remain comma-joined across a row.

**2. One TSV row per variant for multivariant alleles** (`45a9f3085`)
Restores the pre-existing behavior: a single allele with N variants now produces N TSV rows. Allele-level columns repeat across the rows; each row carries the scalar values for one variant. Allele-only entries (`Category=allele`) still produce exactly one row with empty per-variant fields.

Implemented by overriding `customizeRows()` in `VariantAlleleFileGenerator` — `FileGenerator.dispatch()` already iterates that hook. JSON_RAW output is unchanged; `variantList[]` is still serialized intact.

## Why

Reviewer feedback from Chris Grove on SCRUM-6020:
- TSV reference cells were too dense — wanted one identifier per reference.
- Multivariant alleles (e.g. MGI:3761357 / `Vegfa<sup>tm3Gne</sup>`, 8 variants) were collapsing onto a single row in the new generator; the old file produced one row per variant and that behavior needs to be preserved.

## Test plan
- [x] `mvn -pl agr_file_generator -am clean compile` passes
- [x] Regenerated TSVs for all 6 MODs (MGI, WB, ZFIN, FB, SGD, RGD):
  - No pipes remain in `VariantInformationReference` cells.
  - PMID preferred; MOD fallback uses the file's MOD prefix (MGI:, WB:WBPaper..., ZFIN:ZDB-PUB-...).
  - Multi-reference rows comma-joined cleanly.
- [x] MGI:3761357 (`Vegfa<sup>tm3Gne</sup>`) produces 8 rows, one per variant, with allele-level columns repeated.
- [x] `Category=allele` rows (no variants) still produce exactly one row with empty per-variant fields.
- [x] No leftover aggregation pipes in any per-variant scalar column.