### PR TITLE
SCRUM-1953: map negated is_model_of to does_not_model in download

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -202,6 +202,9 @@ public class DiseaseFileGenerator extends FileGenerator {
 		if (relationName.isEmpty() || !pa.path("negated").asBoolean(false)) {
 			return relationName;
 		}
+		if (relationName.equals("is_model_of")) {
+			return "does_not_model";
+		}
 		return relationName.replaceFirst("_", "_not_");
 	}
 


### PR DESCRIPTION
Per Chris's review, the TSV should use the established does_not_model convention for negated is_model_of (matching the JSON generatedRelationString and the website), not is_not_model_of.