### PR TITLE
SCRUM-6019 VCF: smart-alpha sort, padding, IUPAC, INFO escape, htsjdk validator

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
@@ -1,14 +1,13 @@
 package org.alliancegenome.filegenerator.generators;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.alliancegenome.core.util.SmartAlphaComparator;
 import org.alliancegenome.filegenerator.config.FileGeneratorConfig;
 import org.alliancegenome.filegenerator.es.EsParallelFetcher;
 import org.alliancegenome.filegenerator.writers.JsonPath;
@@ -131,24 +130,8 @@ public class VariantVcfFileGenerator extends FileGenerator {
 			tuples.add(new String[] { chrom, assembly, spp });
 		}
 
-		// Numeric chroms ascend by parsed integer, then non-numeric chroms follow lexically — keeps 1..21 before X, Y, MtDNA, etc.
-		Comparator<String[]> byChrom = (a, b) -> {
-			String ca = a[0];
-			String cb = b[0];
-			Integer ia = parseChromInt(ca);
-			Integer ib = parseChromInt(cb);
-			if (ia != null && ib != null) {
-				return Integer.compare(ia, ib);
-			}
-			if (ia != null) {
-				return -1;
-			}
-			if (ib != null) {
-				return 1;
-			}
-			return ca.compareTo(cb);
-		};
-		Collections.sort(tuples, byChrom);
+		// Smart-alpha (natural sort) on the chrom string keeps Drosophila's 2L/2R/3L/3R/4 in mod-order while still putting Mouse's 1..19 before MT/X/Y and Worm's I/II/III/IV before V/X.
+		tuples.sort((a, b) -> SmartAlphaComparator.INSTANCE.compare(a[0], b[0]));
 
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < tuples.size(); i++) {
@@ -161,17 +144,6 @@ public class VariantVcfFileGenerator extends FileGenerator {
 					.append(",species=\"").append(t[2]).append("\">");
 		}
 		return sb.toString();
-	}
-
-	private static Integer parseChromInt(String s) {
-		if (s == null || s.isEmpty()) {
-			return null;
-		}
-		try {
-			return Integer.valueOf(s);
-		} catch (NumberFormatException e) {
-			return null;
-		}
 	}
 
 	@Override

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.alliancegenome.core.util.SmartAlphaComparator;
 import org.alliancegenome.filegenerator.config.FileGeneratorConfig;
@@ -41,6 +42,10 @@ public class VariantVcfFileGenerator extends FileGenerator {
 	private static final String CHROM_PATH = "variantList.curatedVariantGenomicLocations.variantGenomicLocationAssociationObject.name";
 	private static final String ASSEMBLY_PATH = "variantList.curatedVariantGenomicLocations.variantGenomicLocationAssociationObject.genomeAssembly.primaryExternalId";
 	private static final String SPECIES_PATH = "allele.taxon.species.fullName";
+	// IUPAC ambiguity codes that need to be wrapped in angle brackets to remain valid as a VCF ALT (they reference the corresponding ##ALT=<ID=..> declarations in the header).
+	private static final Set<Character> IUPAC_AMBIGUITY_CODES = Set.of('R', 'Y', 'S', 'W', 'K', 'M', 'B', 'D', 'H', 'V');
+	// VCF v4.3 INFO values cannot contain whitespace; appendKv replaces matches with underscore so the field parses while preserving the symbol token.
+	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
 	private final Map<String, String> contigLinesByMod = new LinkedHashMap<>();
 
@@ -210,10 +215,29 @@ public class VariantVcfFileGenerator extends FileGenerator {
 		String alt = "";
 		if (loc != null && loc.isObject()) {
 			chrom = loc.path("variantGenomicLocationAssociationObject").path("name").asText("");
-			pos = loc.path("start").asText("");
 			id = loc.path("hgvs").asText("");
-			ref = loc.path("referenceSequence").asText("");
-			alt = loc.path("variantSequence").asText("");
+			long start = loc.path("start").asLong(0);
+			String rawRef = loc.path("referenceSequence").asText("");
+			// IUPAC ambiguity codes in the ALT have to be wrapped in angle brackets so they reference the ##ALT=<ID=R,...> header lines (VCF v4.3 symbolic alleles); the legacy python generator did the same substitution.
+			String rawAlt = wrapIupacAmbiguityCodes(loc.path("variantSequence").asText(""));
+			String paddedBase = loc.path("paddedBase").asText("");
+			// VCF v4.3 §5.1: insertions/deletions/delins require a padding base at POS = start - 1 so REF and ALT are non-empty. When paddedBase is absent on an indel/delins we silently emit unpadded — matches the legacy python generator's quiet fall-through.
+			boolean isInsertion = rawRef.isEmpty() && !rawAlt.isEmpty();
+			boolean isDeletion = rawAlt.isEmpty() && !rawRef.isEmpty();
+			boolean isDelins = !rawRef.isEmpty() && !rawAlt.isEmpty() && rawRef.length() != rawAlt.length();
+			if (!paddedBase.isEmpty() && isInsertion) {
+				ref = paddedBase;
+				alt = paddedBase + rawAlt;
+				pos = Long.toString(start);
+			} else if (!paddedBase.isEmpty() && (isDeletion || isDelins)) {
+				ref = paddedBase + rawRef;
+				alt = paddedBase + rawAlt;
+				pos = Long.toString(start - 1);
+			} else {
+				ref = rawRef;
+				alt = rawAlt;
+				pos = start > 0 ? Long.toString(start) : "";
+			}
 		}
 
 		obj.put("_chrom", chrom);
@@ -324,7 +348,9 @@ public class VariantVcfFileGenerator extends FileGenerator {
 		if (sb.length() > 0) {
 			sb.append(";");
 		}
-		sb.append(key).append("=\"").append(value == null ? "" : value).append("\"");
+		// VCF v4.3 INFO values cannot contain whitespace (space/tab/newline); replace with underscore to keep the field parseable while preserving the symbol token.
+		String escaped = value == null ? "" : WHITESPACE.matcher(value).replaceAll("_");
+		sb.append(key).append("=\"").append(escaped).append("\"");
 	}
 
 	private static List<String> collectArrayStrings(JsonNode arr) {
@@ -339,6 +365,31 @@ public class VariantVcfFileGenerator extends FileGenerator {
 			}
 		}
 		return out;
+	}
+
+	// VCF v4.3 §1.4.1.1: REF/ALT bases must be one of A/C/G/T/N. IUPAC ambiguity codes (R/Y/S/W/K/M/B/D/H/V) are valid only as symbolic alleles — i.e. when the entire ALT is `<R>`, referencing the matching ##ALT=<ID=R,..> header line.
+	// A single-base ALT made of an IUPAC code is therefore wrapped in angle brackets; the same code embedded in a longer multi-base ALT is collapsed to N (we lose the specific ambiguity but the row stays parseable; the legacy python generator wrapped unconditionally and produced files htsjdk refused to read).
+	private static String wrapIupacAmbiguityCodes(String s) {
+		if (s == null || s.isEmpty()) {
+			return s;
+		}
+		if (s.length() == 1 && IUPAC_AMBIGUITY_CODES.contains(s.charAt(0))) {
+			return "<" + s + ">";
+		}
+		StringBuilder out = null;
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
+			if (IUPAC_AMBIGUITY_CODES.contains(c)) {
+				if (out == null) {
+					out = new StringBuilder(s.length());
+					out.append(s, 0, i);
+				}
+				out.append('N');
+			} else if (out != null) {
+				out.append(c);
+			}
+		}
+		return out == null ? s : out.toString();
 	}
 
 	private static List<String> dedup(List<String> values) {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/tools/VcfValidator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/tools/VcfValidator.java
@@ -1,0 +1,187 @@
+package org.alliancegenome.filegenerator.tools;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import htsjdk.tribble.TribbleException;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFFileReader;
+import htsjdk.variant.vcf.VCFHeader;
+
+/**
+ * Standalone VCF validator. Opens each .vcf.gz file with htsjdk and reports header / record parse errors. Run with:
+ *
+ *   java -cp target/agr_file_generator-jar-with-dependencies.jar org.alliancegenome.filegenerator.tools.VcfValidator <file_or_dir> [...]
+ *
+ * Each argument can be a single .vcf or .vcf.gz file, or a directory (in which case every .vcf / .vcf.gz under it is scanned). Exit code is 0 only when every file parses cleanly.
+ */
+public final class VcfValidator {
+
+	private VcfValidator() {
+	}
+
+	public static void main(String[] args) {
+		if (args.length == 0) {
+			System.err.println("usage: VcfValidator <file_or_dir> [more...]");
+			System.exit(2);
+		}
+
+		List<Path> files = new ArrayList<>();
+		for (String a : args) {
+			Path p = Paths.get(a);
+			if (!Files.exists(p)) {
+				System.err.println("skip (not found): " + p);
+				continue;
+			}
+			if (Files.isDirectory(p)) {
+				try (Stream<Path> walk = Files.walk(p)) {
+					walk.filter(Files::isRegularFile)
+							.filter(f -> {
+								String n = f.getFileName().toString();
+								return n.endsWith(".vcf") || n.endsWith(".vcf.gz");
+							})
+							.sorted(Comparator.comparing(Path::toString))
+							.forEach(files::add);
+				} catch (Exception e) {
+					System.err.println("walk failed: " + p + " — " + e.getMessage());
+				}
+			} else {
+				files.add(p);
+			}
+		}
+
+		if (files.isEmpty()) {
+			System.err.println("no .vcf / .vcf.gz files found");
+			System.exit(2);
+		}
+
+		int failed = 0;
+		for (Path f : files) {
+			Report r = validate(f);
+			System.out.println(r.summary());
+			if (!r.errors.isEmpty()) {
+				failed++;
+				for (String e : r.errors) {
+					System.out.println("    " + e);
+				}
+			}
+		}
+
+		System.out.println();
+		System.out.println(failed == 0
+				? "OK: " + files.size() + " file(s) parsed without errors"
+				: "FAIL: " + failed + "/" + files.size() + " file(s) had errors");
+		System.exit(failed == 0 ? 0 : 1);
+	}
+
+	private static Report validate(Path path) {
+		Report r = new Report(path);
+		long records = 0;
+		try (VCFFileReader reader = new VCFFileReader(path.toFile(), false)) {
+			VCFHeader header = reader.getFileHeader();
+			r.contigCount = header.getContigLines().size();
+			r.infoCount = header.getInfoHeaderLines().size();
+			r.formatCount = header.getFormatHeaderLines().size();
+			r.altCount = header.getMetaDataLine("ALT") != null ? header.getMetaDataInInputOrder().stream().filter(l -> "ALT".equals(l.getKey())).toList().size() : (int) header.getMetaDataInInputOrder().stream().filter(l -> "ALT".equals(l.getKey())).count();
+			for (VariantContext vc : reader) {
+				records++;
+				List<String> issues = recordIssues(vc);
+				if (!issues.isEmpty()) {
+					for (String issue : issues) {
+						r.errors.add("record " + records + " (" + vc.getContig() + ":" + vc.getStart() + " " + vc.getID() + "): " + issue);
+						if (r.errors.size() >= 20) {
+							r.errors.add("(further errors truncated; " + records + " records scanned so far)");
+							r.records = records;
+							return r;
+						}
+					}
+				}
+			}
+		} catch (TribbleException e) {
+			r.errors.add("PARSE ERROR at record ~" + (records + 1) + ": " + e.getMessage());
+		} catch (Exception e) {
+			r.errors.add("UNEXPECTED " + e.getClass().getSimpleName() + ": " + e.getMessage());
+		}
+		r.records = records;
+		return r;
+	}
+
+	private static List<String> recordIssues(VariantContext vc) {
+		List<String> out = new ArrayList<>();
+		Allele ref = vc.getReference();
+		if (ref.getBases().length == 0) {
+			out.add("REF is empty");
+		}
+		if (!isValidBaseString(ref.getBaseString(), true)) {
+			out.add("REF contains non-IUPAC base: " + ref.getBaseString());
+		}
+		for (Allele alt : vc.getAlternateAlleles()) {
+			if (alt.isSymbolic()) {
+				continue;
+			}
+			if (alt.getBases().length == 0) {
+				out.add("ALT is empty");
+				continue;
+			}
+			if (!isValidBaseString(alt.getBaseString(), false)) {
+				out.add("ALT contains non-IUPAC base: " + alt.getBaseString());
+			}
+		}
+		if (vc.getStart() < 1) {
+			out.add("POS < 1: " + vc.getStart());
+		}
+		return out;
+	}
+
+	// REF is A/C/G/T/N only per VCF v4.3 §1.4.1.1; ALT additionally permits the ambiguity codes (R/Y/S/W/K/M/B/D/H/V) we declared in the ##ALT header.
+	private static boolean isValidBaseString(String s, boolean isRef) {
+		for (int i = 0; i < s.length(); i++) {
+			char c = Character.toUpperCase(s.charAt(i));
+			if (c == 'A' || c == 'C' || c == 'G' || c == 'T' || c == 'N' || c == '*') {
+				continue;
+			}
+			if (!isRef && (c == 'R' || c == 'Y' || c == 'S' || c == 'W' || c == 'K' || c == 'M' || c == 'B' || c == 'D' || c == 'H' || c == 'V')) {
+				continue;
+			}
+			return false;
+		}
+		return true;
+	}
+
+	private static final class Report {
+		final Path path;
+		long records;
+		int contigCount;
+		int infoCount;
+		int formatCount;
+		int altCount;
+		final List<String> errors = new ArrayList<>();
+
+		Report(Path path) {
+			this.path = path;
+		}
+
+		String summary() {
+			long bytes = 0;
+			try {
+				bytes = Files.size(path);
+			} catch (Exception ignore) {
+			}
+			return String.format("%-65s records=%-7d contigs=%-3d info=%-3d alt=%-3d size=%dKB %s",
+					path.getFileName(), records, contigCount, infoCount, altCount, bytes / 1024,
+					errors.isEmpty() ? "OK" : "ERRORS=" + errors.size());
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private static File toFile(Path p) {
+		return p.toFile();
+	}
+}

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/tools/VcfValidator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/tools/VcfValidator.java
@@ -173,6 +173,7 @@ public final class VcfValidator {
 			try {
 				bytes = Files.size(path);
 			} catch (Exception ignore) {
+				// size is cosmetic — leave at 0 if we can't read it.
 			}
 			return String.format("%-65s records=%-7d contigs=%-3d info=%-3d alt=%-3d size=%dKB %s",
 					path.getFileName(), records, contigCount, infoCount, altCount, bytes / 1024,

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/writers/VcfWriter.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/writers/VcfWriter.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
+import org.alliancegenome.core.util.SmartAlphaComparator;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
@@ -148,40 +150,14 @@ public class VcfWriter implements RowWriter {
 		writer.close();
 	}
 
-	// Numeric chromosomes (1, 2, 3, ...) come first in numeric order, then non-numeric (MT, X, Y, MtDNA, ...) in lexical order. Within a chrom, POS is sorted numerically.
+	// Smart-alpha CHROM ordering (2L < 2R < 3L < 3R < 4 < X for fly; 1 < 2 < ... < 19 < MT < X for mouse) plus numeric POS within a chrom.
 	private static final Comparator<String[]> CHROM_THEN_POS = (a, b) -> {
-		int c = compareChrom(a[0], b[0]);
+		int c = SmartAlphaComparator.INSTANCE.compare(a[0], b[0]);
 		if (c != 0) {
 			return c;
 		}
 		return Long.compare(parsePos(a[1]), parsePos(b[1]));
 	};
-
-	private static int compareChrom(String a, String b) {
-		Integer ia = parseChromInt(a);
-		Integer ib = parseChromInt(b);
-		if (ia != null && ib != null) {
-			return Integer.compare(ia, ib);
-		}
-		if (ia != null) {
-			return -1;
-		}
-		if (ib != null) {
-			return 1;
-		}
-		return a.compareTo(b);
-	}
-
-	private static Integer parseChromInt(String s) {
-		if (s == null || s.isEmpty()) {
-			return null;
-		}
-		try {
-			return Integer.valueOf(s);
-		} catch (NumberFormatException e) {
-			return null;
-		}
-	}
 
 	private static long parsePos(String s) {
 		if (s == null || s.isEmpty() || ".".equals(s)) {

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/writers/VcfWriter.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/writers/VcfWriter.java
@@ -23,6 +23,8 @@ import org.alliancegenome.core.util.SmartAlphaComparator;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * VCF v4.3 writer. Streams a VCFv4.3-compliant gzipped file with:
  *   1. Static `##` header (loaded from {@code vcf_header_template.txt} resource)
@@ -35,6 +37,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  * as a single dot (`.`) per VCF spec for missing fields, and the INFO column should be a
  * pre-formatted {@code key="value";...} string.
  */
+@Slf4j
 public class VcfWriter implements RowWriter {
 
 	private static final String COLUMN_HEADER = "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO";
@@ -46,6 +49,7 @@ public class VcfWriter implements RowWriter {
 	// Rows are buffered then sorted on close so the table is emitted in CHROM (smart-alpha) then POS (numeric) order — matches the legacy VCF format and lets downstream tools rely on positional ordering.
 	private final List<String[]> bufferedRows = new ArrayList<>();
 	private long rowCount;
+	private long skippedRowCount;
 
 	public VcfWriter(Path path, Map<String, String> fieldMap) throws IOException {
 		this(path, fieldMap, Map.of());
@@ -117,6 +121,11 @@ public class VcfWriter implements RowWriter {
 			String v = JsonPath.resolveString(hit, esPaths.get(i));
 			cells[i] = v == null || v.isEmpty() ? "." : escape(v);
 		}
+		// VCF v4.3 §1.4.1: REF cannot be missing, and REF and ALT must differ. Drop rows where either is true — the underlying ES data is degenerate (e.g. `g.X_YinsZ` with no inserted base, or `g.PC>C` no-op SNVs) and emitting them produces files that htsjdk refuses to parse.
+		if (".".equals(cells[3]) || cells[3].isEmpty() || cells[3].equals(cells[4])) {
+			skippedRowCount++;
+			return;
+		}
 		bufferedRows.add(cells);
 		rowCount++;
 	}
@@ -133,6 +142,9 @@ public class VcfWriter implements RowWriter {
 
 	@Override
 	public synchronized void close() throws IOException {
+		if (skippedRowCount > 0) {
+			log.info("VcfWriter: {} — skipped {} row(s) for empty/duplicate REF (degenerate source data)", path.getFileName(), skippedRowCount);
+		}
 		// Field map ordering is fixed by VariantsVcf in FileGeneratorConfig — cells[0] is CHROM and cells[1] is POS, so sort directly on those indices.
 		bufferedRows.sort(CHROM_THEN_POS);
 		StringBuilder sb = new StringBuilder();

--- a/agr_java_core/src/main/java/org/alliancegenome/core/es/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/es/schema/Mapping.java
@@ -150,6 +150,9 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "alleleDocument.allele.alleleSymbol.formatText", "text").keyword().sortSmartAlpha().build(); //
 		new FieldBuilder(builder, "alleleDocument.allele.taxon.species.fullName", "text").keyword().sortSmartAlpha().build(); //
 		new FieldBuilder(builder, "alleleDocument.phylogeneticSortingIndex", "long").keyword().sortSmartAlpha().build(); //
+		new FieldBuilder(builder, "allele.taxon.species.fullName", "text").keyword().sortSmartAlpha().build(); // variant_summary
+		new FieldBuilder(builder, "allele.taxon.species.genomeAssembly.curie", "text").keyword().build(); // variant_summary
+		new FieldBuilder(builder, "allele.taxon.species.genomeAssembly.primaryExternalId", "text").keyword().build(); // variant_summary
 		new FieldBuilder(builder, "definition", "text").standardText().build(); // go, disease
 
 		new FieldBuilder(builder, "models", "text").keyword().autocomplete().build(); // gene, disease

--- a/agr_java_core/src/main/java/org/alliancegenome/core/util/SmartAlphaComparator.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/util/SmartAlphaComparator.java
@@ -1,0 +1,90 @@
+package org.alliancegenome.core.util;
+
+import java.util.Comparator;
+
+/**
+ * Smart alpha string comparator (a.k.a. natural sort): walks two strings in alternating digit / non-digit chunks, compares digit chunks as integers (leading zeros ignored) and non-digit chunks case-insensitively.
+ *
+ * Designed for chromosome / contig sorting where lexical and pure-numeric comparators both fall short. Examples (each line ordered ascending):
+ *   - 2L, 2R, 3L, 3R, 4, X, Y                  (Drosophila — letter-suffixed numerics come before pure numerics with the same prefix, then non-numeric)
+ *   - 1, 2, ..., 9, 10, 11, ..., 19, MT, X, Y  (Mouse — pure numerics in numeric order, then non-numeric lexical)
+ *   - I, II, III, IV, MtDNA, V, X              (Worm — purely non-numeric chunks fall back to case-insensitive lexical)
+ *
+ * Null and empty strings sort last. Mirrors the spirit of the ES {@code smart_alpha_sort} normalizer (zero-pad digit runs, lowercase) but without the analyzer dependency, so it works wherever a Java {@code Comparator} is needed (e.g. the VCF file generator's contig pre-pass and CHROM-then-POS row sort).
+ */
+public final class SmartAlphaComparator implements Comparator<String> {
+
+	public static final SmartAlphaComparator INSTANCE = new SmartAlphaComparator();
+
+	private SmartAlphaComparator() {
+	}
+
+	@Override
+	public int compare(String a, String b) {
+		if (a == null && b == null) {
+			return 0;
+		}
+		if (a == null || a.isEmpty()) {
+			return 1;
+		}
+		if (b == null || b.isEmpty()) {
+			return -1;
+		}
+
+		int ai = 0;
+		int bi = 0;
+		int alen = a.length();
+		int blen = b.length();
+
+		while (ai < alen && bi < blen) {
+			char ac = a.charAt(ai);
+			char bc = b.charAt(bi);
+			boolean ad = Character.isDigit(ac);
+			boolean bd = Character.isDigit(bc);
+
+			if (ad && bd) {
+				int aStart = ai;
+				while (ai < alen && Character.isDigit(a.charAt(ai))) {
+					ai++;
+				}
+				int bStart = bi;
+				while (bi < blen && Character.isDigit(b.charAt(bi))) {
+					bi++;
+				}
+				// Strip leading zeros for value comparison, fall back to length-then-lex.
+				String aNum = stripLeadingZeros(a, aStart, ai);
+				String bNum = stripLeadingZeros(b, bStart, bi);
+				if (aNum.length() != bNum.length()) {
+					return Integer.compare(aNum.length(), bNum.length());
+				}
+				int cmp = aNum.compareTo(bNum);
+				if (cmp != 0) {
+					return cmp;
+				}
+				continue;
+			}
+
+			if (ad != bd) {
+				// Digit vs non-digit at the same position — digits sort first (so "4 < X", and earlier-shared chunks have already settled "2L < 4" by the time we get here).
+				return ad ? -1 : 1;
+			}
+
+			int cmp = Character.compare(Character.toLowerCase(ac), Character.toLowerCase(bc));
+			if (cmp != 0) {
+				return cmp;
+			}
+			ai++;
+			bi++;
+		}
+
+		return Integer.compare(alen - ai, blen - bi);
+	}
+
+	private static String stripLeadingZeros(String s, int from, int to) {
+		int i = from;
+		while (i < to - 1 && s.charAt(i) == '0') {
+			i++;
+		}
+		return s.substring(i, to);
+	}
+}


### PR DESCRIPTION
## Summary

Addresses items 1, 2, and 5 from [SCRUM-6019](https://agr-jira.atlassian.net/browse/SCRUM-6019), plus several hardening passes uncovered by running the output through htsjdk's `VCFFileReader`. Items 3 and 4 landed in #1619; item 6 is skipped (per-allele rows validate clean — not a spec violation).

### Sort + contig (items 1 and 2)
- New shared `SmartAlphaComparator` ("natural sort") in `agr_java_core` — singleton.
- `VariantVcfFileGenerator` uses it to sort the `##contig` block; `VcfWriter` uses it for the row CHROM-then-POS sort. Drosophila now emits `2L, 2R, 3L, 3R, 4, X, Y` (was `4` first because of int-first ordering); mouse emits `1..19, MT, X`; worm emits `I, II, III, IV, MtDNA, V, X`.

### Mapping (LTP indexer schema)
- `Mapping.java` gains `allele.taxon.species.fullName`, `allele.taxon.species.genomeAssembly.curie`, and `allele.taxon.species.genomeAssembly.primaryExternalId` so the contig multi_terms aggregation can find keyword sub-fields. Pairs with the agr_curation JsonView changes that landed in v0.50.2 / v0.50.3 / v0.50.4 ([agr_curation#2763](https://github.com/alliance-genome/agr_curation/pull/2763) / [#2766](https://github.com/alliance-genome/agr_curation/pull/2766) / [#2769](https://github.com/alliance-genome/agr_curation/pull/2769)) that surface those fields on `variant_summary` docs.

### Padding (item 5)
`customizeRow` now mirrors the legacy python `_adjust_variant`:

| Type | POS | REF | ALT |
|---|---|---|---|
| SNV / equal-length MNV | `start` | rawRef | rawAlt |
| deletion | `start - 1` | paddedBase + rawRef | paddedBase |
| insertion | `start` | paddedBase | paddedBase + rawAlt |
| unequal-length delins | `start - 1` | paddedBase + rawRef | paddedBase + rawAlt |

When `paddedBase` is missing (curation-side data gap for delins, see [comment](https://agr-jira.atlassian.net/browse/SCRUM-6019?focusedCommentId=84114)) the row falls through to no-padding rather than being dropped. The DB-level backfill is a separate ticket.

### Output hygiene

- `wrapIupacAmbiguityCodes` wraps `R/Y/S/W/K/M/B/D/H/V` in angle brackets (referencing `##ALT=<ID=R,..>`) only when the entire ALT is one IUPAC char; embedded inside a longer ALT they collapse to `N`. Legacy generator wrapped unconditionally and produced files htsjdk refused to read.
- `appendKv` collapses whitespace inside INFO values to `_` so allele symbols like `Cdkn1b<sup>tm1.1 Hjak</sup>` no longer break the INFO field.
- `VcfWriter.writeRow` drops degenerate rows (empty REF or REF == ALT) and logs the per-file skip count.

### Validator

New `agr_file_generator/src/main/java/.../tools/VcfValidator.java`. Run via:

```
java -cp agr_file_generator/target/agr_file_generator-jar-with-dependencies.jar \
  org.alliancegenome.filegenerator.tools.VcfValidator agr_file_generator/data
```

Opens each `.vcf.gz` with htsjdk's `VCFFileReader`, reports parse errors and a summary.

## Validation

Final htsjdk run against locally regenerated files (variant_summary copied from stage):

```
VARIANT-CONSEQUENCE_VCF_FB.vcf.gz    records=14979  contigs=8   info=14  alt=10  OK
VARIANT-CONSEQUENCE_VCF_MGI.vcf.gz   records=6383   contigs=21  info=14  alt=10  OK
VARIANT-CONSEQUENCE_VCF_WB.vcf.gz    records=4152   contigs=7   info=14  alt=10  OK
VARIANT-CONSEQUENCE_VCF_ZFIN.vcf.gz  records=37     contigs=18  info=14  alt=10  OK

OK: 4 file(s) parsed without errors
```

RGD is missing from the test set because stage has 0 RGD `variant_summary` docs (tracked in [SCRUM-6198](https://agr-jira.atlassian.net/browse/SCRUM-6198) — production has 210).

## Test plan

- [x] `mvn -pl agr_file_generator -am -DskipTests package` builds clean.
- [x] All lines ≤ 400 chars (checkstyle).
- [x] Chris's two cited variants still produce the expected INFO (`NC_003282.8:g.10068797G>A` and `NC_003282.8:g.9919497_9919910del`).
- [x] htsjdk validates all four generated files.
- [ ] After deploy + reindex: re-validate with full RGD content (depends on SCRUM-6198).

[SCRUM-6019]: https://agr-jira.atlassian.net/browse/SCRUM-6019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCRUM-6198]: https://agr-jira.atlassian.net/browse/SCRUM-6198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ