### PR TITLE
SCRUM-6096 fix multi-curie search for RGD (keyword-only id fields)

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/SearchService.java
@@ -48,6 +48,12 @@ import jakarta.ws.rs.core.UriInfo;
 @RequestScoped
 public class SearchService {
 
+	// SCRUM-6096: tokens matching <PREFIX>:<localId> are treated as exact-curie candidates
+	// and OR'd into the must clause as plain term queries, bypassing Lucene query_string's
+	// split_on_whitespace=false behaviour that otherwise breaks multi-curie searches against
+	// keyword fields (e.g. RGD genes whose primary curie sits only on `curie`).
+	private static final Pattern CURIE_TOKEN_PATTERN = Pattern.compile("^[A-Za-z]+:[A-Za-z0-9_.\\-]+$");
+
 	private static SearchDAO searchDAO = new SearchDAO();
 
 	private SearchHelper searchHelper = new SearchHelper();
@@ -233,7 +239,33 @@ public class SearchService {
 			// this applies individual boosts, if they're in the map
 			builder.fields(searchHelper.getBoostMap());
 
-			bool.must(builder);
+			// SCRUM-6096: query_string against keyword fields handles whitespace-separated
+			// tokens as a single literal, so multi-curie searches like
+			// "RGD:1306828 RGD:628748" return 0 hits whenever the primary curie lives only
+			// on a keyword field. Detect ID-shaped tokens and OR-in plain term queries on
+			// the curie/primary-key/cross-reference keyword fields as a parallel match path.
+			List<String> curieTokens = new ArrayList<>();
+			for (String tok : tokenizeQuery(queryTerm)) {
+				if (CURIE_TOKEN_PATTERN.matcher(tok).matches()) {
+					curieTokens.add(tok);
+				}
+			}
+			if (curieTokens.isEmpty()) {
+				bool.must(builder);
+			} else {
+				BoolQueryBuilder curieMatches = boolQuery();
+				for (String tok : curieTokens) {
+					// Tag each clause with the token name so the response's matched_queries
+					// reflects the exact-term path; otherwise the UI labels the token as
+					// "Missing" because the cross_fields MultiMatch boost named after the
+					// token never matches a curie that lives only on a keyword field.
+					curieMatches.should(termQuery("curie", tok).queryName(tok));
+					curieMatches.should(termQuery("primaryKey", tok).queryName(tok));
+					curieMatches.should(termQuery("globalId.keyword", tok).queryName(tok));
+					curieMatches.should(termQuery("crossReferences.keyword", tok).queryName(tok));
+				}
+				bool.must(boolQuery().should(builder).should(curieMatches).minimumShouldMatch(1));
+			}
 
 		} else {
 			bool.must(matchAllQuery());

--- a/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/helper/SearchHelper.java
@@ -2,6 +2,7 @@ package org.alliancegenome.api.service.helper;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -398,6 +399,39 @@ public class SearchHelper {
 		log.debug("Formatting Results: ");
 		ArrayList<Map<String, Object>> ret = new ArrayList<>();
 
+		// SCRUM-6096: build a result-set-wide "matched" set so an ID-shaped token that
+		// matched some other hit on the page isn't flagged as missing on this hit.
+		// (Per-hit "missing" remains correct for non-ID free-text tokens — those don't
+		// equal a doc's curie/primaryKey/globalId/crossReference so they won't be added
+		// here unless ES itself reports them as matched.)
+		Set<String> globallyMatched = new HashSet<>();
+		if (searchedTerms != null && !searchedTerms.isEmpty()) {
+			for (SearchHit hit : res.getHits()) {
+				if (hit.getMatchedQueries() != null) {
+					for (String n : hit.getMatchedQueries()) {
+						globallyMatched.add(n);
+					}
+				}
+				Set<String> docIds = new HashSet<>();
+				collectStringField(hit.getSourceAsMap(), "curie", docIds);
+				collectStringField(hit.getSourceAsMap(), "primaryKey", docIds);
+				collectStringField(hit.getSourceAsMap(), "globalId", docIds);
+				Object xrefs = hit.getSourceAsMap().get("crossReferences");
+				if (xrefs instanceof Collection) {
+					for (Object x : (Collection<?>) xrefs) {
+						if (x instanceof String) {
+							docIds.add((String) x);
+						}
+					}
+				}
+				for (String t : searchedTerms) {
+					if (docIds.contains(t)) {
+						globallyMatched.add(t);
+					}
+				}
+			}
+		}
+
 		for (SearchHit hit : res.getHits()) {
 			Map<String, List<String>> map = new HashMap<>();
 			for (String key : hit.getHighlightFields().keySet()) {
@@ -441,14 +475,14 @@ public class SearchHelper {
 				hit.getSourceAsMap().put("explanation", hit.getExplanation());
 			}
 
-			hit.getSourceAsMap().put("missingTerms", findMissingTerms(Arrays.asList(hit.getMatchedQueries()), searchedTerms));
+			hit.getSourceAsMap().put("missingTerms", findMissingTerms(Arrays.asList(hit.getMatchedQueries()), searchedTerms, globallyMatched));
 			ret.add(hit.getSourceAsMap());
 		}
 		log.debug("Finished Formatting Results: ");
 		return ret;
 	}
 
-	private List<String> findMissingTerms(List<String> matchedTerms, List<String> searchedTerms) {
+	private List<String> findMissingTerms(List<String> matchedTerms, List<String> searchedTerms, Set<String> globallyMatched) {
 
 		List<String> terms = new ArrayList<>();
 
@@ -462,7 +496,23 @@ public class SearchHelper {
 		terms.addAll(searchedTerms);
 		terms.removeAll(matchedTerms);
 
+		// SCRUM-6096: suppress tokens that matched any hit in the result set. Avoids
+		// labelling RGD:628748 as missing on the RGD:1306828 hit (and vice versa) when
+		// the user searched for both IDs at once. Also covers the ES quirk where a
+		// shared _name between a function_score filter and a main-query clause drops
+		// the name from matched_queries.
+		if (globallyMatched != null) {
+			terms.removeAll(globallyMatched);
+		}
+
 		return terms;
+	}
+
+	private static void collectStringField(Map<String, Object> source, String key, Set<String> sink) {
+		Object v = source.get(key);
+		if (v instanceof String) {
+			sink.add((String) v);
+		}
 	}
 
 	public HighlightBuilder buildHighlights() {


### PR DESCRIPTION
## Summary
- Detect ID-shaped tokens (`PREFIX:localId`) in `SearchService.buildQuery()` and OR-in per-token `term` queries on `curie`, `primaryKey`, `globalId.keyword`, and `crossReferences.keyword`. Bypasses Lucene's `query_string` quirk where multiple whitespace-separated tokens collapse into one literal against keyword fields (the cause of multi-RGD-ID searches returning 0 hits).
- `SearchHelper.formatResults` now computes a result-set-wide "matched" set so an ID token that matched some other hit on the page is not reported as missing on this hit. Also masks an ES behavior where `matched_queries` drops a name shared between a non-matching `function_score` filter and a matching main-query clause.

## Test plan
- [ ] `/search?q=RGD:1306828 RGD:628748&category=gene_search_result` returns both genes; neither row shows a "Missing" label
- [ ] `/search?q=MGI:109583 MGI:88225 MGI:2443012&category=gene_search_result` still returns the three expected mouse genes (regression check)
- [ ] `/search?q=WB:WBGene00000898 WB:WBGene00006896&category=gene_search_result` still returns daf-2 and ver-3 (regression check)
- [ ] Free-text multi-token searches (e.g. `pax2 dna`) still surface "Missing" for tokens that genuinely failed to match anywhere in the result set
