### PR TITLE
SCRUM-1953 Add UniqueID column to disease file generator

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -236,6 +236,7 @@ public enum FileGeneratorConfig {
 	 */
 	private static Map<String, String> diseaseFieldMap() {
 		Map<String, String> m = new LinkedHashMap<>();
+		m.put("UniqueID", "_uniqueId");
 		m.put("Taxon", "_taxon");
 		m.put("SpeciesName", "_speciesName");
 		m.put("DBobjectType", "_dbObjectType");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -83,6 +83,7 @@ public class DiseaseFileGenerator extends FileGenerator {
 
 			ObjectNode row = JsonNodeFactory.instance.objectNode();
 
+			row.put("_uniqueId", uniqueId);
 			row.put("_taxon", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.curie"));
 			row.put("_speciesName", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.species.fullName"));
 


### PR DESCRIPTION
## Summary
- Adds `UniqueID` as the first column in the disease TSV file output
- Populates the column from `primaryAnnotations[i].uniqueId` (the canonical dedup key from curation)

## Test plan
- [ ] Run disease file generator and verify `UniqueID` appears as the first column header
- [ ] Verify each row contains the correct uniqueId value from the annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)