### PR TITLE
SCRUM-6197: Fix gene description search (standard_text analyzer)

### DIFF
--- a/agr_java_core/src/main/java/org/alliancegenome/core/es/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/es/schema/Mapping.java
@@ -112,8 +112,8 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "cellularComponentWithParents", "text").keyword().build(); // gene
 		new FieldBuilder(builder, "chromosomes", "text").keyword().build(); // gene
 		new FieldBuilder(builder, "expressionStages", "text").keyword().standardText().build(); // gene
-		new FieldBuilder(builder, "geneSynopsis", "text").build(); // gene
-		new FieldBuilder(builder, "geneSynopsisUrl", "keyword").build(); // gene
+		new FieldBuilder(builder, "geneDescription", "text").analyzer("standard_text").build(); // gene
+		new FieldBuilder(builder, "automatedGeneDescription", "text").analyzer("standard_text").build(); // gene
 		new FieldBuilder(builder, "molecularFunctionAgrSlim", "text").keyword().build(); // gene
 		new FieldBuilder(builder, "molecularFunctionWithParents", "text").keyword().build(); // gene
 		new FieldBuilder(builder, "soTermName", "text").keyword().letterText().build(); // gene


### PR DESCRIPTION
## Problem
Searching the public site for a word that appears next to punctuation in a gene description does not match. Reported case (SCRUM-6197): searching **nicastrin** does not return worm gene **aph-2** (`WB:WBGene00000148`), whose `automatedGeneDescription` contains "...Orthologous to human NCSTN (nicastrin)."

## Root cause
`geneDescription` and `automatedGeneDescription` were never explicitly mapped, so they fell through to ES **dynamic mapping**, which applies the index's `default` analyzer — a **whitespace tokenizer**. That keeps punctuation attached to tokens, so `(nicastrin)` is indexed as the token `(nicastrin).` and a search for `nicastrin` never matches. Same pattern affected sentence-final words like `oocyte.`. Verified end-to-end against stage ES via `_termvectors` and `_analyze`.

## Fix
Explicitly map both description fields with the existing `standard_text` analyzer (standard tokenizer + apostrophe + lowercase) as the **main** analyzer. With no separate `search_analyzer`, ES uses `standard_text` at search time too, so punctuation is stripped on **both** index and search sides. `nicastrin`, `(nicastrin)`, and `oocyte.` all match.

Also removes the stale `geneSynopsis`/`geneSynopsisUrl` mappings (renamed to `geneDescription`, no longer populated; confirmed no remaining consumers).

## Notes
- No `SearchHelper`/`SearchService` change needed — the bare fields are already in the searchFields list and the function-score boost targets them.
- `.keyword()` intentionally omitted — no references anywhere, and a keyword sub-field on long description text risks the Lucene 32766-byte term limit without `ignore_above`.
- ⚠️ **Requires a full site-index reindex** (`IndexerStage`) to take effect — mapping changes only apply to newly built indices.

## Verification
- `mvn -pl agr_java_core -am compile` → success.