### PR TITLE
fix: SCRUM-6148 emit one Expression TSV row per cross reference / reference pair

### DIFF
--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -284,7 +284,10 @@ public enum FileGeneratorConfig {
 	 * Expression field map. Anatomy / sub-structure / cellular-component term IDs
 	 * and names come straight off whereExpressed; the six qualifier list columns
 	 * are pipe-joined inside ExpressionFileGenerator.customizeRow() into synthetic
-	 * fields.
+	 * fields. These docs are consolidated by gene + location + stage + assay, so
+	 * ExpressionFileGenerator.customizeRows() then expands each ES hit into one TSV
+	 * row per crossReferences[i] / referenceId[i] pair; JSON_RAW writes the
+	 * consolidated doc verbatim.
 	 */
 	private static Map<String, String> expressionFieldMap() {
 		Map<String, String> m = new LinkedHashMap<>();
@@ -308,9 +311,10 @@ public enum FileGeneratorConfig {
 		m.put("AnatomyTermName", "geneExpressionAnnotation.expressionPattern.whereExpressed.anatomicalStructure.name");
 		m.put("AnatomyTermQualifierIDs", "_anatomyQualifierIds");
 		m.put("AnatomyTermQualifierTermNames", "_anatomyQualifierNames");
-		// SourceURL is built from the first crossReference's urlTemplate +
-		// referencedCurie inside ExpressionFileGenerator.customizeRow(); this path
-		// resolves the synthetic field.
+		// SourceURL and Reference are populated per row by
+		// ExpressionFileGenerator.customizeRows() from the crossReference and the
+		// referenceId sharing an index, so each URL is reported against the one
+		// publication it came from; these paths resolve the synthetic fields.
 		m.put("SourceURL", "_sourceUrl");
 		m.put("Source", "geneExpressionAnnotation.dataProvider.abbreviation");
 		m.put("Reference", "_reference");

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/ExpressionFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/ExpressionFileGenerator.java
@@ -1,11 +1,15 @@
 package org.alliancegenome.filegenerator.generators;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.alliancegenome.filegenerator.config.FileGeneratorConfig;
 import org.alliancegenome.filegenerator.writers.JsonPath;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import lombok.extern.slf4j.Slf4j;
@@ -36,20 +40,6 @@ public class ExpressionFileGenerator extends FileGenerator {
 		}
 		ObjectNode obj = (ObjectNode) hit;
 
-		// Build the SourceURL from the first crossReference's urlTemplate + referencedCurie.
-		JsonNode xrefs = JsonPath.resolve(hit, "geneExpressionAnnotation.crossReferences");
-		if (xrefs != null && xrefs.isArray() && xrefs.size() > 0) {
-			JsonNode first = xrefs.get(0);
-			String curie = first.path("referencedCurie").asText("");
-			String urlTemplate = first.path("resourceDescriptorPage").path("urlTemplate").asText("");
-			if (!curie.isEmpty() && !urlTemplate.isEmpty()) {
-				int idx = curie.indexOf(':');
-				String localId = idx >= 0 ? curie.substring(idx + 1) : curie;
-				String url = urlTemplate.replace("[%s]", localId);
-				obj.put("_sourceUrl", url);
-			}
-		}
-
 		// Pipe-join the three qualifier lists under whereExpressed into synthetic ID + name fields.
 		String wherePath = "geneExpressionAnnotation.expressionPattern.whereExpressed";
 		obj.put("_anatomyQualifierIds", joinField(hit, wherePath + ".anatomicalStructureQualifiers", "curie"));
@@ -59,10 +49,62 @@ public class ExpressionFileGenerator extends FileGenerator {
 		obj.put("_cellularComponentQualifierIds", joinField(hit, wherePath + ".cellularComponentQualifiers", "curie"));
 		obj.put("_cellularComponentQualifierNames", joinField(hit, wherePath + ".cellularComponentQualifiers", "name"));
 
-		// Pipe-join the references from the referenceXrefs array; the consolidation upstream in agr_curation packs all PMIDs supporting one annotation into this list.
-		obj.put("_reference", joinField(hit, "referenceXrefs", "referencedCurie"));
-
 		return hit;
+	}
+
+	/**
+	 * The consolidation in agr_curation's GeneExpressionDocumentBuilder pads crossReferences and referenceId so entry i of
+	 * each describes the same underlying annotation. Emit one row per pair so a SourceURL is never reported against a
+	 * publication it did not come from, and so no cross reference beyond the first is dropped. referenceId is the aligned
+	 * list; referenceXrefs is a deduplicated set in a different order and cannot be paired positionally.
+	 */
+	@Override
+	protected List<JsonNode> customizeRows(JsonNode customizedHit) {
+		if (!customizedHit.isObject()) {
+			return List.of(customizedHit);
+		}
+		ObjectNode obj = (ObjectNode) customizedHit;
+
+		JsonNode xrefs = JsonPath.resolve(customizedHit, "geneExpressionAnnotation.crossReferences");
+		JsonNode refIds = JsonPath.resolve(customizedHit, "referenceId");
+		int xrefSize = xrefs != null && xrefs.isArray() ? xrefs.size() : 0;
+		int refSize = refIds != null && refIds.isArray() ? refIds.size() : 0;
+
+		// A doc carrying neither list still emits its single row — the location / stage / assay columns stand on their own.
+		int rowCount = Math.max(1, Math.max(xrefSize, refSize));
+		List<JsonNode> rows = new ArrayList<>(rowCount);
+		// Scoped to this document: the same figure + publication pair recurs legitimately under other locations and stages, so only exact repeats within one gene + location + stage + assay group are dropped.
+		Set<String> seenPairs = new LinkedHashSet<>();
+
+		for (int i = 0; i < rowCount; i++) {
+			String sourceUrl = buildSourceUrl(i < xrefSize ? xrefs.get(i) : null);
+			// Fewer references than cross references means one publication documented in several places; every row keeps that single reference.
+			String reference = refSize == 0 ? "" : (i < refSize ? refIds.get(i) : refIds.get(0)).asText("");
+			if (!seenPairs.add(sourceUrl + "\t" + reference)) {
+				continue;
+			}
+			ObjectNode row = JsonNodeFactory.instance.objectNode();
+			// Shallow copy: the doc-level fields are shared by reference and never mutated, only the two per-pair fields differ.
+			row.setAll(obj);
+			row.put("_sourceUrl", sourceUrl);
+			row.put("_reference", reference);
+			rows.add(row);
+		}
+		return rows;
+	}
+
+	private static String buildSourceUrl(JsonNode xref) {
+		if (xref == null) {
+			return "";
+		}
+		String curie = xref.path("referencedCurie").asText("");
+		String urlTemplate = xref.path("resourceDescriptorPage").path("urlTemplate").asText("");
+		if (curie.isEmpty() || urlTemplate.isEmpty()) {
+			return "";
+		}
+		int idx = curie.indexOf(':');
+		String localId = idx >= 0 ? curie.substring(idx + 1) : curie;
+		return urlTemplate.replace("[%s]", localId);
 	}
 
 	private static String joinField(JsonNode root, String arrayPath, String fieldName) {
@@ -73,21 +115,6 @@ public class ExpressionFileGenerator extends FileGenerator {
 		LinkedHashSet<String> values = new LinkedHashSet<>();
 		for (JsonNode element : array) {
 			String value = element.path(fieldName).asText("");
-			if (!value.isEmpty()) {
-				values.add(value);
-			}
-		}
-		return String.join(QUALIFIER_DELIMITER, values);
-	}
-
-	private static String joinScalarArray(JsonNode root, String arrayPath) {
-		JsonNode array = JsonPath.resolve(root, arrayPath);
-		if (array == null || !array.isArray() || array.size() == 0) {
-			return "";
-		}
-		LinkedHashSet<String> values = new LinkedHashSet<>();
-		for (JsonNode element : array) {
-			String value = element.asText("");
 			if (!value.isEmpty()) {
 				values.add(value);
 			}


### PR DESCRIPTION
[SCRUM-6148](https://agr-jira.atlassian.net/browse/SCRUM-6148)

## Problem

The Expression TSV reported a single `SourceURL` against a pipe-joined list of every publication supporting the annotation. Two symptoms, both in one row: a figure was shown next to publications it did not come from, and **every cross reference after the first was dropped from the download entirely**.

Affects WB, MGI and ZFIN — the MODs that populate expression cross references.

This is a direct consequence of the SCRUM-6007 fix, which changed `Reference` from a single ID to a pipe-join of all PMIDs. Before that the file was aligned but lossy; after, complete but misaligned.

## Root cause

`ExpressionFileGenerator` read `crossReferences[0]` only, joined *all* of `referenceXrefs` into one cell, and never overrode `customizeRows` — so one ES document produced exactly one TSV row, leaving every other cross reference unreachable.

The ES document was already correct and complete. `agr_curation`'s `GeneExpressionDocumentBuilder` deliberately pads `crossReferences` and `referenceId` so entry `i` of each describes the same underlying annotation, with an in-code comment stating it exists for deconsolidation at download time. The generator ignored that contract.

## Fix

Override `customizeRows` to emit one row per `crossReferences[i]` / `referenceId[i]` pair, falling back to `referenceId[0]` when a single publication is documented in several figures (the `group.size() == 1` short-circuit means the 1:1 invariant does not hold universally, so the fallback is load-bearing rather than defensive).

`Reference` now reads the positionally-aligned `referenceId` list rather than `referenceXrefs`, which is a deduplicated set in a different order and cannot be paired by index.

No reindex, no curation-side change, no `agr_indexer` change. `agr_api`'s gene-page download already did this correctly (`ExpressionToTdfTranslator`); the bulk generator was the outlier.

## Verification

Full local generator run, all 8 MODs, 248,457 rows:

- **Zero** pipe-joined `Reference` or `SourceURL` cells; zero empty references.
- Every expected row re-derived independently from the JSON output and diffed against the actual TSV: **exact match, 0 differing lines** on all 8 MODs.
- Combined file reconciles exactly against the sum of the per-MOD files.
- Both paths exercised by real data — in ZFIN alone, 2,890 groups now carry more than one distinct reference (previously single piped rows) and 1,534 groups hit the `referenceId[0]` fallback.

Example, `ZFIN:ZDB-GENE-050125-1` / whole organism / Hatching:Pec-fin:

```
https://zfin.org/ZDB-FIG-180613-24    PMID:27407144
https://zfin.org/ZDB-FIG-120123-8     PMID:21614507
```

Previously one row with `PMID:27407144|PMID:21614507`, with `ZDB-FIG-120123-8` missing from the download.

## Reviewer notes

- **Row count grows ~1.26x** (MGI heaviest at 1.45x, ZFIN 1.14x). `gene + location + stage + assay` is **no longer a unique key** in the TSV — rows differing only in `SourceURL`/`Reference` are expected. Consumers and DQMs likely want a heads-up.
- **JSON_RAW no longer carries the `_sourceUrl` / `_reference` fields.** No information is lost — the authoritative `crossReferences` and `referenceId` arrays are still present, and the six `_*Qualifier*` fields are unchanged — but it is a visible shape change. Flag if the JSON is contractual.
- Rows are shallow copies (`setAll`) sharing document subtrees by reference; only the two synthetic top-level fields differ per row. Verified byte-identical to a `deepCopy()` control at 1.8x lower cost. A future *nested* per-row mutation would require switching to `deepCopy()`; noted in a comment on that line.
- `readmes/expression.txt` is a 0-byte file on `stage` and is left untouched here, so the row-count caveat is not yet documented anywhere user-facing.
- `agr_file_generator` has **no tests** (no `src/test`, no surefire deps), so `mvn test` passing proves nothing. The verification above was done with a throwaway harness plus the output-vs-JSON diff, neither of which is committed. Worth a follow-up if we want regression cover.

[SCRUM-6148]: https://agr-jira.atlassian.net/browse/SCRUM-6148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ