### PR TITLE
SCRUM-6117 fix sort order on disease page model table

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
@@ -328,12 +328,18 @@ public class DiseaseESService extends ESService {
 		// create histogram of select columns of unfiltered query
 		addTableFilter(pagination, bool);
 
-		// Sorting sets for different names of the sorting selection box
+		// Sorting sets for different names of the sorting selection box.
+		// SCRUM-6117: AGM disease annotation docs have no subject.name field — the AGM
+		// name lives at subject.agmFullName.displayText (.sort sub-field carries the
+		// smart_alpha_sort normalizer). The previous subject.name.sort keys silently
+		// no-op'd, which is why model sort did nothing and the secondary/tertiary AGM
+		// tier was missing on species/disease sorts. Also add the missing
+		// alpha-by-disease tertiary to the default order.
 		Map<String, List<String>> sortingSetMap = new HashMap<>();
-		sortingSetMap.put("default", List.of("phylogeneticSortingIndex", "subject.name.sort"));
-		sortingSetMap.put("model", List.of("subject.name.sort", "phylogeneticSortingIndex"));
-		sortingSetMap.put("disease", List.of("object.name.sort", "phylogeneticSortingIndex", "subject.name.sort"));
-		sortingSetMap.put("species", List.of("subject.taxon.species.fullName.keyword", "subject.name.sort"));
+		sortingSetMap.put("default", List.of("phylogeneticSortingIndex", "subject.agmFullName.displayText.sort", "object.name.sort"));
+		sortingSetMap.put("model", List.of("subject.agmFullName.displayText.sort", "phylogeneticSortingIndex"));
+		sortingSetMap.put("disease", List.of("object.name.sort", "phylogeneticSortingIndex", "subject.agmFullName.displayText.sort"));
+		sortingSetMap.put("species", List.of("subject.taxon.species.fullName.keyword", "subject.agmFullName.displayText.sort"));
 
 		LinkedHashMap<String, SortOrder> sortingMap = new LinkedHashMap<>();
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/DiseaseESService.java
@@ -336,10 +336,10 @@ public class DiseaseESService extends ESService {
 		// tier was missing on species/disease sorts. Also add the missing
 		// alpha-by-disease tertiary to the default order.
 		Map<String, List<String>> sortingSetMap = new HashMap<>();
-		sortingSetMap.put("default", List.of("phylogeneticSortingIndex", "subject.agmFullName.displayText.sort", "object.name.sort"));
-		sortingSetMap.put("model", List.of("subject.agmFullName.displayText.sort", "phylogeneticSortingIndex"));
-		sortingSetMap.put("disease", List.of("object.name.sort", "phylogeneticSortingIndex", "subject.agmFullName.displayText.sort"));
-		sortingSetMap.put("species", List.of("subject.taxon.species.fullName.keyword", "subject.agmFullName.displayText.sort"));
+		sortingSetMap.put("default", List.of("phylogeneticSortingIndex", "subject.agmFullName.displayText.keyword", "object.name.sort"));
+		sortingSetMap.put("model", List.of("subject.agmFullName.displayText.keyword", "phylogeneticSortingIndex"));
+		sortingSetMap.put("disease", List.of("object.name.sort", "phylogeneticSortingIndex", "subject.agmFullName.displayText.keyword"));
+		sortingSetMap.put("species", List.of("subject.taxon.species.fullName.keyword", "subject.agmFullName.displayText.keyword"));
 
 		LinkedHashMap<String, SortOrder> sortingMap = new LinkedHashMap<>();
 


### PR DESCRIPTION
## Summary
- Repoint the disease-page model table sorts from the non-existent `subject.name.sort` field to `subject.agmFullName.displayText.sort` (smart-alpha) for AGM disease annotations.
- Add the missing alpha-by-disease tertiary (`object.name.sort`) to the default sort order.

## Why
AGM disease-annotation docs index the AGM name at `subject.agmFullName.displayText` — there is no `subject.name`. The old sort spec keys all pointed at `subject.name.sort`, which ES silently treats as missing/`_last`, so every AGM-name sort tier no-op'd. This is why:
- The default order showed only the phylogenetic primary,
- The model sort did not appear to sort at all,
- The species sort did not apply the secondary AGM-name tier,
- The disease sort did not apply the tertiary AGM-name tier.

The fix targets the field that actually exists on these docs (with a `.sort` sub-field that carries the `smart_alpha_sort` normalizer — verified against the live mapping).

## Test plan
- [ ] `/disease/DOID:14330` (Susan's example) — model rows order by phylogenetic species, then smart-alpha by AGM name, then alpha by disease
- [ ] Switch to model column sort — rows order by smart-alpha AGM name, then phylogenetic
- [ ] Switch to species column sort — rows order by species, then smart-alpha AGM name
- [ ] Switch to disease column sort — rows order by disease, then phylogenetic species, then smart-alpha AGM name
- [ ] Existing gene and allele disease tables are untouched (regression check)
