### PR TITLE
SCRUM-1953 & SCRUM-6239: Disease + Variant-Allele download file generator fixes

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -247,7 +247,7 @@ public enum FileGeneratorConfig {
 		m.put("DOtermName", "_doTermName");
 		m.put("WithOrtholog", "_withOrtholog");
 		m.put("InferredFromID", "_unavailable");
-		m.put("InferredFromSymbol", "_unavailable");
+		m.put("InferredFromSymbol", "_inferredFromSymbol");
 		m.put("ExperimentalCondition", "_unavailable");
 		m.put("Modifier", "_unavailable");
 		m.put("EvidenceCode", "_evidenceCode");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -133,7 +133,7 @@ public enum FileGeneratorConfig {
 	 * does not include the HTP variant_index). Same source the agr_api uses for the
 	 * gene-page allele table (see AlleleESService.getAllelesByGene).
 	 *
-	 * One row per allele. variantList-derived fields (VariantId, VariantSymbol,
+	 * One row per allele. variantList-derived fields (VariantSymbol,
 	 * position, consequence, etc.) are pipe-joined when an allele has multiple
 	 * known variants.
 	 */
@@ -144,7 +144,6 @@ public enum FileGeneratorConfig {
 		m.put("AlleleId", "allele.primaryExternalId");
 		m.put("AlleleSymbol", "allele.alleleSymbol.displayText");
 		m.put("AlleleSynonyms", "_alleleSynonyms");
-		m.put("VariantId", "_variantId");
 		m.put("VariantSymbol", "_variantSymbol");
 		m.put("VariantSynonyms", "_variantSynonyms");
 		m.put("VariantCrossReferences", "allele.primaryExternalId");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -130,6 +130,7 @@ public class DiseaseFileGenerator extends FileGenerator {
 			row.put("_doTermName", JsonPath.resolveString(pa, "diseaseAnnotationObject.name"));
 
 			row.put("_withOrtholog", joinWithOrthologs(pa));
+			row.put("_inferredFromSymbol", joinBasedOnSymbols(pa));
 
 			JsonNode evCodes = pa.path("evidenceCodes");
 			List<String> curies = new ArrayList<>();
@@ -197,6 +198,29 @@ public class DiseaseFileGenerator extends FileGenerator {
 			}
 		}
 		List<String> sorted = new ArrayList<>(ids);
+		Collections.sort(sorted);
+		return String.join("|", sorted);
+	}
+
+	private static String joinBasedOnSymbols(JsonNode pa) {
+		JsonNode with = pa.path("with");
+		if (!with.isArray()) {
+			return "";
+		}
+		LinkedHashSet<String> symbols = new LinkedHashSet<>();
+		for (JsonNode w : with) {
+			String symbol = w.path("geneSymbol").path("displayText").asText("");
+			if (symbol.isEmpty()) {
+				continue;
+			}
+			String abbreviation = w.path("taxon").path("species").path("abbreviation").asText("");
+			if (abbreviation.isEmpty()) {
+				symbols.add(symbol);
+			} else {
+				symbols.add(symbol + " (" + abbreviation + ")");
+			}
+		}
+		List<String> sorted = new ArrayList<>(symbols);
 		Collections.sort(sorted);
 		return String.join("|", sorted);
 	}

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -82,48 +82,63 @@ public class DiseaseFileGenerator extends FileGenerator {
 		}
 		List<JsonNode> rows = new ArrayList<>(primary.size());
 		for (JsonNode pa : primary) {
+			String relationName = JsonPath.resolveString(pa, "relation.name");
+			boolean isViaOrthology = relationName.contains("_via_orthology");
+
 			// Annotation.uniqueId is the canonical dedup key computed by AnnotationUniqueIdHelper in curation. Skip empty values so the generator keeps working before the curation-side @JsonView change has been deployed and reindexed; once it lands, this becomes a real dedup.
 			String uniqueId = JsonPath.resolveString(pa, "uniqueId");
-			if (!uniqueId.isEmpty() && !seenUniqueIds.add(uniqueId)) {
+			// A via_orthology annotation's uniqueId is identical across every ortholog-gene doc it fans out to (it is keyed on the source entity, not the ortholog gene), so include the enclosing doc's gene subject in the dedup key to keep one row per ortholog gene instead of collapsing them all into one.
+			String dedupKey = isViaOrthology ? JsonPath.resolveString(customizedHit, "subject.primaryExternalId") + "|" + uniqueId : uniqueId;
+			if (!uniqueId.isEmpty() && !seenUniqueIds.add(dedupKey)) {
 				continue;
 			}
 
 			ObjectNode row = JsonNodeFactory.instance.objectNode();
 
 			row.put("_uniqueId", uniqueId);
-			row.put("_taxon", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.curie"));
-			row.put("_speciesName", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.species.fullName"));
 
-			String paType = JsonPath.resolveString(pa, "type");
-			String dbObjectType;
-			if ("GeneDiseaseAnnotation".equals(paType)) {
-				dbObjectType = "gene";
-			} else if ("AlleleDiseaseAnnotation".equals(paType)) {
-				dbObjectType = "allele";
-			} else if ("AGMDiseaseAnnotation".equals(paType)) {
-				dbObjectType = "affected_genomic_model";
+			if (isViaOrthology) {
+				// A via_orthology annotation lives inside the ortholog GENE's consolidated doc, but its diseaseAnnotationSubject still points at the source entity (allele/AGM/source gene). The row must be keyed on the enclosing doc's gene subject, so source every subject column from the top-level subject.
+				row.put("_taxon", JsonPath.resolveString(customizedHit, "subject.taxon.curie"));
+				row.put("_speciesName", JsonPath.resolveString(customizedHit, "subject.taxon.species.fullName"));
+				row.put("_dbObjectType", "gene");
+				row.put("_dbObjectId", JsonPath.resolveString(customizedHit, "subject.primaryExternalId"));
+				row.put("_dbObjectSymbol", JsonPath.resolveString(customizedHit, "subject.geneSymbol.displayText"));
 			} else {
-				dbObjectType = paType.replace("DiseaseAnnotation", "").toLowerCase();
-			}
-			row.put("_dbObjectType", dbObjectType);
+				row.put("_taxon", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.curie"));
+				row.put("_speciesName", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.species.fullName"));
 
-			row.put("_dbObjectId", JsonPath.resolveString(pa, "diseaseAnnotationSubject.primaryExternalId"));
+				String paType = JsonPath.resolveString(pa, "type");
+				String dbObjectType;
+				if ("GeneDiseaseAnnotation".equals(paType)) {
+					dbObjectType = "gene";
+				} else if ("AlleleDiseaseAnnotation".equals(paType)) {
+					dbObjectType = "allele";
+				} else if ("AGMDiseaseAnnotation".equals(paType)) {
+					dbObjectType = "affected_genomic_model";
+				} else {
+					dbObjectType = paType.replace("DiseaseAnnotation", "").toLowerCase();
+				}
+				row.put("_dbObjectType", dbObjectType);
 
-			String subjectType = JsonPath.resolveString(pa, "diseaseAnnotationSubject.type");
-			String symbol;
-			if ("Gene".equals(subjectType)) {
-				symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.geneSymbol.displayText");
-			} else if ("Allele".equals(subjectType)) {
-				symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.alleleSymbol.displayText");
-			} else if ("AffectedGenomicModel".equals(subjectType)) {
-				symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.agmFullName.displayText");
-				if (symbol.isEmpty()) {
+				row.put("_dbObjectId", JsonPath.resolveString(pa, "diseaseAnnotationSubject.primaryExternalId"));
+
+				String subjectType = JsonPath.resolveString(pa, "diseaseAnnotationSubject.type");
+				String symbol;
+				if ("Gene".equals(subjectType)) {
+					symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.geneSymbol.displayText");
+				} else if ("Allele".equals(subjectType)) {
+					symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.alleleSymbol.displayText");
+				} else if ("AffectedGenomicModel".equals(subjectType)) {
+					symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.agmFullName.displayText");
+					if (symbol.isEmpty()) {
+						symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.name");
+					}
+				} else {
 					symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.name");
 				}
-			} else {
-				symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.name");
+				row.put("_dbObjectSymbol", symbol);
 			}
-			row.put("_dbObjectSymbol", symbol);
 
 			row.put("_associationType", JsonPath.resolveString(pa, "relation.name"));
 			row.put("_doId", JsonPath.resolveString(pa, "diseaseAnnotationObject.curie"));
@@ -156,9 +171,6 @@ public class DiseaseFileGenerator extends FileGenerator {
 				reference = JsonPath.resolveString(pa, "evidenceItem.curie");
 			}
 			row.put("_reference", reference);
-
-			String relationName = JsonPath.resolveString(pa, "relation.name");
-			boolean isViaOrthology = relationName.contains("_via_orthology");
 
 			// The per-annotation element does not carry dateUpdated; only dateCreated is present. Fall back to file-generation-date for via_orthology rows when the date is missing, preserving existing behavior.
 			String iso = JsonPath.resolveString(pa, "dateUpdated");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -24,6 +24,8 @@ public class DiseaseFileGenerator extends FileGenerator {
 	private static final String FILE_GENERATION_DATE =
 			LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE); // YYYYMMDD
 
+	private static final String LINKML_README_URL = "https://alliance-genome.github.io/agr_curation_schema/DiseaseAnnotation/";
+
 	// Same primaryAnnotation appears across many consolidated docs (gene/allele/agm rollups + via_orthology fan-out). Dedup by the canonical Annotation.uniqueId so each annotation is emitted once per run. dispatch() runs from the parallel scroll pool, so this must be a concurrent set.
 	private final Set<String> seenUniqueIds = ConcurrentHashMap.newKeySet();
 
@@ -34,6 +36,11 @@ public class DiseaseFileGenerator extends FileGenerator {
 	@Override
 	protected void generate() throws Exception {
 		scrollAndWrite();
+	}
+
+	@Override
+	protected String jsonReadmeOverride() {
+		return LINKML_README_URL;
 	}
 
 	@Override

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/VariantAlleleFileGenerator.java
@@ -105,7 +105,6 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 	}
 
 	private static void populateEmptyVariantFields(ObjectNode row) {
-		row.put("_variantId", "");
 		row.put("_variantSymbol", "");
 		row.put("_variantSynonyms", "");
 		row.put("_variantsTypeId", "");
@@ -220,8 +219,7 @@ public class VariantAlleleFileGenerator extends FileGenerator {
 			}
 		}
 
-		row.put("_variantId", v.path("primaryExternalId").asText(""));
-		row.put("_variantSymbol", v.path("variantSymbol").path("displayText").asText(""));
+		row.put("_variantSymbol", joinList(hgvsNames));
 		row.put("_variantSynonyms", joinList(variantSynonyms));
 		row.put("_variantsTypeId", v.path("variantType").path("curie").asText(""));
 		row.put("_variantsTypeName", v.path("variantType").path("name").asText(""));


### PR DESCRIPTION
Covers two tickets against the `agr_file_generator` submodule.

## SCRUM-1953 — Disease download file fixes

1. **JSON `README` field** — populate the Disease JSON metadata `readme` with the LinkML DiseaseAnnotation schema URL (`https://alliance-genome.github.io/agr_curation_schema/DiseaseAnnotation/`) via `jsonReadmeOverride()`, matching the Gene/Orthology pattern. Scoped to Disease JSON output only.

2. **"Based On" symbol species abbreviation** — the previously-empty `InferredFromSymbol` column now emits the based-on (ortholog) gene symbols formatted as `Symbol (Abbr)`, e.g. `WRN (Hsa)`, pulling the abbreviation from `taxon.species.abbreviation`. Multi-gene values are `|`-delimited, deduped and sorted.

3. **via_orthology row subject fix (data-correctness)** — via_orthology annotations are rolled up into a gene doc's `primaryAnnotations` with their `diseaseAnnotationSubject` pointing at the *evidence/source* entity (allele, AGM, or ortholog gene), not the gene the doc is about. The generator was keying every row on that per-annotation subject, producing bogus allele/AGM-subject via_orthology rows (297 allele + 56 AGM in WB alone), dropping the gene's own via_orthology rows, and injecting the subject's own gene into its Based On list. Now via_orthology rows key on the enclosing gene doc's top-level `subject`, with a via-orthology-aware dedup key (`subject.primaryExternalId + uniqueId`) so distinct per-ortholog rows survive. Direct annotations unchanged.

Verified on regenerated files: all via_orthology rows are now gene-subject (WB: 34,167 gene / 0 allele / 0 AGM, was 217 / 297 / 56); wrn-1 shows its full orthology-inferred disease set matching the gene page; Based On no longer self-includes.

## SCRUM-6239 — Variant-Allele download files missing variant IDs/symbols

Variants carry no top-level `variantSymbol` or `primaryExternalId` in ES (the HGVS name lives at `curatedVariantGenomicLocations[].hgvs`), so both columns came out empty. Per curator plan of action:
- **Variant Symbol** ← the variant HGVS name.
- **Variant ID column removed** altogether (config + TSV header + JSON).

Verified on regenerated files: `VariantSymbol` now carries HGVS for variant-bearing rows (MGI 6,384; WB 4,153, matching `VariantsHgvsNames`), empty for allele-only rows; the `VariantId` column is gone.

## Not included / follow-ups
- The 34-column Disease TSV restructure proposed in SCRUM-1953 is split out to **SCRUM-6274** (deferred).
- `PhenotypeFileGenerator` shares the via_orthology code pattern but ES has zero phenotype via_orthology annotations, so the defect can't manifest; left unchanged, noted on SCRUM-4008.

`mvn -pl agr_file_generator -am compile` passes.