### PR TITLE
SCRUM-6019 fix VCF INFO fields, sort rows, address Chris review

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/es/EsParallelFetcher.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/es/EsParallelFetcher.java
@@ -58,7 +58,7 @@ public class EsParallelFetcher {
 		try {
 			return es.search(index, body);
 		} catch (Exception e) {
-			log.warn("search() failed on {}: {}", index, e.getMessage());
+			log.warn("search() failed on {}: {}", index, e.getMessage(), e);
 			return null;
 		}
 	}

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
@@ -286,7 +286,8 @@ public class VariantVcfFileGenerator extends FileGenerator {
 		}
 		appendKv(sb, "geneLevelConsequence", String.join("|", geneLevel));
 
-		// transcriptLevelConsequence — pipe-joined unique names across all predictedVariantConsequences[*].vepConsequences[*]. transcriptImpact and geneSymbols collected during the same pass for cache locality. Transcript IDs are kept per-transcript (comma-joined, dedup) — allele_of_transcript_ids gets the MOD prefix per legacy format, the two gff3_* keys carry the unprefixed transcript name.
+		// transcriptLevelConsequence — pipe-joined unique names across all predictedVariantConsequences[*].vepConsequences[*]. transcriptImpact and geneSymbols collected during the same pass.
+		// Transcript IDs are kept per-transcript (comma-joined, dedup) — allele_of_transcript_ids gets the MOD prefix per legacy format, the two gff3_* keys carry the unprefixed transcript name.
 		LinkedHashSet<String> txLevel = new LinkedHashSet<>();
 		LinkedHashSet<String> txImpacts = new LinkedHashSet<>();
 		List<String> geneSymbols = new ArrayList<>();

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
@@ -70,6 +70,9 @@ public class VariantVcfFileGenerator extends FileGenerator {
 			String prefix = mod + ":";
 			Map<String, Object> body = buildContigAggBody(prefix);
 			Map<String, Object> resp = fetcher.search(body);
+			if (resp == null) {
+				log.warn("{}: contig pre-pass for MOD {} returned null response — contig header lines will be empty", getClass().getSimpleName(), mod);
+			}
 			String contigLines = renderContigLines(resp);
 			contigLinesByMod.put(mod, contigLines);
 			log.info("{}: contig pre-pass for MOD {} produced {} line(s)", getClass().getSimpleName(), mod, contigLines.isEmpty() ? 0 : contigLines.split("\n").length);
@@ -248,24 +251,44 @@ public class VariantVcfFileGenerator extends FileGenerator {
 		obj.put("_alt", alt);
 		obj.put("_qual", ".");
 		obj.put("_filter", ".");
-		obj.put("_info", buildInfo(hit, loc, id));
+		String alleleId = JsonPath.resolveString(hit, "allele.primaryExternalId");
+		obj.put("_info", buildInfo(hit, loc, id, alleleId));
 
 		return hit;
 	}
 
-	private static String buildInfo(JsonNode hit, JsonNode loc, String hgvs) {
+	private static String buildInfo(JsonNode hit, JsonNode loc, String hgvs, String alleleId) {
 		StringBuilder sb = new StringBuilder();
 
 		appendKv(sb, "hgvs_nomenclature", hgvs);
 
-		String geneLevel = loc == null ? "" : firstNonEmpty(
-				loc.path("mostSevereConsequence").path("variantConsequence").path("name").asText(""),
-				loc.path("mostSevereConsequence").path("vepConsequences").path(0).path("name").asText(""));
-		appendKv(sb, "geneLevelConsequence", geneLevel);
+		// MOD prefix derived from the allele curie (e.g., "WB:WBVar..." -> "WB:") — applied to transcript IDs to match legacy VCF format.
+		String modPrefix = "";
+		if (alleleId != null) {
+			int colon = alleleId.indexOf(':');
+			if (colon > 0) {
+				modPrefix = alleleId.substring(0, colon + 1);
+			}
+		}
 
-		// transcriptLevelConsequence — comma-joined names from each predictedVariantConsequences entry's vepConsequences[0]
-		List<String> txLevel = new ArrayList<>();
-		List<String> txImpacts = new ArrayList<>();
+		// geneLevelConsequence — pipe-joined unique names across mostSevereConsequence.vepConsequences[*].
+		LinkedHashSet<String> geneLevel = new LinkedHashSet<>();
+		if (loc != null) {
+			JsonNode vepCs = loc.path("mostSevereConsequence").path("vepConsequences");
+			if (vepCs.isArray()) {
+				for (JsonNode v : vepCs) {
+					String n = v.path("name").asText("");
+					if (!n.isEmpty()) {
+						geneLevel.add(n);
+					}
+				}
+			}
+		}
+		appendKv(sb, "geneLevelConsequence", String.join("|", geneLevel));
+
+		// transcriptLevelConsequence — pipe-joined unique names across all predictedVariantConsequences[*].vepConsequences[*]. transcriptImpact and geneSymbols collected during the same pass for cache locality. Transcript IDs are kept per-transcript (comma-joined, dedup) — allele_of_transcript_ids gets the MOD prefix per legacy format, the two gff3_* keys carry the unprefixed transcript name.
+		LinkedHashSet<String> txLevel = new LinkedHashSet<>();
+		LinkedHashSet<String> txImpacts = new LinkedHashSet<>();
 		List<String> geneSymbols = new ArrayList<>();
 		List<String> transcriptIds = new ArrayList<>();
 		List<String> transcriptGff3Ids = new ArrayList<>();
@@ -274,9 +297,14 @@ public class VariantVcfFileGenerator extends FileGenerator {
 			JsonNode pvc = loc.path("predictedVariantConsequences");
 			if (pvc.isArray()) {
 				for (JsonNode entry : pvc) {
-					String c = entry.path("vepConsequences").path(0).path("name").asText("");
-					if (!c.isEmpty()) {
-						txLevel.add(c);
+					JsonNode vepCs = entry.path("vepConsequences");
+					if (vepCs.isArray()) {
+						for (JsonNode v : vepCs) {
+							String n = v.path("name").asText("");
+							if (!n.isEmpty()) {
+								txLevel.add(n);
+							}
+						}
 					}
 					String imp = entry.path("vepImpact").path("name").asText("");
 					if (!imp.isEmpty()) {
@@ -289,26 +317,20 @@ public class VariantVcfFileGenerator extends FileGenerator {
 					}
 					String tn = entry.path("variantTranscript").path("name").asText("");
 					if (!tn.isEmpty()) {
-						transcriptIds.add(tn);
-					}
-					String gff3Id = entry.path("variantTranscript").path("modCrossRefCompleteUrl").asText("");
-					if (!gff3Id.isEmpty()) {
-						transcriptGff3Ids.add(gff3Id);
-					}
-					String gff3Name = entry.path("variantTranscript").path("displayName").asText("");
-					if (!gff3Name.isEmpty()) {
-						transcriptGff3Names.add(gff3Name);
+						transcriptIds.add(modPrefix + tn);
+						transcriptGff3Ids.add(tn);
+						transcriptGff3Names.add(tn);
 					}
 				}
 			}
 		}
-		appendKv(sb, "transcriptLevelConsequence", String.join(",", txLevel));
+		appendKv(sb, "transcriptLevelConsequence", String.join("|", txLevel));
 
 		String geneImpact = loc == null ? "" : loc.path("mostSevereConsequence").path("vepImpact").path("name").asText("");
 		appendKv(sb, "geneImpact", geneImpact);
-		appendKv(sb, "transcriptImpact", String.join(",", txImpacts));
+		appendKv(sb, "transcriptImpact", String.join("|", txImpacts));
 
-		appendKv(sb, "allele_ids", JsonPath.resolveString(hit, "allele.primaryExternalId"));
+		appendKv(sb, "allele_ids", alleleId);
 		appendKv(sb, "allele_symbols", JsonPath.resolveString(hit, "allele.alleleSymbol.displayText"));
 		appendKv(sb, "allele_symbols_text", JsonPath.resolveString(hit, "allele.alleleSymbol.formatText"));
 
@@ -330,15 +352,6 @@ public class VariantVcfFileGenerator extends FileGenerator {
 			sb.append(";");
 		}
 		sb.append(key).append("=\"").append(value == null ? "" : value).append("\"");
-	}
-
-	private static String firstNonEmpty(String... values) {
-		for (String v : values) {
-			if (v != null && !v.isEmpty()) {
-				return v;
-			}
-		}
-		return "";
 	}
 
 	private static List<String> collectArrayStrings(JsonNode arr) {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/writers/VcfWriter.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/writers/VcfWriter.java
@@ -13,6 +13,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,8 @@ public class VcfWriter implements RowWriter {
 	private final Path path;
 	private final BufferedWriter writer;
 	private final List<String> esPaths;
+	// Rows are buffered then sorted on close so the table is emitted in CHROM (smart-alpha) then POS (numeric) order — matches the legacy VCF format and lets downstream tools rely on positional ordering.
+	private final List<String[]> bufferedRows = new ArrayList<>();
 	private long rowCount;
 
 	public VcfWriter(Path path, Map<String, String> fieldMap) throws IOException {
@@ -107,16 +110,12 @@ public class VcfWriter implements RowWriter {
 
 	@Override
 	public synchronized void writeRow(JsonNode hit) throws IOException {
-		StringBuilder sb = new StringBuilder();
+		String[] cells = new String[esPaths.size()];
 		for (int i = 0; i < esPaths.size(); i++) {
-			if (i > 0) {
-				sb.append("\t");
-			}
 			String v = JsonPath.resolveString(hit, esPaths.get(i));
-			sb.append(v == null || v.isEmpty() ? "." : escape(v));
+			cells[i] = v == null || v.isEmpty() ? "." : escape(v);
 		}
-		sb.append("\n");
-		writer.write(sb.toString());
+		bufferedRows.add(cells);
 		rowCount++;
 	}
 
@@ -132,8 +131,67 @@ public class VcfWriter implements RowWriter {
 
 	@Override
 	public synchronized void close() throws IOException {
+		// Field map ordering is fixed by VariantsVcf in FileGeneratorConfig — cells[0] is CHROM and cells[1] is POS, so sort directly on those indices.
+		bufferedRows.sort(CHROM_THEN_POS);
+		StringBuilder sb = new StringBuilder();
+		for (String[] cells : bufferedRows) {
+			for (int i = 0; i < cells.length; i++) {
+				if (i > 0) {
+					sb.append('\t');
+				}
+				sb.append(cells[i]);
+			}
+			sb.append('\n');
+		}
+		writer.write(sb.toString());
 		writer.flush();
 		writer.close();
+	}
+
+	// Numeric chromosomes (1, 2, 3, ...) come first in numeric order, then non-numeric (MT, X, Y, MtDNA, ...) in lexical order. Within a chrom, POS is sorted numerically.
+	private static final Comparator<String[]> CHROM_THEN_POS = (a, b) -> {
+		int c = compareChrom(a[0], b[0]);
+		if (c != 0) {
+			return c;
+		}
+		return Long.compare(parsePos(a[1]), parsePos(b[1]));
+	};
+
+	private static int compareChrom(String a, String b) {
+		Integer ia = parseChromInt(a);
+		Integer ib = parseChromInt(b);
+		if (ia != null && ib != null) {
+			return Integer.compare(ia, ib);
+		}
+		if (ia != null) {
+			return -1;
+		}
+		if (ib != null) {
+			return 1;
+		}
+		return a.compareTo(b);
+	}
+
+	private static Integer parseChromInt(String s) {
+		if (s == null || s.isEmpty()) {
+			return null;
+		}
+		try {
+			return Integer.valueOf(s);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	private static long parsePos(String s) {
+		if (s == null || s.isEmpty() || ".".equals(s)) {
+			return Long.MAX_VALUE;
+		}
+		try {
+			return Long.parseLong(s);
+		} catch (NumberFormatException e) {
+			return Long.MAX_VALUE;
+		}
 	}
 
 	private static String escape(String s) {

--- a/agr_java_core/src/main/java/org/alliancegenome/core/es/util/IndexManager.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/es/util/IndexManager.java
@@ -368,7 +368,7 @@ public class IndexManager {
 				request.verify(true);
 				request.timeout(new TimeValue(30, TimeUnit.MINUTES));
 
-				log.info(repoName + " -> s3://agr-es-backup/" + fullBasePath );
+				log.info(repoName + " -> s3://agr-es-backup/" + fullBasePath);
 
 				AcknowledgedResponse response = closableSearchClient.snapshot().createRepository(request, RequestOptions.DEFAULT);
 


### PR DESCRIPTION
## Summary

Addresses items 1–4 from Chris Grove's review of the new VCF download files on [SCRUM-6019](https://agr-jira.atlassian.net/browse/SCRUM-6019).

- **Pipe-join unique consequences** — `geneLevelConsequence` and `transcriptLevelConsequence` are now pipe-joined unique across all `vepConsequences[*].name`. Previously the code only took `vepConsequences[0]` per transcript and comma-joined per-transcript.
- **MOD-prefixed transcript IDs** — `allele_of_transcript_ids` now carries the MOD prefix derived from `allele.primaryExternalId` (e.g. `WB:F25H8.6.1`).
- **gff3_ids / gff3_names populated** — both fields are now filled from `variantTranscript.name` (unprefixed). Previously they were empty because the old code referenced ES fields that don't exist in the new data model (`modCrossRefCompleteUrl`, `displayName`).
- **`transcriptImpact` pipe-joined unique** — was comma-joined and not deduped.
- **Rows sorted by CHROM then POS** — `VcfWriter` now buffers rendered rows and sorts on close: numeric chroms ascending first, then non-numeric lexical; POS sorted numerically within a chrom.
- **Better diagnostics on contig pre-pass failure** — `EsParallelFetcher.search()` now logs the full stack trace, and `precomputeContigLines` emits an explicit warn when the response is null, so silent ES errors are visible in future runs.

Verified end-to-end against Chris's two cited test variants:

- `NC_003282.8:g.10068797G>A` — INFO now has `WB:W01B6.1.1` + populated gff3_*.
- `NC_003282.8:g.9919497_9919910del` — `geneLevelConsequence` / `transcriptLevelConsequence` exactly match the old VCF: `splice_acceptor_variant|splice_donor_variant|frameshift_variant|stop_lost|splice_donor_5th_base_variant|intron_variant`.

Items 5 (padded base for deletions/delins) and 6 (one row per variant when multiple alleles share a variant) are deferred to follow-up tickets — both need bigger design discussions (FASTA lookup vs upstream variant indexer change; group-by-hgvs in the writer).

## Test plan

- [x] `mvn -pl agr_file_generator -am -DskipTests package` builds cleanly
- [x] Regenerated `VARIANT-CONSEQUENCE_VCF_{WB,MGI,RGD,FB,ZFIN}.vcf.gz` locally
- [x] WB file: 7 `##contig` lines, rows sorted CHROM I→V→X→MtDNA then POS ascending
- [x] MGI file: 21 `##contig` lines (1–19, MT, X), GRCm39 assembly
- [x] Chris's test variants produce the expected old-format INFO strings

[SCRUM-6019]: https://agr-jira.atlassian.net/browse/SCRUM-6019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ