### PR TITLE
SCRUM-6204: use focus DA's evidenceItem on via-orthology rows

### DIFF
--- a/agr_indexer/src/main/java/org/alliancegenome/indexer/service/GeneDiseaseAnnotationService.java
+++ b/agr_indexer/src/main/java/org/alliancegenome/indexer/service/GeneDiseaseAnnotationService.java
@@ -105,9 +105,6 @@ public class GeneDiseaseAnnotationService extends BaseDiseaseAnnotationService {
 		VocabularyTerm isMarkerViaOrthology = vocabularyTermService.getDiseaseRelationTerms().get("is_marker_via_orthology");
 		VocabularyTerm isImplicatedViaOrthology = vocabularyTermService.getDiseaseRelationTerms().get("is_implicated_via_orthology");
 		ECOTerm ecoTermIEA = ecoTermService.getEcoTerm("ECO:0000501");
-		// hard code MGI:6194238 with corresponding AGRKB ID
-		Reference allianceReference = referenceService.getReference("AGRKB:101000000828456");
-
 
 		display.startProcess("Creating Gene DA's via orthology", geneMap.size());
 		// loop over all Markers of validated DiseaseAnnotation records
@@ -157,7 +154,7 @@ public class GeneDiseaseAnnotationService extends BaseDiseaseAnnotationService {
 					Organization dataProvider = orgService.getOrganization("Alliance");
 					gda.setDataProvider(dataProvider);
 					gda.setWith(List.of(geneGeneOrthology.getSubjectGene()));
-					gda.setEvidenceItem(allianceReference);
+					gda.setEvidenceItem(focusDiseaseAnnotation.getEvidenceItem());
 					gda.setDiseaseAnnotationObject(focusDiseaseAnnotation.getDiseaseAnnotationObject());
 					gda.setEvidenceCodes(List.of(ecoTermIEA));
 					gda.setDiseaseQualifiers(focusDiseaseAnnotation.getDiseaseQualifiers());


### PR DESCRIPTION
The synthesized via_orthology GDAs pinned evidenceItem to a hardcoded placeholder Reference (AGRKB:101000000828456) with no crossReferences, so the disease page's Alliance-sourced ortho rows rendered as unlinked AGRKB text. Reuse the focus DA's evidenceItem instead — ortho rows now carry the underlying MOD publication's xrefs and RDPs, matching the shape of direct DAs.