### PR TITLE
SCRUM-4008: Add HUMAN phenotype download files and fix missing species name

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -36,7 +36,7 @@ public enum FileGeneratorConfig {
 
 	Phenotype("Phenotype", "PHENOTYPE-ALLIANCE", List.of("gene_phenotype_annotation", "allele_phenotype_annotation", "agm_phenotype_annotation"),
 		List.of(new OutputSpec(Format.TSV, SplitMode.TAXON), new OutputSpec(Format.TSV, SplitMode.COMBINED), new OutputSpec(Format.JSON_RAW, SplitMode.TAXON), new OutputSpec(Format.JSON_RAW, SplitMode.COMBINED)),
-		List.of("FB", "MGI", "RGD", "SGD", "WB", "XBXL", "XBXT", "ZFIN"), phenotypeFieldMap(), "readmes/phenotype.txt", PhenotypeFileGenerator.class, 1000, 8),
+		List.of("FB", "HUMAN", "MGI", "RGD", "SGD", "WB", "XBXL", "XBXT", "ZFIN"), phenotypeFieldMap(), "readmes/phenotype.txt", PhenotypeFileGenerator.class, 1000, 8),
 
 	VariantsAlleles("Variant/Allele", "VARIANT-ALLELE", List.of("allele_summary"), List.of(new OutputSpec(Format.TSV, SplitMode.TAXON), new OutputSpec(Format.JSON_RAW, SplitMode.TAXON)), List.of("FB", "MGI", "RGD", "SGD", "WB", "ZFIN"), variantAlleleFieldMap(), "readmes/variants_alleles.txt",
 		VariantAlleleFileGenerator.class, 1000, 8),;

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/PhenotypeFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/PhenotypeFileGenerator.java
@@ -75,8 +75,18 @@ public class PhenotypeFileGenerator extends FileGenerator {
 			ObjectNode row = JsonNodeFactory.instance.objectNode();
 
 			// Per-row taxon — drives row-level routing (see rowTaxonPath()). Pulled from the individual primaryAnnotations[i] entry so via-orthology fan-out rows land in the right per-MOD file.
-			row.put("_taxon", JsonPath.resolveString(pa, "phenotypeAnnotationSubject.taxon.curie"));
-			row.put("_speciesName", JsonPath.resolveString(pa, "phenotypeAnnotationSubject.taxon.species.fullName"));
+			String taxonCurie = JsonPath.resolveString(pa, "phenotypeAnnotationSubject.taxon.curie");
+			row.put("_taxon", taxonCurie);
+
+			// The nested taxon.species object is only hydrated on some ES docs (e.g. allele annotations, mouse/fly/worm gene annotations) and absent on others (all human/Xenopus gene annotations, most rat gene annotations), which left the Species Name column blank or sporadic. Fall back to the taxon-curie -> fullName lookup (the same source the file header uses) so every row is populated.
+			String speciesName = JsonPath.resolveString(pa, "phenotypeAnnotationSubject.taxon.species.fullName");
+			if (speciesName.isEmpty() && species != null) {
+				String looked = species.fullNameFor(taxonCurie);
+				if (looked != null) {
+					speciesName = looked;
+				}
+			}
+			row.put("_speciesName", speciesName);
 
 			// The phenotype statement is the full curated phrase (e.g. "decreased mating efficiency"); phenotypeTerms are its individual ontology components (e.g. "decreased", "mating efficiency"). Emit the statement and the terms in separate columns.
 			row.put("_phenotypeStatement", JsonPath.resolveString(pa, "phenotypeAnnotationObject"));

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/PhenotypeFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/PhenotypeFileGenerator.java
@@ -71,7 +71,6 @@ public class PhenotypeFileGenerator extends FileGenerator {
 			String taxonCurie = JsonPath.resolveString(pa, "phenotypeAnnotationSubject.taxon.curie");
 			row.put("_taxon", taxonCurie);
 
-			// The nested taxon.species object is only hydrated on some ES docs (e.g. allele annotations, mouse/fly/worm gene annotations) and absent on others (all human/Xenopus gene annotations, most rat gene annotations), which left the Species Name column blank or sporadic. Fall back to the taxon-curie -> fullName lookup (the same source the file header uses) so every row is populated.
 			String speciesName = JsonPath.resolveString(pa, "phenotypeAnnotationSubject.taxon.species.fullName");
 			if (speciesName.isEmpty() && species != null) {
 				String looked = species.fullNameFor(taxonCurie);

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/PhenotypeFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/PhenotypeFileGenerator.java
@@ -20,7 +20,6 @@ public class PhenotypeFileGenerator extends FileGenerator {
 
 	private static final String LINKML_README_URL = "https://alliance-genome.github.io/agr_curation_schema/PhenotypeAnnotation/";
 
-	// Same primaryAnnotation appears across many consolidated docs. Dedup by the canonical Annotation.uniqueId so each annotation is emitted once per run. dispatch() runs from the parallel scroll pool, so this must be a concurrent set.
 	private final Set<String> seenUniqueIds = ConcurrentHashMap.newKeySet();
 
 	public PhenotypeFileGenerator(FileGeneratorConfig config) {
@@ -42,9 +41,6 @@ public class PhenotypeFileGenerator extends FileGenerator {
 		return "subject.taxon.curie";
 	}
 
-	/**
-	 * Row-format outputs route by the per-annotation taxon, not the consolidated doc's subject taxon. {@code _taxon} is populated inside customizeRows() from {@code primaryAnnotations[i].phenotypeAnnotationSubject.taxon.curie}, so via-orthology fan-out rows land in the file matching their own subject's MOD instead of the parent doc's.
-	 */
 	@Override
 	protected String rowTaxonPath() {
 		return "_taxon";
@@ -55,9 +51,6 @@ public class PhenotypeFileGenerator extends FileGenerator {
 		return hit;
 	}
 
-	/**
-	 * The gene_phenotype_annotation ES docs are consolidated — each hit carries a primaryAnnotations[] array containing the individual phenotype annotations. JSON_RAW writes the consolidated doc verbatim (via customizeRow); TSV writes one flattened row per primaryAnnotations[i].
-	 */
 	@Override
 	protected List<JsonNode> customizeRows(JsonNode customizedHit) {
 		JsonNode primary = JsonPath.resolve(customizedHit, "primaryAnnotations");


### PR DESCRIPTION
## SCRUM-4008 — (New data) Phenotype download file

Addresses the two action items from Chris Grove's sign-off review.

### 1. Add HUMAN phenotype files
Adds `HUMAN` to the Phenotype generator's MOD whitelist so human phenotype annotations get their own JSON and TSV download files. Human data is RGD-submitted with `HGNC:` subjects and taxon `NCBITaxon:9606` (~275K annotation docs in ES — second only to mouse). Routing keys on the annotation subject's taxon curie, so human separates cleanly from rat (`NCBITaxon:10116`) despite the shared RGD data provider. This mirrors the existing Disease generator, which already emits a HUMAN file the same way.

### 2. Fix blank / sporadic Species Name column
The per-row Species Name column was empty or inconsistently populated because the nested `phenotypeAnnotationSubject.taxon.species` object is only hydrated on some ES docs — fully absent for human/Xenopus gene annotations and most rat gene annotations, partial for ZFIN/SGD, present on allele annotations. This produced *fully empty* columns (Xenopus, and human once enabled) and *sporadic* columns (ZFIN/RGD/SGD interleaving hydrated allele rows with unhydrated gene rows).

Fix: fall back to the `SpeciesLookup` taxon-curie → fullName map (the same source the file header already uses) when the ES field is empty, so every row is populated.

### Notes
- Disease and Expression share the same latent species-name bug on their per-row column but are left untouched here.
- The download-vs-Postgres count gap Chris flagged was investigated separately and confirmed to be AGM phenotype annotations with no gene/allele to roll up to (not actionable in this ticket).