### PR TITLE
SCRUM-1953: Emit negated relation for negated disease annotations in download files

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -140,7 +140,7 @@ public class DiseaseFileGenerator extends FileGenerator {
 				row.put("_dbObjectSymbol", symbol);
 			}
 
-			row.put("_associationType", JsonPath.resolveString(pa, "relation.name"));
+			row.put("_associationType", resolveAssociationType(pa));
 			row.put("_doId", JsonPath.resolveString(pa, "diseaseAnnotationObject.curie"));
 			row.put("_doTermName", JsonPath.resolveString(pa, "diseaseAnnotationObject.name"));
 
@@ -195,6 +195,14 @@ public class DiseaseFileGenerator extends FileGenerator {
 			rows.add(row);
 		}
 		return rows;
+	}
+
+	private static String resolveAssociationType(JsonNode pa) {
+		String relationName = JsonPath.resolveString(pa, "relation.name");
+		if (relationName.isEmpty() || !pa.path("negated").asBoolean(false)) {
+			return relationName;
+		}
+		return relationName.replaceFirst("_", "_not_");
 	}
 
 	private static String joinWithOrthologs(JsonNode pa) {


### PR DESCRIPTION
## Problem

Negated disease annotations (`negated=true`) came through the new disease download files (TSV/JSON) with their **positive** relation, making them indistinguishable from positive assertions. Chris reported this on [SCRUM-1953](https://agr-jira.atlassian.net/browse/SCRUM-1953): e.g. a negated `is_implicated_in` annotation was written as plain `is_implicated_in`.

Root cause: `DiseaseFileGenerator` wrote `relation.name` verbatim and never consulted the per-annotation `negated` flag. The flag is available in the document (serialized on each `primaryAnnotations[]` element) and nothing upstream filters negated annotations out — the generator was simply ignoring the flag.

## Fix

`agr_file_generator/.../generators/DiseaseFileGenerator.java`: route the association type through a new `resolveAssociationType(pa)` helper that, when `negated=true`, inserts `_not_` after the first token of the relation name.

| Stored relation | Output when `negated=true` |
|---|---|
| `is_implicated_in` | `is_not_implicated_in` |
| `is_marker_for` | `is_not_marker_for` |
| `is_ameliorated_model_of` | `is_not_ameliorated_model_of` |
| `is_model_of` | `is_not_model_of` |

Positive annotations are unchanged.

## Notes

- Generator-only change: no curation-schema change and no reindex required.
- Follows Chris's comment (2026-07-10) requesting `is_model_of` → `is_not_model_of`. This **intentionally diverges** from the existing `getFullRelationString()`/`getGeneratedRelationString()` logic used by the website, which maps `is_model_of` → `does_not_model`. Flagging for confirmation.

## Testing

- `mvn -pl agr_file_generator -am compile` — BUILD SUCCESS.
- Recommended manual check: regenerate the WB disease file and confirm `wrn-1` (`WB:WBGene00006944`) negated rows now show `is_not_*` relations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-1953]: https://agr-jira.atlassian.net/browse/SCRUM-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ