### PR TITLE
KANBAN-1387: Index literatureSummary fields and add latest-papers-per-MOD endpoint

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
@@ -242,6 +242,16 @@ public class LiteratureController implements LiteratureRESTInterface {
 		}
 	}
 
+	@Override
+	public JsonResultResponse<Map<String, Object>> getLatestLiteratureSummariesByMod(String q, Integer latest) {
+		long startTime = System.currentTimeMillis();
+		try {
+			return timed(referenceDataESService.getLatestLiteratureSummaryByMod(q, latest), startTime);
+		} catch (Exception e) {
+			throw restError("Error while retrieving latest literature summaries by MOD", e);
+		}
+	}
+
 	// Expression / molecular-interaction / genetic-interaction docs on stage ES are
 	// indexed by PMID/MOD curie (referenceId / evidence.referenceID), not by AGRKB curie.
 	// The {id} path param can't be used to scope these queries, so the caller must pass

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
@@ -243,7 +243,7 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<Map<String, Object>> getLatestLiteratureSummariesByMod(String q, Integer latest) {
+	public JsonResultResponse<LiteratureSummaryDocument> getLatestLiteratureSummariesByMod(String q, Integer latest) {
 		long startTime = System.currentTimeMillis();
 		try {
 			return timed(referenceDataESService.getLatestLiteratureSummaryByMod(q, latest), startTime);

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/LiteratureController.java
@@ -243,12 +243,12 @@ public class LiteratureController implements LiteratureRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<LiteratureSummaryDocument> getLatestLiteratureSummariesByMod(String q, Integer latest) {
+	public JsonResultResponse<LiteratureSummaryDocument> getLatestLiteratureByDiseasePerMod(String disease, Integer latest) {
 		long startTime = System.currentTimeMillis();
 		try {
-			return timed(referenceDataESService.getLatestLiteratureSummaryByMod(q, latest), startTime);
+			return timed(referenceDataESService.getLatestLiteratureByDiseasePerMod(disease, latest), startTime);
 		} catch (Exception e) {
-			throw restError("Error while retrieving latest literature summaries by MOD", e);
+			throw restError("Error while retrieving latest literature by disease per MOD", e);
 		}
 	}
 

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
@@ -158,4 +158,12 @@ public interface LiteratureRESTInterface {
 	JsonResultResponse<Map<String, Object>> getModelsByReference(
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id);
 
+	@GET
+	@Path("/literature-summaries-by-mod")
+	@Operation(summary = "Retrieve the latest literature summaries per MOD whose title or abstract match the search term")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "Latest matching literature summaries grouped by MOD", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<Map<String, Object>> getLatestLiteratureSummariesByMod(
+		@Parameter(in = ParameterIn.QUERY, name = "q", description = "Term to match in title or abstract", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("diabetes") @QueryParam("q") String q,
+		@Parameter(in = ParameterIn.QUERY, name = "latest", description = "Number of most-recent papers to return per MOD", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("latest") Integer latest);
+
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
@@ -159,11 +159,11 @@ public interface LiteratureRESTInterface {
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Reference curie", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id);
 
 	@GET
-	@Path("/literature-summaries-by-mod")
-	@Operation(summary = "Retrieve the latest literature summaries per MOD whose title or abstract match the search term")
-	@APIResponses(value = { @APIResponse(responseCode = "200", description = "Latest matching literature summaries grouped by MOD", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
-	JsonResultResponse<LiteratureSummaryDocument> getLatestLiteratureSummariesByMod(
-		@Parameter(in = ParameterIn.QUERY, name = "q", description = "Term to match in title or abstract", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("diabetes") @QueryParam("q") String q,
+	@Path("/latest-literature-by-disease-per-mod")
+	@Operation(summary = "Retrieve the latest literature summaries per MOD whose title or abstract match the given disease")
+	@APIResponses(value = { @APIResponse(responseCode = "200", description = "Latest matching literature summaries per MOD", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
+	JsonResultResponse<LiteratureSummaryDocument> getLatestLiteratureByDiseasePerMod(
+		@Parameter(in = ParameterIn.QUERY, name = "disease", description = "Disease to match in title or abstract", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("diabetes") @QueryParam("disease") String disease,
 		@Parameter(in = ParameterIn.QUERY, name = "latest", description = "Number of most-recent papers to return per MOD", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("latest") Integer latest);
 
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/LiteratureRESTInterface.java
@@ -162,7 +162,7 @@ public interface LiteratureRESTInterface {
 	@Path("/literature-summaries-by-mod")
 	@Operation(summary = "Retrieve the latest literature summaries per MOD whose title or abstract match the search term")
 	@APIResponses(value = { @APIResponse(responseCode = "200", description = "Latest matching literature summaries grouped by MOD", content = @Content(mediaType = "application/json", schema = @Schema(implementation = Null.class))) })
-	JsonResultResponse<Map<String, Object>> getLatestLiteratureSummariesByMod(
+	JsonResultResponse<LiteratureSummaryDocument> getLatestLiteratureSummariesByMod(
 		@Parameter(in = ParameterIn.QUERY, name = "q", description = "Term to match in title or abstract", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("diabetes") @QueryParam("q") String q,
 		@Parameter(in = ParameterIn.QUERY, name = "latest", description = "Number of most-recent papers to return per MOD", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("1") @QueryParam("latest") Integer latest);
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
@@ -1,6 +1,7 @@
 package org.alliancegenome.api.service;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 
@@ -39,6 +40,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.TopHits;
+import org.elasticsearch.search.sort.SortOrder;
 
 import jakarta.enterprise.context.RequestScoped;
 import lombok.extern.slf4j.Slf4j;
@@ -618,6 +620,51 @@ public class ReferenceDataESService extends ESService {
 
 		ret.setTotal(subjects.size());
 		ret.setResults(subjects);
+		return ret;
+	}
+
+	// literatureSummary.title/abstract/mods_in_corpus are indexed as of the Mapping change; match the term in title
+	// OR abstract, bucket by MOD, and keep the `latest` most-recently-published papers per MOD via a top_hits sub-agg.
+	public JsonResultResponse<Map<String, Object>> getLatestLiteratureSummaryByMod(String term, int latest) {
+		BoolQueryBuilder query = boolQuery()
+			.filter(termQuery("category", "literature_summary"))
+			.should(matchQuery("literatureSummary.title", term))
+			.should(matchQuery("literatureSummary.abstract", term))
+			.minimumShouldMatch(1);
+
+		AggregationBuilder agg = AggregationBuilders
+			.terms("by_mod")
+			.field("literatureSummary.mods_in_corpus.keyword")
+			.size(30)
+			.subAggregation(AggregationBuilders.topHits("latest").size(latest)
+				.sort("literatureSummary.date_published.keyword", SortOrder.DESC)
+				.fetchSource(new String[]{"literatureSummary.title", "literatureSummary.date_published", "literatureSummary.curie", "literatureSummary.cross_references", "literatureSummary.mods_in_corpus"}, null));
+
+		SearchResponse searchResponse = SEARCH_DAO.performQuery(
+			(QueryBuilder) query, List.of(agg), null, List.of(), 0, 0,
+			new org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder(), null, false);
+
+		JsonResultResponse<Map<String, Object>> ret = new JsonResultResponse<>();
+		List<Map<String, Object>> rows = new ArrayList<>();
+
+		ParsedStringTerms terms = searchResponse.getAggregations().get("by_mod");
+		for (Terms.Bucket bucket : terms.getBuckets()) {
+			TopHits topHits = bucket.getAggregations().get("latest");
+			List<Object> papers = new ArrayList<>();
+			for (SearchHit hit : topHits.getHits().getHits()) {
+				papers.add(hit.getSourceAsMap().get("literatureSummary"));
+			}
+			if (!papers.isEmpty()) {
+				Map<String, Object> row = new LinkedHashMap<>();
+				row.put("mod", bucket.getKeyAsString());
+				row.put("count", bucket.getDocCount());
+				row.put("latestPapers", papers);
+				rows.add(row);
+			}
+		}
+
+		ret.setTotal(rows.size());
+		ret.setResults(rows);
 		return ret;
 	}
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
@@ -27,6 +27,7 @@ import org.alliancegenome.core.document.GeneDiseaseAnnotationDocument;
 import org.alliancegenome.core.document.GeneGeneticInteractionDocument;
 import org.alliancegenome.core.document.GeneMolecularInteractionDocument;
 import org.alliancegenome.core.document.GenePhenotypeAnnotationDocument;
+import org.alliancegenome.core.document.LiteratureSummaryDocument;
 import org.alliancegenome.core.document.PhenotypeAnnotationDocument;
 import org.alliancegenome.curation_api.model.document.es.GeneExpressionDocument;
 import org.apache.commons.collections4.CollectionUtils;
@@ -625,7 +626,7 @@ public class ReferenceDataESService extends ESService {
 
 	// literatureSummary.title/abstract/mods_in_corpus are indexed as of the Mapping change; match the term in title
 	// OR abstract, bucket by MOD, and keep the `latest` most-recently-published papers per MOD via a top_hits sub-agg.
-	public JsonResultResponse<Map<String, Object>> getLatestLiteratureSummaryByMod(String term, int latest) {
+	public JsonResultResponse<LiteratureSummaryDocument> getLatestLiteratureSummaryByMod(String term, int latest) {
 		BoolQueryBuilder query = boolQuery()
 			.filter(termQuery("category", "literature_summary"))
 			.should(matchQuery("literatureSummary.title", term))
@@ -637,34 +638,28 @@ public class ReferenceDataESService extends ESService {
 			.field("literatureSummary.mods_in_corpus.keyword")
 			.size(30)
 			.subAggregation(AggregationBuilders.topHits("latest").size(latest)
-				.sort("literatureSummary.date_published.keyword", SortOrder.DESC)
-				.fetchSource(new String[]{"literatureSummary.title", "literatureSummary.date_published", "literatureSummary.curie", "literatureSummary.cross_references", "literatureSummary.mods_in_corpus"}, null));
+				.sort("literatureSummary.date_published.keyword", SortOrder.DESC));
 
 		SearchResponse searchResponse = SEARCH_DAO.performQuery(
 			(QueryBuilder) query, List.of(agg), null, List.of(), 0, 0,
 			new org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder(), null, false);
 
-		JsonResultResponse<Map<String, Object>> ret = new JsonResultResponse<>();
-		List<Map<String, Object>> rows = new ArrayList<>();
+		JsonResultResponse<LiteratureSummaryDocument> ret = new JsonResultResponse<>();
+		List<LiteratureSummaryDocument> results = new ArrayList<>();
 
 		ParsedStringTerms terms = searchResponse.getAggregations().get("by_mod");
 		for (Terms.Bucket bucket : terms.getBuckets()) {
 			TopHits topHits = bucket.getAggregations().get("latest");
-			List<Object> papers = new ArrayList<>();
 			for (SearchHit hit : topHits.getHits().getHits()) {
-				papers.add(hit.getSourceAsMap().get("literatureSummary"));
-			}
-			if (!papers.isEmpty()) {
-				Map<String, Object> row = new LinkedHashMap<>();
-				row.put("mod", bucket.getKeyAsString());
-				row.put("count", bucket.getDocCount());
-				row.put("latestPapers", papers);
-				rows.add(row);
+				LiteratureSummaryDocument doc = mapHit(hit, LiteratureSummaryDocument.class);
+				if (doc != null) {
+					results.add(doc);
+				}
 			}
 		}
 
-		ret.setTotal(rows.size());
-		ret.setResults(rows);
+		ret.setTotal(results.size());
+		ret.setResults(results);
 		return ret;
 	}
 

--- a/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/ReferenceDataESService.java
@@ -624,13 +624,13 @@ public class ReferenceDataESService extends ESService {
 		return ret;
 	}
 
-	// literatureSummary.title/abstract/mods_in_corpus are indexed as of the Mapping change; match the term in title
+	// literatureSummary.title/abstract/mods_in_corpus are indexed as of the Mapping change; match the disease in title
 	// OR abstract, bucket by MOD, and keep the `latest` most-recently-published papers per MOD via a top_hits sub-agg.
-	public JsonResultResponse<LiteratureSummaryDocument> getLatestLiteratureSummaryByMod(String term, int latest) {
+	public JsonResultResponse<LiteratureSummaryDocument> getLatestLiteratureByDiseasePerMod(String disease, int latest) {
 		BoolQueryBuilder query = boolQuery()
 			.filter(termQuery("category", "literature_summary"))
-			.should(matchQuery("literatureSummary.title", term))
-			.should(matchQuery("literatureSummary.abstract", term))
+			.should(matchQuery("literatureSummary.title", disease))
+			.should(matchQuery("literatureSummary.abstract", disease))
 			.minimumShouldMatch(1);
 
 		AggregationBuilder agg = AggregationBuilders

--- a/agr_java_core/src/main/java/org/alliancegenome/core/es/schema/Mapping.java
+++ b/agr_java_core/src/main/java/org/alliancegenome/core/es/schema/Mapping.java
@@ -253,6 +253,9 @@ public class Mapping extends Builder {
 		new FieldBuilder(builder, "literatureSummary.date_last_modified_in_pubmed", "text").keyword().build();
 		new FieldBuilder(builder, "literatureSummary.page_range", "keyword").build();
 		new FieldBuilder(builder, "literatureSummary.curie", "text").keyword().build();
+		new FieldBuilder(builder, "literatureSummary.title", "text").keyword().build();
+		new FieldBuilder(builder, "literatureSummary.abstract", "text").build();
+		new FieldBuilder(builder, "literatureSummary.mods_in_corpus", "keyword").build();
 
 		// GeneExpressionDocument: dynamic false (78 -> ~8 indexed fields)
 		builder.startObject("geneExpressionAnnotation");


### PR DESCRIPTION
## Background

The `literatureSummary` object in the site_index ES mapping is configured with `dynamic: false`, so the `title`, `abstract`, and `mods_in_corpus` subfields are stored in `_source` but never indexed — they cannot be searched, filtered, or aggregated. Confirmed on the stage cluster: a `match` on `literatureSummary.title` returns 0 hits and a terms aggregation on `mods_in_corpus.keyword` returns empty buckets.

## Changes

**1. Index the fields** (`agr_java_core` — `core/es/schema/Mapping.java`)
- `title` → `text` + `.keyword` sub-field (full-text search + exact/sort)
- `abstract` → `text` (full-text search)
- `mods_in_corpus` → `keyword` (aggregatable/filterable)

**2. New REST endpoint** (`agr_api`)
- `GET /reference/literature-summaries-by-mod?q=<term>&latest=<n>`
- Matches the term in title **OR** abstract (`should` + `minimumShouldMatch(1)`), buckets by MOD (`mods_in_corpus.keyword`), and returns the `latest` most-recently-published papers per MOD via a `top_hits` sub-aggregation sorted by `date_published` descending.
- Params: `q` (default `diabetes`), `latest` (default `1`).
- Files touched: `ReferenceDataESService.java` (`getLatestLiteratureSummaryByMod`), `LiteratureRESTInterface.java`, `LiteratureController.java`.

## Note

The new fields only become searchable in a freshly built site_index — the existing index was created before this mapping change, so a reindex / indexer run is required after deploy for the endpoint to return data.

Jira: https://agr-jira.atlassian.net/browse/KANBAN-1387