### PR TITLE
SCRUM-5964 add GeneName column and case-insensitive list sort to Gene TSV

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -206,6 +206,7 @@ public enum FileGeneratorConfig {
 		m.put("Taxon", "gene.taxon.curie");
 		m.put("SpeciesName", "gene.taxon.species.fullName");
 		m.put("GeneId", "gene.primaryExternalId");
+		m.put("GeneName", "gene.geneFullName.displayText");
 		m.put("GeneSymbol", "gene.geneSymbol.displayText");
 		m.put("GeneSynonyms", "_geneSynonyms");
 		m.put("GeneSystematicName", "gene.geneSystematicName.displayText");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/GeneFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/GeneFileGenerator.java
@@ -1,7 +1,6 @@
 package org.alliancegenome.filegenerator.generators;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -83,7 +82,7 @@ public class GeneFileGenerator extends FileGenerator {
 				out.add(v);
 			}
 		}
-		Collections.sort(out);
+		out.sort(String.CASE_INSENSITIVE_ORDER);
 		return String.join("|", out);
 	}
 
@@ -116,7 +115,7 @@ public class GeneFileGenerator extends FileGenerator {
 			out.add(gcrpTagged);
 		}
 		List<String> deduped = new ArrayList<>(new LinkedHashSet<>(out));
-		Collections.sort(deduped);
+		deduped.sort(String.CASE_INSENSITIVE_ORDER);
 		return String.join("|", deduped);
 	}
 


### PR DESCRIPTION
## Summary
- Add `GeneName` column (sourced from `gene.geneFullName.displayText`) between `GeneId` and `GeneSymbol` in all Gene TSV outputs (per-MOD + COMBINED).
- Switch synonyms, secondary IDs, and cross references to case-insensitive sort so e.g. `eL40` interleaves with `L40A`/`L40e` instead of trailing all-uppercase entries.

Addresses the outstanding items from Chris's most recent comment on [SCRUM-5964](https://agr-jira.atlassian.net/browse/SCRUM-5964).

## Verification
Regenerated all 20 Gene files locally and verified against stage ES data:
- GeneName column lands between GeneId and GeneSymbol in every TSV.
- BRCA1 -> "BRCA1 DNA repair associated", TP53 -> "tumor protein p53", etc.
- Coverage: 100% populated for HUMAN/MGI/ZFIN/SGD/XBXT/XBXL; 72-81% for RGD/FB/WB (empties are genuinely nameless predicted loci like `CG31828`, `AABR07001519.1`, `F53F10.6`).
- Synonym sort: SGD entry that was previously `CEP52A|L40A|L40e|UB11|UBI1|eL40` is now `CEP52A|eL40|L40A|L40e|UB11|UBI1`.

## Test plan
- [x] `mvn -pl agr_file_generator -am clean package` succeeds
- [x] Gene TSVs regenerated locally, GeneName populated for well-known genes
- [x] Synonym sort verified case-insensitive on SGD sample

[SCRUM-5964]: https://agr-jira.atlassian.net/browse/SCRUM-5964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ