### PR TITLE
SCRUM-5973 Add missing @JsonView to interaction documents

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/document/GeneGeneticInteractionDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/document/GeneGeneticInteractionDocument.java
@@ -1,13 +1,17 @@
 package org.alliancegenome.core.document;
 
+import org.alliancegenome.core.view.PublicView;
 import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.curation_api.model.entities.GeneGeneticInteraction;
+
+import com.fasterxml.jackson.annotation.JsonView;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonView({PublicView.GeneticInteraction.class})
 public class GeneGeneticInteractionDocument extends ESDocument {
 	{
 		category = "gene_genetic_interaction";

--- a/agr_java_core/src/main/java/org/alliancegenome/core/document/GeneMolecularInteractionDocument.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/document/GeneMolecularInteractionDocument.java
@@ -1,13 +1,17 @@
 package org.alliancegenome.core.document;
 
+import org.alliancegenome.core.view.PublicView;
 import org.alliancegenome.curation_api.model.document.es.ESDocument;
 import org.alliancegenome.curation_api.model.entities.GeneMolecularInteraction;
+
+import com.fasterxml.jackson.annotation.JsonView;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonView({PublicView.MolecularInteraction.class})
 public class GeneMolecularInteractionDocument extends ESDocument {
 	{
 		category = "gene_molecular_interaction";


### PR DESCRIPTION
## Summary
- Restores class-level `@JsonView` annotations on `GeneMolecularInteractionDocument` and `GeneGeneticInteractionDocument`
- These were intentionally removed in #1605 (commit `25ca8643d`) as part of Neo4j cleanup, reasoning that they were "no-op" since the indexer's ObjectMapper uses `DEFAULT_VIEW_INCLUSION=true`
- However, the **API side** uses `@JsonView(PublicView.MolecularInteraction.class)` on the REST endpoint (`GeneRESTInterface`), which requires the class-level annotation for Jackson to include the document's fields during response serialization
- Without it, every molecular/genetic interaction result is serialized as `{}`, producing empty rows in the UI tables

## Test plan
- [ ] Build and deploy API to stage
- [ ] Verify `GET /api/gene/HGNC:23113/molecular-interactions` returns populated result objects (currently returns `{}` for each)
- [ ] Verify `GET /api/gene/HGNC:23113/genetic-interactions` returns populated result objects
- [ ] Confirm molecular and genetic interaction tables render data on gene pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)