### PR TITLE
KANBAN-678 add reference-scoped data endpoints for reference report

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
@@ -96,11 +96,13 @@ public class LiteratureController implements LiteratureRESTInterface {
 																									String species,
 																									String asc) {
 		long startTime = System.currentTimeMillis();
+		List<String> xrefs = splitCommas(crossReferences);
+		requireCrossReferences(xrefs);
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("geneExpressionAnnotation.expressionAnnotationSubject.taxon.species.fullName.keyword", species);
 		validate(pagination);
 		try {
-			return timed(referenceDataESService.getExpressionAnnotations(splitCommas(crossReferences), pagination), startTime);
+			return timed(referenceDataESService.getExpressionAnnotations(xrefs, pagination), startTime);
 		} catch (Exception e) {
 			throw restError("Error while retrieving expression annotations by reference", e);
 		}
@@ -115,11 +117,13 @@ public class LiteratureController implements LiteratureRESTInterface {
 																									String species,
 																									String asc) {
 		long startTime = System.currentTimeMillis();
+		List<String> xrefs = splitCommas(crossReferences);
+		requireCrossReferences(xrefs);
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("geneMolecularInteraction.geneAssociationSubject.taxon.species.fullName.keyword", species);
 		validate(pagination);
 		try {
-			return timed(referenceDataESService.getMolecularInteractions(splitCommas(crossReferences), pagination), startTime);
+			return timed(referenceDataESService.getMolecularInteractions(xrefs, pagination), startTime);
 		} catch (Exception e) {
 			throw restError("Error while retrieving molecular interactions by reference", e);
 		}
@@ -134,11 +138,13 @@ public class LiteratureController implements LiteratureRESTInterface {
 																								String species,
 																								String asc) {
 		long startTime = System.currentTimeMillis();
+		List<String> xrefs = splitCommas(crossReferences);
+		requireCrossReferences(xrefs);
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("geneGeneticInteraction.geneAssociationSubject.taxon.species.fullName.keyword", species);
 		validate(pagination);
 		try {
-			return timed(referenceDataESService.getGeneticInteractions(splitCommas(crossReferences), pagination), startTime);
+			return timed(referenceDataESService.getGeneticInteractions(xrefs, pagination), startTime);
 		} catch (Exception e) {
 			throw restError("Error while retrieving genetic interactions by reference", e);
 		}
@@ -199,6 +205,20 @@ public class LiteratureController implements LiteratureRESTInterface {
 			return timed(referenceDataESService.getModelsByReference(id), startTime);
 		} catch (Exception e) {
 			throw restError("Error while retrieving models by reference", e);
+		}
+	}
+
+	// Expression / molecular-interaction / genetic-interaction docs on stage ES are
+	// indexed by PMID/MOD curie (referenceId / evidence.referenceID), not by AGRKB curie.
+	// The {id} path param can't be used to scope these queries, so the caller must pass
+	// the cross-reference curies (typically pulled from the literature summary) as a
+	// non-empty query param. Without it the endpoint would return unscoped data from
+	// the entire index, so we reject the request with 400.
+	private void requireCrossReferences(List<String> crossReferences) {
+		if (crossReferences == null || crossReferences.isEmpty()) {
+			RestErrorMessage message = new RestErrorMessage(
+				"crossReferences query param is required (provide one or more PMID/MOD curies, comma-separated)");
+			throw new RestErrorException(message);
 		}
 	}
 

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
@@ -1,17 +1,30 @@
 package org.alliancegenome.api.controller;
 
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.core.document.LiteratureSummaryDocument;
 import org.alliancegenome.api.rest.interfaces.LiteratureRESTInterface;
 import org.alliancegenome.api.service.LiteratureESService;
+import org.alliancegenome.api.service.ReferenceDataESService;
+import org.alliancegenome.api.response.JsonResultResponse;
 import org.alliancegenome.api.exceptions.RestErrorException;
 import org.alliancegenome.api.exceptions.RestErrorMessage;
+import org.alliancegenome.api.es.query.Pagination;
 
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 
+@RequestScoped
 public class LiteratureController implements LiteratureRESTInterface {
+
 	@Inject
 	LiteratureESService literatureESService;
-	
+
+	@Inject
+	ReferenceDataESService referenceDataESService;
+
 	@Override
 	public LiteratureSummaryDocument getLiterature(String id) {
 		LiteratureSummaryDocument literatureSummary = literatureESService.getById(id);
@@ -21,5 +34,198 @@ public class LiteratureController implements LiteratureRESTInterface {
 		} else {
 			return literatureSummary;
 		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getDiseaseAnnotationsByReference(String id,
+																						  Integer limit,
+																						  Integer page,
+																						  String sortBy,
+																						  String species,
+																						  String diseaseName,
+																						  String associationType,
+																						  String evidenceCode,
+																						  String dataProvider,
+																						  String asc) {
+		long startTime = System.currentTimeMillis();
+		Pagination pagination = new Pagination(page, limit, sortBy, asc);
+		pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
+		pagination.addFilterOption("object.name", diseaseName);
+		pagination.addFilterOption("generatedRelationString.keyword", associationType);
+		pagination.addFilterOption("evidenceCodes.abbreviation", evidenceCode);
+		pagination.addFilterOption("primaryAnnotations.dataProvider.abbreviation", dataProvider);
+		validate(pagination);
+		try {
+			return timed(referenceDataESService.getDiseaseAnnotations(id, pagination), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving disease annotations by reference", e);
+		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getPhenotypeAnnotationsByReference(String id,
+																							  Integer limit,
+																							  Integer page,
+																							  String sortBy,
+																							  String species,
+																							  String phenotype,
+																							  String asc) {
+		long startTime = System.currentTimeMillis();
+		Pagination pagination = new Pagination(page, limit, sortBy, asc);
+		pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
+		pagination.addFilterOption("phenotypeStatement", phenotype);
+		validate(pagination);
+		try {
+			return timed(referenceDataESService.getPhenotypeAnnotations(id, pagination), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving phenotype annotations by reference", e);
+		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getExpressionAnnotationsByReference(String id,
+																									List<String> crossReferences,
+																									Integer limit,
+																									Integer page,
+																									String sortBy,
+																									String species,
+																									String asc) {
+		long startTime = System.currentTimeMillis();
+		Pagination pagination = new Pagination(page, limit, sortBy, asc);
+		pagination.addFilterOption("geneExpressionAnnotation.expressionAnnotationSubject.taxon.species.fullName.keyword", species);
+		validate(pagination);
+		try {
+			return timed(referenceDataESService.getExpressionAnnotations(splitCommas(crossReferences), pagination), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving expression annotations by reference", e);
+		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getMolecularInteractionsByReference(String id,
+																									List<String> crossReferences,
+																									Integer limit,
+																									Integer page,
+																									String sortBy,
+																									String species,
+																									String asc) {
+		long startTime = System.currentTimeMillis();
+		Pagination pagination = new Pagination(page, limit, sortBy, asc);
+		pagination.addFilterOption("geneMolecularInteraction.geneAssociationSubject.taxon.species.fullName.keyword", species);
+		validate(pagination);
+		try {
+			return timed(referenceDataESService.getMolecularInteractions(splitCommas(crossReferences), pagination), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving molecular interactions by reference", e);
+		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getGeneticInteractionsByReference(String id,
+																								List<String> crossReferences,
+																								Integer limit,
+																								Integer page,
+																								String sortBy,
+																								String species,
+																								String asc) {
+		long startTime = System.currentTimeMillis();
+		Pagination pagination = new Pagination(page, limit, sortBy, asc);
+		pagination.addFilterOption("geneGeneticInteraction.geneAssociationSubject.taxon.species.fullName.keyword", species);
+		validate(pagination);
+		try {
+			return timed(referenceDataESService.getGeneticInteractions(splitCommas(crossReferences), pagination), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving genetic interactions by reference", e);
+		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getRelatedPapersByReference(String id, Integer limit, Boolean includeOrthologs) {
+		long startTime = System.currentTimeMillis();
+		try {
+			int n = (limit == null || limit <= 0) ? 10 : limit;
+			boolean expand = includeOrthologs != null && includeOrthologs;
+			return timed(referenceDataESService.getRelatedPapers(id, n, expand), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving related papers", e);
+		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getOrthologyByReference(String id,
+																			Integer limit,
+																			Integer page,
+																			String sortBy,
+																			String asc) {
+		long startTime = System.currentTimeMillis();
+		Pagination pagination = new Pagination(page, limit, sortBy, asc);
+		validate(pagination);
+		try {
+			return timed(referenceDataESService.getOrthologyByReference(id, pagination), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving orthology by reference", e);
+		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getGenesByReference(String id) {
+		long startTime = System.currentTimeMillis();
+		try {
+			return timed(referenceDataESService.getGenesByReference(id), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving genes by reference", e);
+		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getAllelesByReference(String id) {
+		long startTime = System.currentTimeMillis();
+		try {
+			return timed(referenceDataESService.getAllelesByReference(id), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving alleles by reference", e);
+		}
+	}
+
+	@Override
+	public JsonResultResponse<Map<String, Object>> getModelsByReference(String id) {
+		long startTime = System.currentTimeMillis();
+		try {
+			return timed(referenceDataESService.getModelsByReference(id), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving models by reference", e);
+		}
+	}
+
+	private void validate(Pagination pagination) {
+		if (pagination.hasErrors()) {
+			RestErrorMessage message = new RestErrorMessage();
+			message.setErrors(pagination.getErrors());
+			throw new RestErrorException(message);
+		}
+	}
+
+	private <T> JsonResultResponse<T> timed(JsonResultResponse<T> response, long startTime) {
+		response.setHttpServletRequest(null);
+		response.calculateRequestDuration(startTime);
+		return response;
+	}
+
+	private RestErrorException restError(String logMsg, Exception e) {
+		Log.error(logMsg, e);
+		RestErrorMessage error = new RestErrorMessage();
+		error.addErrorMessage(e.getMessage());
+		return new RestErrorException(error);
+	}
+
+	// JAX-RS gives a List<String> for repeated params; this also handles a single "a,b,c" value.
+	private static List<String> splitCommas(List<String> raw) {
+		if (raw == null) return List.of();
+		return raw.stream()
+			.filter(s -> s != null && !s.isBlank())
+			.flatMap(s -> java.util.Arrays.stream(s.split(",")))
+			.map(String::trim)
+			.filter(s -> !s.isEmpty())
+			.toList();
 	}
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
@@ -3,14 +3,19 @@ package org.alliancegenome.api.controller;
 import java.util.List;
 import java.util.Map;
 
-import org.alliancegenome.core.document.LiteratureSummaryDocument;
+import org.alliancegenome.api.es.query.Pagination;
+import org.alliancegenome.api.exceptions.RestErrorException;
+import org.alliancegenome.api.exceptions.RestErrorMessage;
+import org.alliancegenome.api.response.JsonResultResponse;
 import org.alliancegenome.api.rest.interfaces.LiteratureRESTInterface;
 import org.alliancegenome.api.service.LiteratureESService;
 import org.alliancegenome.api.service.ReferenceDataESService;
-import org.alliancegenome.api.response.JsonResultResponse;
-import org.alliancegenome.api.exceptions.RestErrorException;
-import org.alliancegenome.api.exceptions.RestErrorMessage;
-import org.alliancegenome.api.es.query.Pagination;
+import org.alliancegenome.core.document.DiseaseAnnotationDocument;
+import org.alliancegenome.core.document.GeneGeneticInteractionDocument;
+import org.alliancegenome.core.document.GeneMolecularInteractionDocument;
+import org.alliancegenome.core.document.LiteratureSummaryDocument;
+import org.alliancegenome.core.document.PhenotypeAnnotationDocument;
+import org.alliancegenome.curation_api.model.document.es.GeneExpressionDocument;
 
 import io.quarkus.logging.Log;
 import jakarta.enterprise.context.RequestScoped;
@@ -37,7 +42,7 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<Map<String, Object>> getDiseaseAnnotationsByReference(String id,
+	public JsonResultResponse<DiseaseAnnotationDocument> getDiseaseAnnotationsByReference(String id,
 																						  Integer limit,
 																						  Integer page,
 																						  String sortBy,
@@ -63,7 +68,7 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<Map<String, Object>> getPhenotypeAnnotationsByReference(String id,
+	public JsonResultResponse<PhenotypeAnnotationDocument> getPhenotypeAnnotationsByReference(String id,
 																							  Integer limit,
 																							  Integer page,
 																							  String sortBy,
@@ -83,7 +88,7 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<Map<String, Object>> getExpressionAnnotationsByReference(String id,
+	public JsonResultResponse<GeneExpressionDocument> getExpressionAnnotationsByReference(String id,
 																									List<String> crossReferences,
 																									Integer limit,
 																									Integer page,
@@ -102,7 +107,7 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<Map<String, Object>> getMolecularInteractionsByReference(String id,
+	public JsonResultResponse<GeneMolecularInteractionDocument> getMolecularInteractionsByReference(String id,
 																									List<String> crossReferences,
 																									Integer limit,
 																									Integer page,
@@ -121,7 +126,7 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<Map<String, Object>> getGeneticInteractionsByReference(String id,
+	public JsonResultResponse<GeneGeneticInteractionDocument> getGeneticInteractionsByReference(String id,
 																								List<String> crossReferences,
 																								Integer limit,
 																								Integer page,

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
@@ -42,16 +42,18 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<DiseaseAnnotationDocument> getDiseaseAnnotationsByReference(String id,
-																						  Integer limit,
-																						  Integer page,
-																						  String sortBy,
-																						  String species,
-																						  String diseaseName,
-																						  String associationType,
-																						  String evidenceCode,
-																						  String dataProvider,
-																						  String asc) {
+	public JsonResultResponse<DiseaseAnnotationDocument> getDiseaseAnnotationsByReference(
+		String id,
+		Integer limit,
+		Integer page,
+		String sortBy,
+		String species,
+		String diseaseName,
+		String associationType,
+		String evidenceCode,
+		String dataProvider,
+		String asc
+	) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
@@ -68,13 +70,15 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<PhenotypeAnnotationDocument> getPhenotypeAnnotationsByReference(String id,
-																							  Integer limit,
-																							  Integer page,
-																							  String sortBy,
-																							  String species,
-																							  String phenotype,
-																							  String asc) {
+	public JsonResultResponse<PhenotypeAnnotationDocument> getPhenotypeAnnotationsByReference(
+		String id,
+		Integer limit,
+		Integer page,
+		String sortBy,
+		String species,
+		String phenotype,
+		String asc
+	) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("subject.taxon.species.fullName.keyword", species);
@@ -88,13 +92,15 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<GeneExpressionDocument> getExpressionAnnotationsByReference(String id,
-																									List<String> crossReferences,
-																									Integer limit,
-																									Integer page,
-																									String sortBy,
-																									String species,
-																									String asc) {
+	public JsonResultResponse<GeneExpressionDocument> getExpressionAnnotationsByReference(
+		String id,
+		List<String> crossReferences,
+		Integer limit,
+		Integer page,
+		String sortBy,
+		String species,
+		String asc
+	) {
 		long startTime = System.currentTimeMillis();
 		List<String> xrefs = splitCommas(crossReferences);
 		requireCrossReferences(xrefs);
@@ -109,13 +115,15 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<GeneMolecularInteractionDocument> getMolecularInteractionsByReference(String id,
-																									List<String> crossReferences,
-																									Integer limit,
-																									Integer page,
-																									String sortBy,
-																									String species,
-																									String asc) {
+	public JsonResultResponse<GeneMolecularInteractionDocument> getMolecularInteractionsByReference(
+		String id,
+		List<String> crossReferences,
+		Integer limit,
+		Integer page,
+		String sortBy,
+		String species,
+		String asc
+	) {
 		long startTime = System.currentTimeMillis();
 		List<String> xrefs = splitCommas(crossReferences);
 		requireCrossReferences(xrefs);
@@ -130,13 +138,15 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<GeneGeneticInteractionDocument> getGeneticInteractionsByReference(String id,
-																								List<String> crossReferences,
-																								Integer limit,
-																								Integer page,
-																								String sortBy,
-																								String species,
-																								String asc) {
+	public JsonResultResponse<GeneGeneticInteractionDocument> getGeneticInteractionsByReference(
+		String id,
+		List<String> crossReferences,
+		Integer limit,
+		Integer page,
+		String sortBy,
+		String species,
+		String asc
+	) {
 		long startTime = System.currentTimeMillis();
 		List<String> xrefs = splitCommas(crossReferences);
 		requireCrossReferences(xrefs);
@@ -163,11 +173,13 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<Map<String, Object>> getOrthologyByReference(String id,
-																			Integer limit,
-																			Integer page,
-																			String sortBy,
-																			String asc) {
+	public JsonResultResponse<Map<String, Object>> getOrthologyByReference(
+		String id,
+		Integer limit,
+		Integer page,
+		String sortBy,
+		String asc
+	) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		validate(pagination);
@@ -245,7 +257,9 @@ public class LiteratureController implements LiteratureRESTInterface {
 
 	// JAX-RS gives a List<String> for repeated params; this also handles a single "a,b,c" value.
 	private static List<String> splitCommas(List<String> raw) {
-		if (raw == null) return List.of();
+		if (raw == null) {
+			return List.of();
+		}
 		return raw.stream()
 			.filter(s -> s != null && !s.isBlank())
 			.flatMap(s -> java.util.Arrays.stream(s.split(",")))

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
@@ -3,8 +3,13 @@ package org.alliancegenome.api.rest.interfaces;
 import java.util.List;
 import java.util.Map;
 
-import org.alliancegenome.core.document.LiteratureSummaryDocument;
 import org.alliancegenome.api.response.JsonResultResponse;
+import org.alliancegenome.core.document.DiseaseAnnotationDocument;
+import org.alliancegenome.core.document.GeneGeneticInteractionDocument;
+import org.alliancegenome.core.document.GeneMolecularInteractionDocument;
+import org.alliancegenome.core.document.LiteratureSummaryDocument;
+import org.alliancegenome.core.document.PhenotypeAnnotationDocument;
+import org.alliancegenome.curation_api.model.document.es.GeneExpressionDocument;
 import org.apache.commons.lang3.ObjectUtils.Null;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
@@ -42,7 +47,7 @@ public interface LiteratureRESTInterface {
 	@Path("/{id}/disease-annotations")
 	@Operation(summary = "Retrieve disease annotations that cite the given reference")
 	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of disease annotations", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
-	JsonResultResponse<Map<String, Object>> getDiseaseAnnotationsByReference(
+	JsonResultResponse<DiseaseAnnotationDocument> getDiseaseAnnotationsByReference(
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie, e.g. AGRKB:101000000828456", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", description = "Number of rows returned", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
 		@Parameter(in = ParameterIn.QUERY, name = "page", description = "Page number", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
@@ -58,7 +63,7 @@ public interface LiteratureRESTInterface {
 	@Path("/{id}/phenotype-annotations")
 	@Operation(summary = "Retrieve phenotype annotations that cite the given reference")
 	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of phenotype annotations", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
-	JsonResultResponse<Map<String, Object>> getPhenotypeAnnotationsByReference(
+	JsonResultResponse<PhenotypeAnnotationDocument> getPhenotypeAnnotationsByReference(
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
 		@Parameter(in = ParameterIn.QUERY, name = "page", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
@@ -71,7 +76,7 @@ public interface LiteratureRESTInterface {
 	@Path("/{id}/expression-annotations")
 	@Operation(summary = "Retrieve expression annotations that cite the given reference")
 	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of expression annotations", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
-	JsonResultResponse<Map<String, Object>> getExpressionAnnotationsByReference(
+	JsonResultResponse<GeneExpressionDocument> getExpressionAnnotationsByReference(
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
 		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies for filtering (required on stage ES)", schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
@@ -84,7 +89,7 @@ public interface LiteratureRESTInterface {
 	@Path("/{id}/molecular-interactions")
 	@Operation(summary = "Retrieve molecular interactions that cite the given reference")
 	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of molecular interactions", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
-	JsonResultResponse<Map<String, Object>> getMolecularInteractionsByReference(
+	JsonResultResponse<GeneMolecularInteractionDocument> getMolecularInteractionsByReference(
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
 		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies for filtering (required on stage ES)", schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
@@ -97,7 +102,7 @@ public interface LiteratureRESTInterface {
 	@Path("/{id}/genetic-interactions")
 	@Operation(summary = "Retrieve genetic interactions that cite the given reference")
 	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of genetic interactions", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
-	JsonResultResponse<Map<String, Object>> getGeneticInteractionsByReference(
+	JsonResultResponse<GeneGeneticInteractionDocument> getGeneticInteractionsByReference(
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
 		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies (required on stage ES)", schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
@@ -78,7 +78,7 @@ public interface LiteratureRESTInterface {
 	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of expression annotations", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
 	JsonResultResponse<GeneExpressionDocument> getExpressionAnnotationsByReference(
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
-		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies for filtering (required on stage ES)", schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
+		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies", required = true, schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
 		@Parameter(in = ParameterIn.QUERY, name = "page", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
 		@Parameter(in = ParameterIn.QUERY, name = "sortBy", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("sortBy") String sortBy,
@@ -91,7 +91,7 @@ public interface LiteratureRESTInterface {
 	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of molecular interactions", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
 	JsonResultResponse<GeneMolecularInteractionDocument> getMolecularInteractionsByReference(
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
-		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies for filtering (required on stage ES)", schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
+		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies", required = true, schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
 		@Parameter(in = ParameterIn.QUERY, name = "page", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
 		@Parameter(in = ParameterIn.QUERY, name = "sortBy", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("sortBy") String sortBy,
@@ -104,7 +104,7 @@ public interface LiteratureRESTInterface {
 	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of genetic interactions", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
 	JsonResultResponse<GeneGeneticInteractionDocument> getGeneticInteractionsByReference(
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
-		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies (required on stage ES)", schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
+		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies", required = true, schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
 		@Parameter(in = ParameterIn.QUERY, name = "page", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
 		@Parameter(in = ParameterIn.QUERY, name = "sortBy", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("sortBy") String sortBy,

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
@@ -1,6 +1,10 @@
 package org.alliancegenome.api.rest.interfaces;
 
+import java.util.List;
+import java.util.Map;
+
 import org.alliancegenome.core.document.LiteratureSummaryDocument;
+import org.alliancegenome.api.response.JsonResultResponse;
 import org.apache.commons.lang3.ObjectUtils.Null;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
@@ -13,10 +17,12 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
 @Path("/reference")
@@ -31,5 +37,114 @@ public interface LiteratureRESTInterface {
 		@APIResponse(responseCode = "200", description = "Literature summary object.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
 
 	LiteratureSummaryDocument getLiterature(@Parameter(in = ParameterIn.PATH, name = "id", description = "Search for a literature summary by ID", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id);
-	
+
+	@GET
+	@Path("/{id}/disease-annotations")
+	@Operation(summary = "Retrieve disease annotations that cite the given reference")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of disease annotations", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getDiseaseAnnotationsByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie, e.g. AGRKB:101000000828456", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
+		@Parameter(in = ParameterIn.QUERY, name = "limit", description = "Number of rows returned", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
+		@Parameter(in = ParameterIn.QUERY, name = "page", description = "Page number", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
+		@Parameter(in = ParameterIn.QUERY, name = "sortBy", description = "Field name by which to sort", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("sortBy") String sortBy,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.species", description = "filter by species", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.species") String species,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.disease", description = "filter by disease name", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.disease") String diseaseName,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.associationType", description = "filter by association type", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.associationType") String associationType,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.evidenceCode", description = "filter by evidence code", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.evidenceCode") String evidenceCode,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.dataProvider", description = "filter by source", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.dataProvider") String dataProvider,
+		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "sort order", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc);
+
+	@GET
+	@Path("/{id}/phenotype-annotations")
+	@Operation(summary = "Retrieve phenotype annotations that cite the given reference")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of phenotype annotations", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getPhenotypeAnnotationsByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
+		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
+		@Parameter(in = ParameterIn.QUERY, name = "page", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
+		@Parameter(in = ParameterIn.QUERY, name = "sortBy", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("sortBy") String sortBy,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.species", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.species") String species,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.phenotype", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.phenotype") String phenotype,
+		@Parameter(in = ParameterIn.QUERY, name = "asc", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc);
+
+	@GET
+	@Path("/{id}/expression-annotations")
+	@Operation(summary = "Retrieve expression annotations that cite the given reference")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of expression annotations", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getExpressionAnnotationsByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
+		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies for filtering (required on stage ES)", schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
+		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
+		@Parameter(in = ParameterIn.QUERY, name = "page", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
+		@Parameter(in = ParameterIn.QUERY, name = "sortBy", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("sortBy") String sortBy,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.species", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.species") String species,
+		@Parameter(in = ParameterIn.QUERY, name = "asc", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc);
+
+	@GET
+	@Path("/{id}/molecular-interactions")
+	@Operation(summary = "Retrieve molecular interactions that cite the given reference")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of molecular interactions", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getMolecularInteractionsByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
+		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies for filtering (required on stage ES)", schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
+		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
+		@Parameter(in = ParameterIn.QUERY, name = "page", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
+		@Parameter(in = ParameterIn.QUERY, name = "sortBy", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("sortBy") String sortBy,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.species", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.species") String species,
+		@Parameter(in = ParameterIn.QUERY, name = "asc", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc);
+
+	@GET
+	@Path("/{id}/genetic-interactions")
+	@Operation(summary = "Retrieve genetic interactions that cite the given reference")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of genetic interactions", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getGeneticInteractionsByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
+		@Parameter(in = ParameterIn.QUERY, name = "crossReferences", description = "Comma-separated PMID/MOD curies (required on stage ES)", schema = @Schema(type = SchemaType.STRING)) @QueryParam("crossReferences") List<String> crossReferences,
+		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
+		@Parameter(in = ParameterIn.QUERY, name = "page", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
+		@Parameter(in = ParameterIn.QUERY, name = "sortBy", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("sortBy") String sortBy,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.species", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.species") String species,
+		@Parameter(in = ParameterIn.QUERY, name = "asc", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc);
+
+	@GET
+	@Path("/{id}/genes")
+	@Operation(summary = "Retrieve distinct genes associated with the given reference")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of genes", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getGenesByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id);
+
+	@GET
+	@Path("/{id}/alleles")
+	@Operation(summary = "Retrieve distinct alleles associated with the given reference")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of alleles", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getAllelesByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id);
+
+	@GET
+	@Path("/{id}/related-papers")
+	@Operation(summary = "Papers sharing gene subjects with this reference, ranked by Jaccard similarity")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of related papers", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getRelatedPapersByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
+		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("10") @QueryParam("limit") Integer limit,
+		@Parameter(in = ParameterIn.QUERY, name = "includeOrthologs", description = "Expand gene set via orthology to include cross-species papers", schema = @Schema(type = SchemaType.BOOLEAN)) @DefaultValue("false") @QueryParam("includeOrthologs") Boolean includeOrthologs);
+
+	@GET
+	@Path("/{id}/orthology")
+	@Operation(summary = "Retrieve orthologs of genes associated with the given reference")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of orthology pairs", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getOrthologyByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
+		@Parameter(in = ParameterIn.QUERY, name = "limit", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
+		@Parameter(in = ParameterIn.QUERY, name = "page", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("page") Integer page,
+		@Parameter(in = ParameterIn.QUERY, name = "sortBy", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("") @QueryParam("sortBy") String sortBy,
+		@Parameter(in = ParameterIn.QUERY, name = "asc", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc);
+
+	@GET
+	@Path("/{id}/models")
+	@Operation(summary = "Retrieve distinct genetic models (AGMs) associated with the given reference")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "List of models", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getModelsByReference(
+		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id);
+
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ESService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
@@ -241,5 +242,14 @@ public class ESService {
 		bool2.should(new MatchQueryBuilder("subject.curie.keyword", geneID));
 		bool2.should(new MatchQueryBuilder("subject.primaryExternalId.keyword", geneID));
 		bool2.should(new MatchQueryBuilder("subject.modInternalId.keyword", geneID));
+	}
+
+	protected <T> T mapHit(SearchHit hit, Class<T> type) {
+		try {
+			return this.mapper.readValue(hit.getSourceAsString(), type);
+		} catch (Exception e) {
+			Log.error("Failed to deserialize hit id=" + hit.getId() + " as " + type.getSimpleName(), e);
+			return null;
+		}
 	}
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
@@ -135,7 +135,9 @@ public class ReferenceDataESService extends ESService {
 		List<String> focusGenes = new ArrayList<>();
 		for (Map<String, Object> g : genesResp.getResults()) {
 			Object id = g.get("primaryExternalId");
-			if (id != null) focusGenes.add(id.toString());
+			if (id != null) {
+				focusGenes.add(id.toString());
+			}
 		}
 
 		List<String> aGenes = new ArrayList<>(focusGenes);
@@ -173,9 +175,13 @@ public class ReferenceDataESService extends ESService {
 		ParsedStringTerms refTerms = sharedResp.getAggregations().get("refs");
 		for (Terms.Bucket b : refTerms.getBuckets()) {
 			String candidateRef = b.getKeyAsString();
-			if (candidateRef.equals(referenceCurie)) continue;
+			if (candidateRef.equals(referenceCurie)) {
+				continue;
+			}
 			// Skip external disease-database refs (OMIM, Orphanet) that aren't papers.
-			if (!candidateRef.startsWith("AGRKB:")) continue;
+			if (!candidateRef.startsWith("AGRKB:")) {
+				continue;
+			}
 			org.elasticsearch.search.aggregations.metrics.Cardinality card = b.getAggregations().get("uniqGenes");
 			sharedCounts.put(candidateRef, (int) card.getValue());
 			ParsedStringTerms speciesAgg = b.getAggregations().get("species");
@@ -214,7 +220,7 @@ public class ReferenceDataESService extends ESService {
 		}
 
 		// 3) compute Jaccard and sort
-		record Scored(String curie, int shared, int bSize, double jaccard) {}
+		record Scored(String curie, int shared, int bSize, double jaccard) { }
 		List<Scored> scored = new ArrayList<>();
 		for (Map.Entry<String, Integer> e : sharedCounts.entrySet()) {
 			int shared = e.getValue();
@@ -260,12 +266,18 @@ public class ReferenceDataESService extends ESService {
 			try {
 				@SuppressWarnings("unchecked")
 				Map<String, Object> gto = (Map<String, Object>) hit.getSourceAsMap().get("geneToGeneOrthologyGenerated");
-				if (gto == null) continue;
+				if (gto == null) {
+					continue;
+				}
 				@SuppressWarnings("unchecked")
 				Map<String, Object> obj = (Map<String, Object>) gto.get("objectGene");
-				if (obj == null) continue;
+				if (obj == null) {
+					continue;
+				}
 				Object id = obj.get("primaryExternalId");
-				if (id != null) out.add(id.toString());
+				if (id != null) {
+					out.add(id.toString());
+				}
 			} catch (Exception e) {
 				log.warn("Failed to parse ortholog object gene (hit id={})", hit.getId(), e);
 			}
@@ -281,7 +293,9 @@ public class ReferenceDataESService extends ESService {
 		List<String> geneIds = new ArrayList<>();
 		for (Map<String, Object> gene : genesResp.getResults()) {
 			Object id = gene.get("primaryExternalId");
-			if (id != null) geneIds.add(id.toString());
+			if (id != null) {
+				geneIds.add(id.toString());
+			}
 		}
 
 		JsonResultResponse<Map<String, Object>> ret = new JsonResultResponse<>();

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
@@ -9,19 +9,29 @@ import java.util.List;
 import java.util.Map;
 
 import org.alliancegenome.api.es.dao.SearchDAO;
+import org.alliancegenome.api.es.query.Pagination;
+import org.alliancegenome.api.response.JsonResultResponse;
+import org.alliancegenome.api.service.helper.APIServiceHelper;
+import org.alliancegenome.core.document.AGMDiseaseAnnotationDocument;
+import org.alliancegenome.core.document.AlleleDiseaseAnnotationDocument;
+import org.alliancegenome.core.document.AllelePhenotypeAnnotationDocument;
+import org.alliancegenome.core.document.DiseaseAnnotationDocument;
+import org.alliancegenome.core.document.GeneDiseaseAnnotationDocument;
+import org.alliancegenome.core.document.GeneGeneticInteractionDocument;
+import org.alliancegenome.core.document.GeneMolecularInteractionDocument;
+import org.alliancegenome.core.document.GenePhenotypeAnnotationDocument;
+import org.alliancegenome.core.document.PhenotypeAnnotationDocument;
+import org.alliancegenome.curation_api.model.document.es.GeneExpressionDocument;
+import org.apache.commons.collections4.CollectionUtils;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.TopHits;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
-
-import org.alliancegenome.api.response.JsonResultResponse;
-import org.alliancegenome.api.es.query.Pagination;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.search.SearchHit;
 
 import jakarta.enterprise.context.RequestScoped;
 import lombok.extern.slf4j.Slf4j;
@@ -57,52 +67,52 @@ public class ReferenceDataESService extends ESService {
 		"agm_phenotype_annotation"
 	);
 
-	public JsonResultResponse<Map<String, Object>> getDiseaseAnnotations(String referenceCurie, Pagination pagination) {
+	public JsonResultResponse<DiseaseAnnotationDocument> getDiseaseAnnotations(String referenceCurie, Pagination pagination) {
 		BoolQueryBuilder query = boolQuery()
 			.filter(termsQuery("category", DISEASE_CATEGORIES))
 			.must(termQuery("references.curie.keyword", referenceCurie));
 
-		return runQuery(query, pagination, this::hitAsMap);
+		return runQuery(query, pagination, this::deserializeDiseaseByCategory);
 	}
 
-	public JsonResultResponse<Map<String, Object>> getPhenotypeAnnotations(String referenceCurie, Pagination pagination) {
+	public JsonResultResponse<PhenotypeAnnotationDocument> getPhenotypeAnnotations(String referenceCurie, Pagination pagination) {
 		BoolQueryBuilder query = boolQuery()
 			.filter(termsQuery("category", PHENOTYPE_CATEGORIES))
 			.must(termQuery("references.curie.keyword", referenceCurie));
 
-		return runQuery(query, pagination, this::hitAsMap);
+		return runQuery(query, pagination, this::deserializePhenotypeByCategory);
 	}
 
 	// Expression docs on stage index only `referenceId` (PMID/MOD IDs).
 	// The caller passes the set of cross-reference curies (PMID/MOD) from the literature summary.
-	public JsonResultResponse<Map<String, Object>> getExpressionAnnotations(List<String> crossReferenceCuries, Pagination pagination) {
+	public JsonResultResponse<GeneExpressionDocument> getExpressionAnnotations(List<String> crossReferenceCuries, Pagination pagination) {
 		BoolQueryBuilder query = boolQuery()
 			.filter(termQuery("category", "gene_expression_annotation"));
 		if (crossReferenceCuries != null && !crossReferenceCuries.isEmpty()) {
 			query.must(termsQuery("referenceId.keyword", crossReferenceCuries));
 		}
-		return runQuery(query, pagination, this::hitAsMap);
+		return runQuery(query, pagination, hit -> mapHit(hit, GeneExpressionDocument.class));
 	}
 
 	// Molecular interaction docs only index `geneMolecularInteraction.evidence.referenceID` (PMID/MOD IDs).
-	public JsonResultResponse<Map<String, Object>> getMolecularInteractions(List<String> crossReferenceCuries, Pagination pagination) {
+	public JsonResultResponse<GeneMolecularInteractionDocument> getMolecularInteractions(List<String> crossReferenceCuries, Pagination pagination) {
 		BoolQueryBuilder query = boolQuery()
 			.filter(termQuery("category", "gene_molecular_interaction"));
 		if (crossReferenceCuries != null && !crossReferenceCuries.isEmpty()) {
 			query.must(termsQuery("geneMolecularInteraction.evidence.referenceID.keyword", crossReferenceCuries));
 		}
-		return runQuery(query, pagination, this::hitAsMap);
+		return runQuery(query, pagination, hit -> mapHit(hit, GeneMolecularInteractionDocument.class));
 	}
 
 	// Genetic interaction category mirrors molecular interaction shape. Note: stage ES currently has
 	// zero docs in `gene_genetic_interaction` (indexing gap); code works once the category is populated.
-	public JsonResultResponse<Map<String, Object>> getGeneticInteractions(List<String> crossReferenceCuries, Pagination pagination) {
+	public JsonResultResponse<GeneGeneticInteractionDocument> getGeneticInteractions(List<String> crossReferenceCuries, Pagination pagination) {
 		BoolQueryBuilder query = boolQuery()
 			.filter(termQuery("category", "gene_genetic_interaction"));
 		if (crossReferenceCuries != null && !crossReferenceCuries.isEmpty()) {
 			query.must(termsQuery("geneGeneticInteraction.evidence.referenceID.keyword", crossReferenceCuries));
 		}
-		return runQuery(query, pagination, this::hitAsMap);
+		return runQuery(query, pagination, hit -> mapHit(hit, GeneGeneticInteractionDocument.class));
 	}
 
 	public JsonResultResponse<Map<String, Object>> getGenesByReference(String referenceCurie) {
@@ -367,10 +377,57 @@ public class ReferenceDataESService extends ESService {
 		return ret;
 	}
 
-	private Map<String, Object> hitAsMap(SearchHit hit) {
-		Map<String, Object> source = hit.getSourceAsMap();
-		if (source == null) return null;
-		source.put("uniqueId", hit.getId());
-		return source;
+	private <T> T mapHit(SearchHit hit, Class<T> type) {
+		try {
+			return this.mapper.readValue(hit.getSourceAsString(), type);
+		} catch (Exception e) {
+			log.error("Failed to deserialize hit id={} as {}", hit.getId(), type.getSimpleName(), e);
+			return null;
+		}
+	}
+
+	private DiseaseAnnotationDocument deserializeDiseaseByCategory(SearchHit hit) {
+		try {
+			Object category = hit.getSourceAsMap().get("category");
+			String json = hit.getSourceAsString();
+			DiseaseAnnotationDocument doc;
+			if ("allele_disease_annotation".equals(category)) {
+				doc = mapper.readValue(json, AlleleDiseaseAnnotationDocument.class);
+			} else if ("agm_disease_annotation".equals(category)) {
+				doc = mapper.readValue(json, AGMDiseaseAnnotationDocument.class);
+			} else {
+				doc = mapper.readValue(json, GeneDiseaseAnnotationDocument.class);
+			}
+			doc.setUniqueId(hit.getId());
+			if (CollectionUtils.isNotEmpty(doc.getPrimaryAnnotations())) {
+				doc.setProviders(APIServiceHelper.buildProvidersWithUrl(doc.getPrimaryAnnotations()));
+			}
+			return doc;
+		} catch (Exception e) {
+			log.error("Failed to deserialize disease annotation hit id={}", hit.getId(), e);
+			return null;
+		}
+	}
+
+	// agm_phenotype_annotation has no dedicated subclass on this branch — fall back to the
+	// base PhenotypeAnnotationDocument for that category.
+	private PhenotypeAnnotationDocument deserializePhenotypeByCategory(SearchHit hit) {
+		try {
+			Object category = hit.getSourceAsMap().get("category");
+			String json = hit.getSourceAsString();
+			PhenotypeAnnotationDocument doc;
+			if ("allele_phenotype_annotation".equals(category)) {
+				doc = mapper.readValue(json, AllelePhenotypeAnnotationDocument.class);
+			} else if ("gene_phenotype_annotation".equals(category)) {
+				doc = mapper.readValue(json, GenePhenotypeAnnotationDocument.class);
+			} else {
+				doc = mapper.readValue(json, PhenotypeAnnotationDocument.class);
+			}
+			doc.setUniqueId(hit.getId());
+			return doc;
+		} catch (Exception e) {
+			log.error("Failed to deserialize phenotype annotation hit id={}", hit.getId(), e);
+			return null;
+		}
 	}
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
@@ -74,6 +74,8 @@ public class ReferenceDataESService extends ESService {
 		"allele_phenotype_annotation"
 	);
 
+	private static final SearchDAO SEARCH_DAO = new SearchDAO();
+
 	public JsonResultResponse<DiseaseAnnotationDocument> getDiseaseAnnotations(String referenceCurie, Pagination pagination) {
 		BoolQueryBuilder query = boolQuery()
 			.filter(termsQuery("category", DISEASE_CATEGORIES))
@@ -371,8 +373,6 @@ public class ReferenceDataESService extends ESService {
 	public JsonResultResponse<Map<String, Object>> getModelsByReference(String referenceCurie) {
 		return getDistinctSubjects(MODEL_SUBJECT_CATEGORIES, referenceCurie);
 	}
-
-	private static final SearchDAO SEARCH_DAO = new SearchDAO();
 
 	private JsonResultResponse<Map<String, Object>> getDistinctSubjects(List<String> categories, String referenceCurie) {
 		BoolQueryBuilder query = boolQuery()

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
@@ -67,12 +67,32 @@ public class ReferenceDataESService extends ESService {
 		"agm_phenotype_annotation"
 	);
 
+	private static final List<String> GENE_AND_ALLELE_ANNOTATION_CATEGORIES = List.of(
+		"gene_disease_annotation",
+		"gene_phenotype_annotation",
+		"allele_disease_annotation",
+		"allele_phenotype_annotation"
+	);
+
 	public JsonResultResponse<DiseaseAnnotationDocument> getDiseaseAnnotations(String referenceCurie, Pagination pagination) {
 		BoolQueryBuilder query = boolQuery()
 			.filter(termsQuery("category", DISEASE_CATEGORIES))
 			.must(termQuery("references.curie.keyword", referenceCurie));
 
-		return runQuery(query, pagination, this::deserializeDiseaseByCategory);
+		addTableFilter(pagination, query);
+		SearchResponse searchResponse = getSearchResponse(query, pagination, null, false);
+
+		JsonResultResponse<DiseaseAnnotationDocument> ret = new JsonResultResponse<>();
+		ret.setTotal((int) searchResponse.getHits().getTotalHits().value);
+		List<DiseaseAnnotationDocument> results = new ArrayList<>();
+		for (SearchHit hit : searchResponse.getHits().getHits()) {
+			DiseaseAnnotationDocument doc = deserializeDiseaseByCategory(hit);
+			if (doc != null) {
+				results.add(doc);
+			}
+		}
+		ret.setResults(results);
+		return ret;
 	}
 
 	public JsonResultResponse<PhenotypeAnnotationDocument> getPhenotypeAnnotations(String referenceCurie, Pagination pagination) {
@@ -80,7 +100,20 @@ public class ReferenceDataESService extends ESService {
 			.filter(termsQuery("category", PHENOTYPE_CATEGORIES))
 			.must(termQuery("references.curie.keyword", referenceCurie));
 
-		return runQuery(query, pagination, this::deserializePhenotypeByCategory);
+		addTableFilter(pagination, query);
+		SearchResponse searchResponse = getSearchResponse(query, pagination, null, false);
+
+		JsonResultResponse<PhenotypeAnnotationDocument> ret = new JsonResultResponse<>();
+		ret.setTotal((int) searchResponse.getHits().getTotalHits().value);
+		List<PhenotypeAnnotationDocument> results = new ArrayList<>();
+		for (SearchHit hit : searchResponse.getHits().getHits()) {
+			PhenotypeAnnotationDocument doc = deserializePhenotypeByCategory(hit);
+			if (doc != null) {
+				results.add(doc);
+			}
+		}
+		ret.setResults(results);
+		return ret;
 	}
 
 	// Expression docs on stage index only `referenceId` (PMID/MOD IDs).
@@ -91,7 +124,7 @@ public class ReferenceDataESService extends ESService {
 		if (crossReferenceCuries != null && !crossReferenceCuries.isEmpty()) {
 			query.must(termsQuery("referenceId.keyword", crossReferenceCuries));
 		}
-		return runQuery(query, pagination, hit -> mapHit(hit, GeneExpressionDocument.class));
+		return runTypedQuery(query, pagination, GeneExpressionDocument.class);
 	}
 
 	// Molecular interaction docs only index `geneMolecularInteraction.evidence.referenceID` (PMID/MOD IDs).
@@ -101,7 +134,7 @@ public class ReferenceDataESService extends ESService {
 		if (crossReferenceCuries != null && !crossReferenceCuries.isEmpty()) {
 			query.must(termsQuery("geneMolecularInteraction.evidence.referenceID.keyword", crossReferenceCuries));
 		}
-		return runQuery(query, pagination, hit -> mapHit(hit, GeneMolecularInteractionDocument.class));
+		return runTypedQuery(query, pagination, GeneMolecularInteractionDocument.class);
 	}
 
 	// Genetic interaction category mirrors molecular interaction shape. Note: stage ES currently has
@@ -112,19 +145,29 @@ public class ReferenceDataESService extends ESService {
 		if (crossReferenceCuries != null && !crossReferenceCuries.isEmpty()) {
 			query.must(termsQuery("geneGeneticInteraction.evidence.referenceID.keyword", crossReferenceCuries));
 		}
-		return runQuery(query, pagination, hit -> mapHit(hit, GeneGeneticInteractionDocument.class));
+		return runTypedQuery(query, pagination, GeneGeneticInteractionDocument.class);
+	}
+
+	private <T> JsonResultResponse<T> runTypedQuery(BoolQueryBuilder query, Pagination pagination, Class<T> type) {
+		addTableFilter(pagination, query);
+		SearchResponse searchResponse = getSearchResponse(query, pagination, null, false);
+
+		JsonResultResponse<T> ret = new JsonResultResponse<>();
+		ret.setTotal((int) searchResponse.getHits().getTotalHits().value);
+		List<T> results = new ArrayList<>();
+		for (SearchHit hit : searchResponse.getHits().getHits()) {
+			T doc = mapHit(hit, type);
+			if (doc != null) {
+				results.add(doc);
+			}
+		}
+		ret.setResults(results);
+		return ret;
 	}
 
 	public JsonResultResponse<Map<String, Object>> getGenesByReference(String referenceCurie) {
 		return getDistinctSubjects(GENE_SUBJECT_CATEGORIES, referenceCurie);
 	}
-
-	private static final List<String> GENE_AND_ALLELE_ANNOTATION_CATEGORIES = List.of(
-		"gene_disease_annotation",
-		"gene_phenotype_annotation",
-		"allele_disease_annotation",
-		"allele_phenotype_annotation"
-	);
 
 	// Related papers by Jaccard similarity of gene subjects.
 	// - A = distinct gene subjects on this reference (optionally expanded with orthologs)
@@ -366,38 +409,6 @@ public class ReferenceDataESService extends ESService {
 		ret.setTotal(subjects.size());
 		ret.setResults(subjects);
 		return ret;
-	}
-
-	@FunctionalInterface
-	private interface HitMapper<T> {
-		T map(SearchHit hit);
-	}
-
-	private <T> JsonResultResponse<T> runQuery(BoolQueryBuilder query, Pagination pagination, HitMapper<T> mapper) {
-		addTableFilter(pagination, query);
-		SearchResponse searchResponse = getSearchResponse(query, pagination, null, false);
-
-		JsonResultResponse<T> ret = new JsonResultResponse<>();
-		ret.setTotal((int) searchResponse.getHits().getTotalHits().value);
-
-		List<T> results = new ArrayList<>();
-		for (SearchHit hit : searchResponse.getHits().getHits()) {
-			T doc = mapper.map(hit);
-			if (doc != null) {
-				results.add(doc);
-			}
-		}
-		ret.setResults(results);
-		return ret;
-	}
-
-	private <T> T mapHit(SearchHit hit, Class<T> type) {
-		try {
-			return this.mapper.readValue(hit.getSourceAsString(), type);
-		} catch (Exception e) {
-			log.error("Failed to deserialize hit id={} as {}", hit.getId(), type.getSimpleName(), e);
-			return null;
-		}
 	}
 
 	private DiseaseAnnotationDocument deserializeDiseaseByCategory(SearchHit hit) {

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
@@ -1,0 +1,376 @@
+package org.alliancegenome.api.service;
+
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.alliancegenome.api.es.dao.SearchDAO;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.metrics.TopHits;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import org.alliancegenome.api.response.JsonResultResponse;
+import org.alliancegenome.api.es.query.Pagination;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.search.SearchHit;
+
+import jakarta.enterprise.context.RequestScoped;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequestScoped
+public class ReferenceDataESService extends ESService {
+
+	private static final List<String> DISEASE_CATEGORIES = List.of(
+		"gene_disease_annotation",
+		"allele_disease_annotation",
+		"agm_disease_annotation"
+	);
+
+	private static final List<String> PHENOTYPE_CATEGORIES = List.of(
+		"gene_phenotype_annotation",
+		"allele_phenotype_annotation",
+		"agm_phenotype_annotation"
+	);
+
+	private static final List<String> GENE_SUBJECT_CATEGORIES = List.of(
+		"gene_disease_annotation",
+		"gene_phenotype_annotation"
+	);
+
+	private static final List<String> ALLELE_SUBJECT_CATEGORIES = List.of(
+		"allele_disease_annotation",
+		"allele_phenotype_annotation"
+	);
+
+	private static final List<String> MODEL_SUBJECT_CATEGORIES = List.of(
+		"agm_disease_annotation",
+		"agm_phenotype_annotation"
+	);
+
+	public JsonResultResponse<Map<String, Object>> getDiseaseAnnotations(String referenceCurie, Pagination pagination) {
+		BoolQueryBuilder query = boolQuery()
+			.filter(termsQuery("category", DISEASE_CATEGORIES))
+			.must(termQuery("references.curie.keyword", referenceCurie));
+
+		return runQuery(query, pagination, this::hitAsMap);
+	}
+
+	public JsonResultResponse<Map<String, Object>> getPhenotypeAnnotations(String referenceCurie, Pagination pagination) {
+		BoolQueryBuilder query = boolQuery()
+			.filter(termsQuery("category", PHENOTYPE_CATEGORIES))
+			.must(termQuery("references.curie.keyword", referenceCurie));
+
+		return runQuery(query, pagination, this::hitAsMap);
+	}
+
+	// Expression docs on stage index only `referenceId` (PMID/MOD IDs).
+	// The caller passes the set of cross-reference curies (PMID/MOD) from the literature summary.
+	public JsonResultResponse<Map<String, Object>> getExpressionAnnotations(List<String> crossReferenceCuries, Pagination pagination) {
+		BoolQueryBuilder query = boolQuery()
+			.filter(termQuery("category", "gene_expression_annotation"));
+		if (crossReferenceCuries != null && !crossReferenceCuries.isEmpty()) {
+			query.must(termsQuery("referenceId.keyword", crossReferenceCuries));
+		}
+		return runQuery(query, pagination, this::hitAsMap);
+	}
+
+	// Molecular interaction docs only index `geneMolecularInteraction.evidence.referenceID` (PMID/MOD IDs).
+	public JsonResultResponse<Map<String, Object>> getMolecularInteractions(List<String> crossReferenceCuries, Pagination pagination) {
+		BoolQueryBuilder query = boolQuery()
+			.filter(termQuery("category", "gene_molecular_interaction"));
+		if (crossReferenceCuries != null && !crossReferenceCuries.isEmpty()) {
+			query.must(termsQuery("geneMolecularInteraction.evidence.referenceID.keyword", crossReferenceCuries));
+		}
+		return runQuery(query, pagination, this::hitAsMap);
+	}
+
+	// Genetic interaction category mirrors molecular interaction shape. Note: stage ES currently has
+	// zero docs in `gene_genetic_interaction` (indexing gap); code works once the category is populated.
+	public JsonResultResponse<Map<String, Object>> getGeneticInteractions(List<String> crossReferenceCuries, Pagination pagination) {
+		BoolQueryBuilder query = boolQuery()
+			.filter(termQuery("category", "gene_genetic_interaction"));
+		if (crossReferenceCuries != null && !crossReferenceCuries.isEmpty()) {
+			query.must(termsQuery("geneGeneticInteraction.evidence.referenceID.keyword", crossReferenceCuries));
+		}
+		return runQuery(query, pagination, this::hitAsMap);
+	}
+
+	public JsonResultResponse<Map<String, Object>> getGenesByReference(String referenceCurie) {
+		return getDistinctSubjects(GENE_SUBJECT_CATEGORIES, referenceCurie);
+	}
+
+	private static final List<String> GENE_AND_ALLELE_ANNOTATION_CATEGORIES = List.of(
+		"gene_disease_annotation",
+		"gene_phenotype_annotation",
+		"allele_disease_annotation",
+		"allele_phenotype_annotation"
+	);
+
+	// Related papers by Jaccard similarity of gene subjects.
+	// - A = distinct gene subjects on this reference (optionally expanded with orthologs)
+	// - For candidates sharing any of A, B = their own distinct gene subjects
+	// - jaccard = |A ∩ B| / |A ∪ B| = shared / (|A| + |B| - shared)
+	public JsonResultResponse<Map<String, Object>> getRelatedPapers(String referenceCurie, int limit, boolean includeOrthologs) {
+		JsonResultResponse<Map<String, Object>> genesResp = getDistinctSubjects(GENE_SUBJECT_CATEGORIES, referenceCurie);
+		List<String> focusGenes = new ArrayList<>();
+		for (Map<String, Object> g : genesResp.getResults()) {
+			Object id = g.get("primaryExternalId");
+			if (id != null) focusGenes.add(id.toString());
+		}
+
+		List<String> aGenes = new ArrayList<>(focusGenes);
+		if (includeOrthologs && !focusGenes.isEmpty()) {
+			aGenes.addAll(getOrthologGeneIds(focusGenes));
+			aGenes = new ArrayList<>(aGenes.stream().distinct().toList());
+		}
+		int aSize = aGenes.size();
+
+		JsonResultResponse<Map<String, Object>> ret = new JsonResultResponse<>();
+		if (aGenes.isEmpty()) {
+			ret.setTotal(0);
+			ret.setResults(List.of());
+			return ret;
+		}
+
+		// 1) find candidate papers and their shared-gene count
+		BoolQueryBuilder sharedQuery = boolQuery()
+			.filter(termsQuery("category", GENE_AND_ALLELE_ANNOTATION_CATEGORIES))
+			.must(termsQuery("subject.primaryExternalId.keyword", aGenes));
+
+		AggregationBuilder sharedAgg = AggregationBuilders
+			.terms("refs")
+			.field("references.curie.keyword")
+			.size(Math.max(50, limit * 3))
+			.subAggregation(AggregationBuilders.cardinality("uniqGenes").field("subject.primaryExternalId.keyword"))
+			.subAggregation(AggregationBuilders.terms("species").field("subject.taxon.species.fullName.keyword").size(10));
+
+		SearchResponse sharedResp = SEARCH_DAO.performQuery(
+			(QueryBuilder) sharedQuery, List.of(sharedAgg), null, List.of(),
+			0, 0, new org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder(), null, false);
+
+		Map<String, Integer> sharedCounts = new java.util.LinkedHashMap<>();
+		Map<String, List<String>> sharedSpecies = new java.util.HashMap<>();
+		ParsedStringTerms refTerms = sharedResp.getAggregations().get("refs");
+		for (Terms.Bucket b : refTerms.getBuckets()) {
+			String candidateRef = b.getKeyAsString();
+			if (candidateRef.equals(referenceCurie)) continue;
+			// Skip external disease-database refs (OMIM, Orphanet) that aren't papers.
+			if (!candidateRef.startsWith("AGRKB:")) continue;
+			org.elasticsearch.search.aggregations.metrics.Cardinality card = b.getAggregations().get("uniqGenes");
+			sharedCounts.put(candidateRef, (int) card.getValue());
+			ParsedStringTerms speciesAgg = b.getAggregations().get("species");
+			List<String> species = new ArrayList<>();
+			for (Terms.Bucket sb : speciesAgg.getBuckets()) {
+				species.add(sb.getKeyAsString());
+			}
+			sharedSpecies.put(candidateRef, species);
+		}
+		if (sharedCounts.isEmpty()) {
+			ret.setTotal(0);
+			ret.setResults(List.of());
+			return ret;
+		}
+
+		// 2) for the candidates, get each one's own distinct gene count (|B|)
+		BoolQueryBuilder bSizeQuery = boolQuery()
+			.filter(termsQuery("category", GENE_AND_ALLELE_ANNOTATION_CATEGORIES))
+			.must(termsQuery("references.curie.keyword", sharedCounts.keySet().stream().toList()));
+
+		AggregationBuilder bSizeAgg = AggregationBuilders
+			.terms("refs")
+			.field("references.curie.keyword")
+			.size(sharedCounts.size() + 1)
+			.subAggregation(AggregationBuilders.cardinality("uniqGenes").field("subject.primaryExternalId.keyword"));
+
+		SearchResponse bSizeResp = SEARCH_DAO.performQuery(
+			(QueryBuilder) bSizeQuery, List.of(bSizeAgg), null, List.of(),
+			0, 0, new org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder(), null, false);
+
+		Map<String, Integer> bSizes = new java.util.HashMap<>();
+		ParsedStringTerms bTerms = bSizeResp.getAggregations().get("refs");
+		for (Terms.Bucket b : bTerms.getBuckets()) {
+			org.elasticsearch.search.aggregations.metrics.Cardinality card = b.getAggregations().get("uniqGenes");
+			bSizes.put(b.getKeyAsString(), (int) card.getValue());
+		}
+
+		// 3) compute Jaccard and sort
+		record Scored(String curie, int shared, int bSize, double jaccard) {}
+		List<Scored> scored = new ArrayList<>();
+		for (Map.Entry<String, Integer> e : sharedCounts.entrySet()) {
+			int shared = e.getValue();
+			int b = bSizes.getOrDefault(e.getKey(), shared);
+			int union = aSize + b - shared;
+			double j = union == 0 ? 0 : ((double) shared) / union;
+			scored.add(new Scored(e.getKey(), shared, b, j));
+		}
+		scored.sort((x, y) -> Double.compare(y.jaccard(), x.jaccard()));
+
+		List<Map<String, Object>> out = new ArrayList<>();
+		for (Scored s : scored.stream().limit(limit).toList()) {
+			Map<String, Object> row = new java.util.LinkedHashMap<>();
+			row.put("referenceCurie", s.curie());
+			row.put("sharedGenes", s.shared());
+			row.put("candidateGeneCount", s.bSize());
+			row.put("focusGeneCount", aSize);
+			row.put("jaccard", s.jaccard());
+			row.put("sharedSpecies", sharedSpecies.getOrDefault(s.curie(), List.of()));
+			out.add(row);
+		}
+		ret.setTotal(out.size());
+		ret.setResults(out);
+		return ret;
+	}
+
+	// Returns the object-side gene IDs for orthology rows whose subject is in the input set.
+	// objectGene.primaryExternalId has no .keyword sub-field in the stage mapping, so we
+	// fetch source docs and pull the ID out of _source rather than using a terms aggregation.
+	private List<String> getOrthologGeneIds(List<String> subjectGeneIds) {
+		BoolQueryBuilder query = boolQuery()
+			.filter(termQuery("category", "gene_to_gene_orthology"))
+			.must(termsQuery("geneToGeneOrthologyGenerated.subjectGene.primaryExternalId.keyword", subjectGeneIds));
+
+		SearchResponse resp = SEARCH_DAO.performQuery(
+			(QueryBuilder) query, List.of(), null,
+			List.of("geneToGeneOrthologyGenerated.objectGene.primaryExternalId"),
+			10_000, 0,
+			new org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder(), null, false);
+
+		java.util.Set<String> out = new java.util.LinkedHashSet<>();
+		for (SearchHit hit : resp.getHits().getHits()) {
+			try {
+				@SuppressWarnings("unchecked")
+				Map<String, Object> gto = (Map<String, Object>) hit.getSourceAsMap().get("geneToGeneOrthologyGenerated");
+				if (gto == null) continue;
+				@SuppressWarnings("unchecked")
+				Map<String, Object> obj = (Map<String, Object>) gto.get("objectGene");
+				if (obj == null) continue;
+				Object id = obj.get("primaryExternalId");
+				if (id != null) out.add(id.toString());
+			} catch (Exception e) {
+				log.warn("Failed to parse ortholog object gene (hit id={})", hit.getId(), e);
+			}
+		}
+		return new ArrayList<>(out);
+	}
+
+	// Orthologs of the genes mentioned in this reference. "Reference-scoped" loosely —
+	// gene_to_gene_orthology docs have no reference field, so we look up distinct genes
+	// first, then fetch their orthologs.
+	public JsonResultResponse<Map<String, Object>> getOrthologyByReference(String referenceCurie, Pagination pagination) {
+		JsonResultResponse<Map<String, Object>> genesResp = getDistinctSubjects(GENE_SUBJECT_CATEGORIES, referenceCurie);
+		List<String> geneIds = new ArrayList<>();
+		for (Map<String, Object> gene : genesResp.getResults()) {
+			Object id = gene.get("primaryExternalId");
+			if (id != null) geneIds.add(id.toString());
+		}
+
+		JsonResultResponse<Map<String, Object>> ret = new JsonResultResponse<>();
+		if (geneIds.isEmpty()) {
+			ret.setTotal(0);
+			ret.setResults(List.of());
+			return ret;
+		}
+
+		BoolQueryBuilder query = boolQuery()
+			.filter(termQuery("category", "gene_to_gene_orthology"))
+			.must(termsQuery("geneToGeneOrthologyGenerated.subjectGene.primaryExternalId.keyword", geneIds));
+
+		addTableFilter(pagination, query);
+		SearchResponse searchResponse = getSearchResponse(query, pagination, null, false);
+		ret.setTotal((int) searchResponse.getHits().getTotalHits().value);
+
+		List<Map<String, Object>> results = new ArrayList<>();
+		for (SearchHit hit : searchResponse.getHits().getHits()) {
+			results.add(hit.getSourceAsMap());
+		}
+		ret.setResults(results);
+		return ret;
+	}
+
+	public JsonResultResponse<Map<String, Object>> getAllelesByReference(String referenceCurie) {
+		return getDistinctSubjects(ALLELE_SUBJECT_CATEGORIES, referenceCurie);
+	}
+
+	public JsonResultResponse<Map<String, Object>> getModelsByReference(String referenceCurie) {
+		return getDistinctSubjects(MODEL_SUBJECT_CATEGORIES, referenceCurie);
+	}
+
+	private static final SearchDAO SEARCH_DAO = new SearchDAO();
+
+	private JsonResultResponse<Map<String, Object>> getDistinctSubjects(List<String> categories, String referenceCurie) {
+		BoolQueryBuilder query = boolQuery()
+			.filter(termsQuery("category", categories))
+			.must(termQuery("references.curie.keyword", referenceCurie));
+
+		AggregationBuilder agg = AggregationBuilders
+			.terms("subjects")
+			.field("subject.primaryExternalId.keyword")
+			.size(1000)
+			.subAggregation(AggregationBuilders.topHits("sample").size(1)
+				.fetchSource(new String[]{"subject"}, null));
+
+		SearchResponse searchResponse = SEARCH_DAO.performQuery(
+			(QueryBuilder) query, List.of(agg), null, List.of("subject"), 0, 0,
+			new org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder(), null, false);
+
+		JsonResultResponse<Map<String, Object>> ret = new JsonResultResponse<>();
+		List<Map<String, Object>> subjects = new ArrayList<>();
+
+		ParsedStringTerms terms = searchResponse.getAggregations().get("subjects");
+		for (Terms.Bucket bucket : terms.getBuckets()) {
+			TopHits topHits = bucket.getAggregations().get("sample");
+			SearchHit[] hits = topHits.getHits().getHits();
+			if (hits.length > 0) {
+				@SuppressWarnings("unchecked")
+				Map<String, Object> src = (Map<String, Object>) hits[0].getSourceAsMap().get("subject");
+				if (src != null) {
+					subjects.add(src);
+				}
+			}
+		}
+
+		ret.setTotal(subjects.size());
+		ret.setResults(subjects);
+		return ret;
+	}
+
+	@FunctionalInterface
+	private interface HitMapper<T> {
+		T map(SearchHit hit);
+	}
+
+	private <T> JsonResultResponse<T> runQuery(BoolQueryBuilder query, Pagination pagination, HitMapper<T> mapper) {
+		addTableFilter(pagination, query);
+		SearchResponse searchResponse = getSearchResponse(query, pagination, null, false);
+
+		JsonResultResponse<T> ret = new JsonResultResponse<>();
+		ret.setTotal((int) searchResponse.getHits().getTotalHits().value);
+
+		List<T> results = new ArrayList<>();
+		for (SearchHit hit : searchResponse.getHits().getHits()) {
+			T doc = mapper.map(hit);
+			if (doc != null) {
+				results.add(doc);
+			}
+		}
+		ret.setResults(results);
+		return ret;
+	}
+
+	private Map<String, Object> hitAsMap(SearchHit hit) {
+		Map<String, Object> source = hit.getSourceAsMap();
+		if (source == null) return null;
+		source.put("uniqueId", hit.getId());
+		return source;
+	}
+}


### PR DESCRIPTION
## Summary
New endpoints powering the Reference Report UI (matching `feature/KANBAN-678` in agr_ui):

Subject tables:
- `GET /api/reference/{id}/genes`
- `GET /api/reference/{id}/alleles`
- `GET /api/reference/{id}/models`

Annotation tables (paginated):
- `GET /api/reference/{id}/disease-annotations`
- `GET /api/reference/{id}/phenotype-annotations`
- `GET /api/reference/{id}/expression-annotations`
- `GET /api/reference/{id}/molecular-interactions`
- `GET /api/reference/{id}/genetic-interactions`
- `GET /api/reference/{id}/orthology`

Related papers:
- `GET /api/reference/{id}/related-papers?limit=10&includeOrthologs=false` - Jaccard-ranked related papers based on shared gene sets, with optional one-hop ortholog expansion

The expression / molecular / genetic interaction endpoints accept an optional `crossReferences` query param so callers can include alternate publication curies (PMID/MOD) in the lookup set.

Supersedes the closed #1611 (which was based on the older pre-SCRUM-6057 stage). Rebased onto current stage — `SearchDAO`, `Pagination`, `JsonResultResponse`, `RestError*` import paths updated; annotation Document classes import from `core.document` (where SCRUM-6057 moved them) rather than the deleted `api.entity` package. Disease annotation deserialization still does the `APIServiceHelper.buildProvidersWithUrl` enrichment so the UI's Disease section Source column populates correctly.

## Test plan
- [ ] `curl 'http://stage.alliancegenome.org/api/reference/AGRKB:101000000828456/genes'` returns distinct genes for that reference
- [ ] Same with `/alleles`, `/models`, `/disease-annotations`, `/phenotype-annotations`, `/expression-annotations`, `/molecular-interactions`, `/genetic-interactions`, `/orthology`
- [ ] `/disease-annotations` response includes a populated `providers` field on each result
- [ ] `curl 'http://stage.alliancegenome.org/api/reference/{id}/related-papers'` returns a ranked list with `sharedGenes`, `jaccard`, `sharedSpecies`
- [ ] `?crossReferences=PMID:12345,WB:WBPaper000xxx` on the cross-reference-aware endpoints expands the lookup set
- [ ] Reference detail page in the matching UI PR renders every section's table

Generated with Claude Code (https://claude.com/claude-code)
