### PR TITLE
SCRUM-6007 Expression file generator: emit all PMIDs in Reference column

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -309,7 +309,7 @@ public enum FileGeneratorConfig {
 		// resolves the synthetic field.
 		m.put("SourceURL", "_sourceUrl");
 		m.put("Source", "geneExpressionAnnotation.dataProvider.abbreviation");
-		m.put("Reference", "referenceId.0");
+		m.put("Reference", "_reference");
 		return m;
 	}
 }

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/ExpressionFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/ExpressionFileGenerator.java
@@ -59,6 +59,9 @@ public class ExpressionFileGenerator extends FileGenerator {
 		obj.put("_cellularComponentQualifierIds", joinField(hit, wherePath + ".cellularComponentQualifiers", "curie"));
 		obj.put("_cellularComponentQualifierNames", joinField(hit, wherePath + ".cellularComponentQualifiers", "name"));
 
+		// Pipe-join the referenceId array; the consolidation upstream in agr_curation packs all PMIDs supporting one annotation into this list.
+		obj.put("_reference", joinScalarArray(hit, "referenceId"));
+
 		return hit;
 	}
 
@@ -70,6 +73,21 @@ public class ExpressionFileGenerator extends FileGenerator {
 		LinkedHashSet<String> values = new LinkedHashSet<>();
 		for (JsonNode element : array) {
 			String value = element.path(fieldName).asText("");
+			if (!value.isEmpty()) {
+				values.add(value);
+			}
+		}
+		return String.join(QUALIFIER_DELIMITER, values);
+	}
+
+	private static String joinScalarArray(JsonNode root, String arrayPath) {
+		JsonNode array = JsonPath.resolve(root, arrayPath);
+		if (array == null || !array.isArray() || array.size() == 0) {
+			return "";
+		}
+		LinkedHashSet<String> values = new LinkedHashSet<>();
+		for (JsonNode element : array) {
+			String value = element.asText("");
 			if (!value.isEmpty()) {
 				values.add(value);
 			}


### PR DESCRIPTION
## Summary

Fixes issue #1 from [SCRUM-6007](https://agr-jira.atlassian.net/browse/SCRUM-6007): multi-publication expression annotations were losing PMIDs 2..N in the TSV.

Upstream consolidation in `agr_curation`'s `GeneExpressionDocumentBuilder` packs multiple PMIDs supporting a single `gene + location + stage + assay` annotation into the `referenceId` array on the indexed document. The previous Reference column mapping read only `referenceId[0]`, silently dropping the rest. This switches the column to a new `_reference` synthetic field built in `ExpressionFileGenerator.customizeRow()` that pipe-joins the full `referenceId` list.

## Verification

Confirmed locally against the two cases Chris flagged on the ticket:

| Case | Before | After |
|---|---|---|
| `RGD:2366` Abcc2 / apical plasma membrane | `PMID:28842383` (dropped `PMID:8599091`) | `PMID:28842383\|PMID:8599091` |
| `RGD:628684` Acox2 / peroxisome | `PMID:8947475` (dropped 2 of 3) | `PMID:8947475\|PMID:1400324\|PMID:8654595` |

## Test plan

- [ ] Regenerate EXPRESSION files in stage and spot-check the Reference column for multi-PMID annotations
- [ ] Confirm no regression on single-PMID rows (column still emits a single PMID with no trailing delimiter)

[SCRUM-6007]: https://agr-jira.atlassian.net/browse/SCRUM-6007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ