### PR TITLE
KANBAN-1322 add disease ontology browser API endpoints

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.alliancegenome.api.entity.AGMDiseaseAnnotationDocument;
 import org.alliancegenome.api.entity.AlleleDiseaseAnnotationDocument;
+import org.alliancegenome.api.entity.DiseaseTermStub;
 import org.alliancegenome.api.entity.GeneDiseaseAnnotationDocument;
 import org.alliancegenome.api.rest.interfaces.DiseaseRESTInterface;
 import org.alliancegenome.api.service.DiseaseESService;
@@ -34,6 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -505,6 +507,42 @@ public class DiseaseController implements DiseaseRESTInterface {
 		
 		JsonResultResponse<AGMDiseaseAnnotationDocument> response = getDiseaseAnnotationsForModel(diseaseID, null, null, null, null, null, null, null, null, null, null, associationType, null, null, null, null, null);
 		return response.getTotal();
+	}
+
+	@Override
+	public List<DiseaseTermStub> getDiseaseAncestors(String diseaseID) {
+		return diseaseESService.getAncestors(diseaseID);
+	}
+
+
+	private static final int MAX_BATCH_IDS = 500;
+
+	@Override
+	public java.util.Map<String, Object> getBatchDiseaseTerms(String ids) {
+		if (ids == null || ids.isBlank()) return java.util.Collections.emptyMap();
+		java.util.List<String> idList = java.util.Arrays.stream(ids.split(","))
+			.map(String::trim)
+			.filter(s -> !s.isEmpty())
+			.distinct()
+			.toList();
+		if (idList.size() > MAX_BATCH_IDS) {
+			throw new BadRequestException("ids exceeds maximum of " + MAX_BATCH_IDS);
+		}
+		return diseaseESService.getBatchTerms(idList);
+	}
+
+	@Override
+	public java.util.Map<String, java.util.Map<String, Long>> getBatchDiseaseCounts(String ids) {
+		if (ids == null || ids.isBlank()) return java.util.Collections.emptyMap();
+		java.util.List<String> idList = java.util.Arrays.stream(ids.split(","))
+			.map(String::trim)
+			.filter(s -> !s.isEmpty())
+			.distinct()
+			.toList();
+		if (idList.size() > MAX_BATCH_IDS) {
+			throw new BadRequestException("ids exceeds maximum of " + MAX_BATCH_IDS);
+		}
+		return diseaseESService.getBatchCounts(idList);
 	}
 
 	@Override

--- a/agr_api/src/main/java/org/alliancegenome/api/entity/DiseaseTermStub.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/entity/DiseaseTermStub.java
@@ -1,0 +1,31 @@
+package org.alliancegenome.api.entity;
+
+public class DiseaseTermStub {
+
+	private String curie;
+	private String name;
+
+	public DiseaseTermStub() {
+	}
+
+	public DiseaseTermStub(String curie, String name) {
+		this.curie = curie;
+		this.name = name;
+	}
+
+	public String getCurie() {
+		return curie;
+	}
+
+	public void setCurie(String curie) {
+		this.curie = curie;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/DiseaseRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/DiseaseRESTInterface.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.alliancegenome.api.entity.AGMDiseaseAnnotationDocument;
 import org.alliancegenome.api.entity.AlleleDiseaseAnnotationDocument;
+import org.alliancegenome.api.entity.DiseaseTermStub;
 import org.alliancegenome.api.entity.GeneDiseaseAnnotationDocument;
 import org.alliancegenome.cache.repository.helper.JsonResultResponse;
 import org.alliancegenome.curation_api.model.document.es.DiseaseSummaryDocument;
@@ -123,6 +124,27 @@ public interface DiseaseRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "filter.associationType", description = "filter by association type") @QueryParam("filter.associationType") String associationType,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.diseaseQualifier", description = "diseaseQualifier", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.diseaseQualifier") String diseaseQualifier,
 		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING)) @QueryParam("asc") String asc);
+
+	@GET
+	@Path("/batch")
+	@Operation(summary = "Batch fetch DiseaseSummaryDocument for many disease ids")
+	@APIResponses(value = { @APIResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	java.util.Map<String, Object> getBatchDiseaseTerms(
+		@Parameter(in = ParameterIn.QUERY, name = "ids", description = "Comma-separated disease IDs", required = true, schema = @Schema(type = SchemaType.STRING)) @QueryParam("ids") String ids);
+
+	@GET
+	@Path("/counts")
+	@Operation(summary = "Batch counts of gene/model/allele annotations for many disease ids")
+	@APIResponses(value = { @APIResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	java.util.Map<String, java.util.Map<String, Long>> getBatchDiseaseCounts(
+		@Parameter(in = ParameterIn.QUERY, name = "ids", description = "Comma-separated disease IDs", required = true, schema = @Schema(type = SchemaType.STRING)) @QueryParam("ids") String ids);
+
+	@GET
+	@Path("/{id}/ancestors")
+	@Operation(summary = "Retrieve the ancestor chain for a given disease id (root-first)")
+	@APIResponses(value = { @APIResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	java.util.List<DiseaseTermStub> getDiseaseAncestors(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Disease ID, e.g. DOID:14330", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id);
 
 	@GET
 	@Path("/{id}/genes/download")

--- a/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
@@ -20,7 +20,9 @@ import org.alliancegenome.api.entity.DiseaseAnnotationDocument;
 import org.alliancegenome.api.entity.DiseaseEntitySubgroupSlim;
 import org.alliancegenome.api.entity.DiseaseRibbonEntity;
 import org.alliancegenome.api.entity.DiseaseRibbonSummary;
+import org.alliancegenome.api.entity.DiseaseTermStub;
 import org.alliancegenome.api.entity.GeneDiseaseAnnotationDocument;
+import org.alliancegenome.es.index.site.dao.SearchDAO;
 import org.alliancegenome.api.service.helper.APIServiceHelper;
 import org.alliancegenome.cache.repository.helper.JsonResultResponse;
 import org.alliancegenome.core.api.service.DiseaseRibbonService;
@@ -35,13 +37,23 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 
 import jakarta.enterprise.context.RequestScoped;
+import lombok.extern.slf4j.Slf4j;
 
 
+@Slf4j
 @RequestScoped
 public class DiseaseESService extends ESService {
 
@@ -468,6 +480,105 @@ public class DiseaseESService extends ESService {
 		result = formatAT(assoList);
 		return result;
 	}
+
+	private static final String DISEASE_ROOT = "DOID:4";
+	private static final int MAX_ANCESTOR_DEPTH = 30;
+
+	public List<DiseaseTermStub> getAncestors(String diseaseID) {
+		List<DiseaseTermStub> chain = new ArrayList<>();
+		Set<String> visited = new HashSet<>();
+		String current = diseaseID;
+		for (int i = 0; i < MAX_ANCESTOR_DEPTH; i++) {
+			if (current == null || !visited.add(current)) break;
+			DiseaseSummaryDocument doc = getById(current);
+			if (doc == null || doc.getDoTerm() == null) break;
+			chain.add(new DiseaseTermStub(doc.getDoTerm().getCurie(), doc.getDoTerm().getName()));
+			if (DISEASE_ROOT.equals(current)) break;
+			if (doc.getParents() == null || doc.getParents().isEmpty()) break;
+			current = doc.getParents().iterator().next().getCurie();
+		}
+		java.util.Collections.reverse(chain);
+		return chain;
+	}
+
+	private static final SearchDAO COUNTS_SEARCH_DAO = new SearchDAO();
+	private static final SearchDAO BATCH_TERMS_SEARCH_DAO = new SearchDAO();
+
+	public java.util.Map<String, Object> getBatchTerms(java.util.List<String> diseaseIds) {
+		java.util.LinkedHashMap<String, Object> result = new java.util.LinkedHashMap<>();
+		if (diseaseIds == null || diseaseIds.isEmpty()) return result;
+
+		BoolQueryBuilder bool = boolQuery()
+			.filter(new TermQueryBuilder("category", "disease_summary"))
+			.filter(new TermsQueryBuilder("doTerm.curie.keyword", diseaseIds));
+
+		SearchResponse response = BATCH_TERMS_SEARCH_DAO.performQuery(
+			(QueryBuilder) bool, java.util.List.of(), null, java.util.List.of(),
+			diseaseIds.size(), 0, new HighlightBuilder(), null, false);
+
+		for (SearchHit hit : response.getHits().getHits()) {
+			try {
+				DiseaseSummaryDocument doc = mapper.readValue(hit.getSourceAsString(), DiseaseSummaryDocument.class);
+				String curie = doc.getDoTerm() != null ? doc.getDoTerm().getCurie() : null;
+				if (curie != null) result.put(curie, doc);
+			} catch (Exception e) {
+				log.error("Failed to deserialize disease term in batch (id={})", hit.getId(), e);
+			}
+		}
+		return result;
+	}
+
+
+	private static final java.util.List<String[]> COUNT_CATEGORIES = java.util.List.of(
+		new String[] { "genes", "gene_disease_annotation" },
+		new String[] { "models", "agm_disease_annotation" },
+		new String[] { "alleles", "allele_disease_annotation" }
+	);
+
+	public java.util.Map<String, java.util.Map<String, Long>> getBatchCounts(java.util.List<String> diseaseIds) {
+		java.util.Map<String, java.util.Map<String, Long>> result = new java.util.LinkedHashMap<>();
+		for (String id : diseaseIds) {
+			java.util.Map<String, Long> zeros = new java.util.LinkedHashMap<>();
+			for (String[] pair : COUNT_CATEGORIES) zeros.put(pair[0], 0L);
+			result.put(id, zeros);
+		}
+		if (diseaseIds.isEmpty()) return result;
+		String[] idArray = diseaseIds.toArray(new String[0]);
+		for (String[] pair : COUNT_CATEGORIES) {
+			String key = pair[0];
+			String category = pair[1];
+			java.util.Map<String, Long> counts = countByDisease(category, idArray);
+			for (String id : diseaseIds) {
+				Long c = counts.get(id);
+				if (c != null) result.get(id).put(key, c);
+			}
+		}
+		return result;
+	}
+
+	private java.util.Map<String, Long> countByDisease(String category, String[] diseaseIds) {
+		BoolQueryBuilder bool = boolQuery()
+			.filter(new TermQueryBuilder("category", category))
+			.filter(new TermsQueryBuilder("parentSlimIDs.keyword", diseaseIds));
+
+		AggregationBuilder agg = AggregationBuilders
+			.terms("by_disease")
+			.field("parentSlimIDs.keyword")
+			.includeExclude(new IncludeExclude(diseaseIds, null))
+			.size(Math.max(diseaseIds.length, 1));
+
+		SearchResponse response = COUNTS_SEARCH_DAO.performQuery(
+			(QueryBuilder) bool, java.util.List.of(agg), null, java.util.List.of("subject"),
+			0, 0, new HighlightBuilder(), null, false);
+
+		java.util.Map<String, Long> counts = new java.util.HashMap<>();
+		ParsedStringTerms terms = response.getAggregations().get("by_disease");
+		for (Terms.Bucket bucket : terms.getBuckets()) {
+			counts.put(bucket.getKeyAsString(), bucket.getDocCount());
+		}
+		return counts;
+	}
+
 
 	private String formatAT(List<String> list) {
 		if (list.size() == 0) {


### PR DESCRIPTION
## Summary
New endpoints powering the disease ontology browser UI (matching `feature/KANBAN-1322` in agr_ui):

- `GET /api/disease/batch?ids=...` - batch fetch `DiseaseSummaryDocument` for many curies in one ES round-trip
- `GET /api/disease/counts?ids=...` - gene/model/allele annotation counts per disease curie
- `GET /api/disease/{id}/ancestors` - root-first ancestor chain (capped at depth 30, cycle-safe)

Both batch endpoints reject requests with more than 500 ids (`BadRequestException`) so a large `ids` list cannot blow up an ES query.

## Test plan
- [ ] `curl 'http://stage.alliancegenome.org/api/disease/batch?ids=DOID:14330,DOID:1287'` returns a map of curie -> document
- [ ] `curl 'http://stage.alliancegenome.org/api/disease/counts?ids=DOID:14330,DOID:1287'` returns `{ DOID:14330: { genes, models, alleles }, ... }`
- [ ] `curl 'http://stage.alliancegenome.org/api/disease/DOID:14330/ancestors'` returns the ancestor chain root-first
- [ ] Sending 501 comma-separated ids to either batch endpoint returns HTTP 400
- [ ] Swagger UI at `/q/swagger-ui/` lists the new endpoints

Generated with Claude Code (https://claude.com/claude-code)
