### PR TITLE
SCRUM-4008: fetch final partial page in Allele and AGM disease annotation indexers

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/service/AGMDiseaseAnnotationService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/service/AGMDiseaseAnnotationService.java
@@ -43,7 +43,8 @@ public class AGMDiseaseAnnotationService extends BaseDiseaseAnnotationService {
 		SearchResponse<AGMDiseaseAnnotation> totalResponse = agmApi.findForPublic(0, 0, params);
 		display.startProcess("Pulling AGM DA's from curation", totalResponse.getTotalResults());
 
-		for (int page = 0; page < (int) (totalResponse.getTotalResults() / batchSize); page++) {
+		int maxPage = (int) (totalResponse.getTotalResults() / batchSize);
+		for (int page = 0; page <= maxPage; page++) {
 			SearchResponse<AGMDiseaseAnnotation> response = agmApi.findForPublic(page, batchSize, params);
 			for (AGMDiseaseAnnotation da : response.getResults()) {
 				if (hasNoObsoletedOrInternalEntities(da)) {

--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/service/AlleleDiseaseAnnotationService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/service/AlleleDiseaseAnnotationService.java
@@ -41,7 +41,8 @@ public class AlleleDiseaseAnnotationService extends BaseDiseaseAnnotationService
 		SearchResponse<AlleleDiseaseAnnotation> totalResponse = alleleApi.findForPublic(0, 0, params);
 		display.startProcess("Pulling Allele DA's from curation", totalResponse.getTotalResults());
 
-		for (int page = 0; page < (int) (totalResponse.getTotalResults() / batchSize); page++) {
+		int maxPage = (int) (totalResponse.getTotalResults() / batchSize);
+		for (int page = 0; page <= maxPage; page++) {
 
 			SearchResponse<AlleleDiseaseAnnotation> response = alleleApi.findForPublic(page, batchSize, params);
 			for (AlleleDiseaseAnnotation da : response.getResults()) {


### PR DESCRIPTION
## Problem

The public site Elasticsearch index (`site_index`) was missing ~1,231 curated disease annotations that exist in the curation DB — specifically **553 allele** + **676 AGM** annotations (gene was fine).

## Root cause

`AlleleDiseaseAnnotationService` and `AGMDiseaseAnnotationService` paginated with:

```java
for (int page = 0; page < (int) (totalResponse.getTotalResults() / batchSize); page++)
```

Integer division floors and `<` excludes the last index, so the loop fetched only `floor(total/1000) * 1000` records and silently dropped the final partial page (up to 999 of the highest-PK annotations). `GeneDiseaseAnnotationService` already uses the correct `page <= maxPage` pattern (fixed in SCRUM-5005, commit 6a2087d4a), but the fix was never ported to the Allele and AGM services.

## Verification

- Allele: 5,551 public annotations → indexer fetched exactly 5,000 (5 pages); ranks 5,001–5,551 by id were all missing — a clean page-boundary cut, confirming the tail-drop.
- AGM: 32,528 public → 528 dropped (32,528 mod 1000), plus records excluded by the existing related-object internal/obsolete filter.

## Fix

Match the Gene service pattern (`int maxPage = total/batchSize; page <= maxPage`) so the final page is fetched.

## Note

These services cache to `allele_disease_annotation.json.gz` / `agm_disease_annotation.json.gz` — a stale cache on the indexer host must be cleared for a re-run to pick up the fix.