### PR TITLE
SCRUM-6019 fix IUPAC after padding, drop delins padding, add ##reference header

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantVcfFileGenerator.java
@@ -48,6 +48,8 @@ public class VariantVcfFileGenerator extends FileGenerator {
 	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
 	private final Map<String, String> contigLinesByMod = new LinkedHashMap<>();
+	// Per-MOD assembly token surfaced into the VCF header as `##reference=...`. Pipe-joined when a MOD has more than one assembly (extremely rare in practice — each MOD typically maps to exactly one).
+	private final Map<String, String> referenceByMod = new LinkedHashMap<>();
 
 	public VariantVcfFileGenerator(FileGeneratorConfig config) {
 		super(config);
@@ -62,7 +64,11 @@ public class VariantVcfFileGenerator extends FileGenerator {
 	@Override
 	protected Map<String, String> headerSubstitutions(String mod) {
 		String contigLines = contigLinesByMod.getOrDefault(mod, "");
-		return Map.of("{contigLines}", contigLines);
+		String reference = referenceByMod.getOrDefault(mod, "");
+		Map<String, String> subs = new LinkedHashMap<>();
+		subs.put("{contigLines}", contigLines);
+		subs.put("{reference}", reference.isEmpty() ? "" : "##reference=" + reference);
+		return subs;
 	}
 
 	/**
@@ -77,9 +83,10 @@ public class VariantVcfFileGenerator extends FileGenerator {
 			if (resp == null) {
 				log.warn("{}: contig pre-pass for MOD {} returned null response — contig header lines will be empty", getClass().getSimpleName(), mod);
 			}
-			String contigLines = renderContigLines(resp);
-			contigLinesByMod.put(mod, contigLines);
-			log.info("{}: contig pre-pass for MOD {} produced {} line(s)", getClass().getSimpleName(), mod, contigLines.isEmpty() ? 0 : contigLines.split("\n").length);
+			List<String[]> tuples = collectContigTuples(resp);
+			contigLinesByMod.put(mod, renderContigLines(tuples));
+			referenceByMod.put(mod, pickAssembly(tuples));
+			log.info("{}: contig pre-pass for MOD {} produced {} line(s); assembly={}", getClass().getSimpleName(), mod, tuples.size(), referenceByMod.get(mod));
 		}
 	}
 
@@ -106,38 +113,39 @@ public class VariantVcfFileGenerator extends FileGenerator {
 	}
 
 	@SuppressWarnings("unchecked")
-	private String renderContigLines(Map<String, Object> resp) {
+	private List<String[]> collectContigTuples(Map<String, Object> resp) {
+		List<String[]> tuples = new ArrayList<>();
 		if (resp == null) {
-			return "";
+			return tuples;
 		}
 		Map<String, Object> aggregations = (Map<String, Object>) resp.get("aggregations");
 		if (aggregations == null) {
-			return "";
+			return tuples;
 		}
 		Map<String, Object> contigs = (Map<String, Object>) aggregations.get("contigs");
 		if (contigs == null) {
-			return "";
+			return tuples;
 		}
 		List<Map<String, Object>> buckets = (List<Map<String, Object>>) contigs.get("buckets");
-		if (buckets == null || buckets.isEmpty()) {
-			return "";
+		if (buckets == null) {
+			return tuples;
 		}
-
-		List<String[]> tuples = new ArrayList<>();
 		for (Map<String, Object> bucket : buckets) {
 			Object keysObj = bucket.get("key");
 			if (!(keysObj instanceof List<?> keys) || keys.size() < 3) {
 				continue;
 			}
-			String chrom = String.valueOf(keys.get(0));
-			String assembly = String.valueOf(keys.get(1));
-			String spp = String.valueOf(keys.get(2));
-			tuples.add(new String[] { chrom, assembly, spp });
+			tuples.add(new String[] { String.valueOf(keys.get(0)), String.valueOf(keys.get(1)), String.valueOf(keys.get(2)) });
 		}
-
 		// Smart-alpha (natural sort) on the chrom string keeps Drosophila's 2L/2R/3L/3R/4 in mod-order while still putting Mouse's 1..19 before MT/X/Y and Worm's I/II/III/IV before V/X.
 		tuples.sort((a, b) -> SmartAlphaComparator.INSTANCE.compare(a[0], b[0]));
+		return tuples;
+	}
 
+	private static String renderContigLines(List<String[]> tuples) {
+		if (tuples.isEmpty()) {
+			return "";
+		}
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < tuples.size(); i++) {
 			String[] t = tuples.get(i);
@@ -149,6 +157,17 @@ public class VariantVcfFileGenerator extends FileGenerator {
 					.append(",species=\"").append(t[2]).append("\">");
 		}
 		return sb.toString();
+	}
+
+	// Each MOD typically has exactly one assembly across its variant_summary docs (FB=R6, MGI=GRCm39, WB=WBcel235, etc.). On the rare chance a MOD ships multiple assemblies, pipe-join the unique values so the `##reference` line stays a single string.
+	private static String pickAssembly(List<String[]> tuples) {
+		LinkedHashSet<String> assemblies = new LinkedHashSet<>();
+		for (String[] t : tuples) {
+			if (t[1] != null && !t[1].isEmpty()) {
+				assemblies.add(t[1]);
+			}
+		}
+		return String.join("|", assemblies);
 	}
 
 	@Override
@@ -218,26 +237,27 @@ public class VariantVcfFileGenerator extends FileGenerator {
 			id = loc.path("hgvs").asText("");
 			long start = loc.path("start").asLong(0);
 			String rawRef = loc.path("referenceSequence").asText("");
-			// IUPAC ambiguity codes in the ALT have to be wrapped in angle brackets so they reference the ##ALT=<ID=R,...> header lines (VCF v4.3 symbolic alleles); the legacy python generator did the same substitution.
-			String rawAlt = wrapIupacAmbiguityCodes(loc.path("variantSequence").asText(""));
+			String rawAlt = loc.path("variantSequence").asText("");
 			String paddedBase = loc.path("paddedBase").asText("");
-			// VCF v4.3 §5.1: insertions/deletions/delins require a padding base at POS = start - 1 so REF and ALT are non-empty. When paddedBase is absent on an indel/delins we silently emit unpadded — matches the legacy python generator's quiet fall-through.
+			// VCF v4.3 §5.1 padding: insertion and deletion need a padding base so REF/ALT are non-empty.
+			// Delins does NOT (per Jennifer Smith's clarification on SCRUM-6019); REF carries the deleted bases and ALT the inserted bases as-is at the natural POS. SNV/MNV are emitted as-is. When paddedBase is absent on an indel we silently fall through to no-padding — matches the legacy python generator.
 			boolean isInsertion = rawRef.isEmpty() && !rawAlt.isEmpty();
 			boolean isDeletion = rawAlt.isEmpty() && !rawRef.isEmpty();
-			boolean isDelins = !rawRef.isEmpty() && !rawAlt.isEmpty() && rawRef.length() != rawAlt.length();
 			if (!paddedBase.isEmpty() && isInsertion) {
 				ref = paddedBase;
 				alt = paddedBase + rawAlt;
 				pos = Long.toString(start);
-			} else if (!paddedBase.isEmpty() && (isDeletion || isDelins)) {
+			} else if (!paddedBase.isEmpty() && isDeletion) {
 				ref = paddedBase + rawRef;
-				alt = paddedBase + rawAlt;
+				alt = paddedBase;
 				pos = Long.toString(start - 1);
 			} else {
 				ref = rawRef;
 				alt = rawAlt;
 				pos = start > 0 ? Long.toString(start) : "";
 			}
+			// IUPAC wrap runs AFTER padding so length-1 ALTs (pure SNVs) get symbolic-allele wrapping (<R>) while padded multi-base ALTs collapse embedded ambiguity codes to N. Applying it before padding produced invalid `T<Y>` style ALTs when an insertion's lone inserted base was IUPAC.
+			alt = wrapIupacAmbiguityCodes(alt);
 		}
 
 		obj.put("_chrom", chrom);

--- a/agr_file_generator/src/main/resources/vcf_header_template.txt
+++ b/agr_file_generator/src/main/resources/vcf_header_template.txt
@@ -1,5 +1,6 @@
 ##fileformat=VCFv4.3
 ##fileDate={fileDate}
+{reference}
 ##ALT=<ID=R,Description="IUPAC code R = A/G">
 ##ALT=<ID=Y,Description="IUPAC code Y = C/T">
 ##ALT=<ID=S,Description="IUPAC code S = C/G">


### PR DESCRIPTION
## Summary

Follow-up to #1623 addressing three more points from [~Chris]'s review of the [SCRUM-6019](https://agr-jira.atlassian.net/browse/SCRUM-6019) VCF output:

1. **IUPAC ambiguity wrap moved after padding.** Wrapping before padding produced invalid `T<Y>` ALTs whenever an insertion's lone inserted base was an IUPAC code: `paddedBase + <Y>` = `T<Y>`. Now the wrap runs on the final ALT — length-1 ALTs (pure SNVs) get symbolic `<R>` wrapping, multi-base padded ALTs collapse embedded IUPAC chars to `N`.

2. **Delins no longer pads.** Per Jennifer Smith (via Chris) the VCF convention for delins is REF = deleted sequence, ALT = inserted sequence at the natural POS, no padded base. The padding branch is now limited to pure insertion (ref empty) and pure deletion (alt empty).

3. **`##reference=<assembly>` header per MOD.** The contig pre-pass already knows each MOD's assembly via the multi_terms bucket; capture it into a parallel `referenceByMod` map and surface as a header substitution. Template gains a `{reference}` placeholder right after `##fileDate`.

## Verification

Final htsjdk validator run:

```
VARIANT-CONSEQUENCE_VCF_FB.vcf.gz    records=14979  contigs=8   info=14  alt=10  OK
VARIANT-CONSEQUENCE_VCF_MGI.vcf.gz   records=6383   contigs=21  info=14  alt=10  OK
VARIANT-CONSEQUENCE_VCF_WB.vcf.gz    records=4152   contigs=7   info=14  alt=10  OK
VARIANT-CONSEQUENCE_VCF_ZFIN.vcf.gz  records=37     contigs=18  info=14  alt=10  OK

OK: 4 file(s) parsed without errors
```

Spot checks:

- Chris's `3R:20638121` row is now `REF=T ALT=TN` (was `T<Y>`).
- Delins samples emit at natural POS without padding: `delinsAG REF=CA ALT=AG`, `delinsG REF=CGAGGT ALT=G`, `delinsA REF=AAAGG ALT=A`.
- Each file header has the expected `##reference=` line: FB `R6`, MGI `GRCm39`, WB `WBcel235`, ZFIN `GRCz11`.
- Deletion behavior unchanged — `g.4566594_4567918del` still emits at `POS=4566593`, ALT=paddedBase.
- Zero `embedded_bad` `<IUPAC>` patterns; 139 (FB) / 32 (WB) legitimate symbolic ALTs preserved.

## Test plan

- [x] `mvn -pl agr_file_generator -am -DskipTests package` builds clean.
- [x] Checkstyle clean (`mvn -pl agr_java_core,agr_file_generator checkstyle:check`).
- [x] htsjdk validator passes on all four regenerated files.
- [ ] After deploy + reindex: re-validate with full RGD content (blocked on [SCRUM-6198](https://agr-jira.atlassian.net/browse/SCRUM-6198)).

[SCRUM-6019]: https://agr-jira.atlassian.net/browse/SCRUM-6019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCRUM-6198]: https://agr-jira.atlassian.net/browse/SCRUM-6198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ