### PR TITLE
KANBAN-864: add filter.referenceCitation to report-table endpoints

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/controller/AlleleController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/AlleleController.java
@@ -172,7 +172,7 @@ public class AlleleController implements AlleleRESTInterface {
 		Integer limit,
 		Integer page,
 		String sortBy,
-		String asc) {
+		String asc, String referenceCitation) {
 
 		LocalDateTime startDate = LocalDateTime.now();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
@@ -182,6 +182,7 @@ public class AlleleController implements AlleleRESTInterface {
 		pagination.addFilterOption("generatedRelationString.keyword", associationType);
 		pagination.addFilterOption("diseaseQualifiers.keyword", diseaseQualifier);
 		pagination.addFilterOption("pubmedPublications.referencedCurie", filterReference);
+		pagination.addFilterOption("references.shortCitation", referenceCitation);
 		pagination.addFilterOption("primaryAnnotations.dataProvider.sourceOrganization.abbreviation", filterSource);
 
 
@@ -219,7 +220,7 @@ public class AlleleController implements AlleleRESTInterface {
 												Integer limit,
 												Integer page,
 												String sortBy,
-												String asc) {
+												String asc, String referenceCitation) {
 		JsonResultResponse<AlleleDiseaseAnnotationDocument> response = getDiseasePerAllele(alleleID,
 			filterOptions,
 			filterReference,
@@ -234,7 +235,7 @@ public class AlleleController implements AlleleRESTInterface {
 			150000,
 			page,
 			sortBy,
-			asc);
+			asc, referenceCitation);
 		Response.ResponseBuilder responseBuilder = Response.ok(diseaseToTdfTranslator.getAllRowsForAlleleDiseaseAnnotations(response.getResults()));
 		String alleleSymbol = getAllele(alleleID).getAllele().getAlleleSymbol().getFormatText();
 		APIServiceHelper.setDownloadHeaderByName(alleleID, alleleSymbol, EntityType.ALLELE, EntityType.DISEASE, responseBuilder);

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/AlleleController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/AlleleController.java
@@ -120,11 +120,13 @@ public class AlleleController implements AlleleRESTInterface {
 		String phenotype,
 		String source,
 		String reference,
-		String sortBy) {
+		String sortBy,
+		String referenceCitation) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, null);
 		pagination.addFilterOption("phenotypeStatement", phenotype);
 		pagination.addFilterOption("pubmedPublications.referencedCurie", reference);
+		pagination.addFilterOption("references.shortCitation", referenceCitation);
 		pagination.addFilterOption("primaryAnnotations.dataProvider.abbreviation", source);
 		try {
 			JsonResultResponse<AllelePhenotypeAnnotationDocument> phenotypes = phenotypeESService.getAllelePhenotypeAnnotations(id, pagination, false);
@@ -140,7 +142,7 @@ public class AlleleController implements AlleleRESTInterface {
 	}
 
 	@Override
-	public Response getPhenotypesPerAlleleDownload(String id, String phenotype, String source, String reference, String sortBy) {
+	public Response getPhenotypesPerAlleleDownload(String id, String phenotype, String source, String reference, String sortBy, String referenceCitation) {
 		// retrieve all records
 		JsonResultResponse<AllelePhenotypeAnnotationDocument> response =
 			getPhenotypePerAllele(id,
@@ -149,7 +151,8 @@ public class AlleleController implements AlleleRESTInterface {
 				phenotype,
 				source,
 				reference,
-				sortBy);
+				sortBy,
+				referenceCitation);
 		Response.ResponseBuilder responseBuilder = Response.ok(phenotypeTranslator.getAllRows(response.getResults()));
 		String alleleSymbol = getAllele(id).getAllele().getAlleleSymbol().getFormatText();
 		APIServiceHelper.setDownloadHeaderByName(id, alleleSymbol, EntityType.ALLELE, EntityType.PHENOTYPE, responseBuilder);

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
@@ -376,8 +376,9 @@ public class DiseaseController implements DiseaseRESTInterface {
 																								Integer page,
 																								String sortBy,
 																								String asc,
+																								String referenceCitation,
 																								List<String> geneIDs) {
-		return getDiseaseAnnotationsRibbonDetails(focusTaxonId, termID, filterOptions, filterSpecies, filterGene, filterReference, diseaseTerm, filterSource, geneticEntity, geneticEntityType, associationType, diseaseQualifier, evidenceCode, basedOnGeneSymbol, includeNegation, debug, limit, page, sortBy, asc, geneIDs, false);
+		return getDiseaseAnnotationsRibbonDetails(focusTaxonId, termID, filterOptions, filterSpecies, filterGene, filterReference, diseaseTerm, filterSource, geneticEntity, geneticEntityType, associationType, diseaseQualifier, evidenceCode, basedOnGeneSymbol, includeNegation, debug, limit, page, sortBy, asc, referenceCitation, geneIDs, false);
 	}
 
 	private JsonResultResponse<GeneDiseaseAnnotationDocument> getDiseaseAnnotationsRibbonDetails(
@@ -401,6 +402,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 																								Integer page,
 																								String sortBy,
 																								String asc,
+																								String referenceCitation,
 																								List<String> geneIDs,
 																								boolean includePrimaryAnnotations) {
 
@@ -412,6 +414,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 		pagination.addFilterOption("generatedRelationString.keyword", associationType);
 		pagination.addFilterOption("diseaseQualifiers.keyword", diseaseQualifier);
 		pagination.addFilterOption("pubmedPublications.referencedCurie", filterReference);
+		pagination.addFilterOption("references.shortCitation", referenceCitation);
 		pagination.addFilterOption("subject.geneSymbol.displayText", filterGene);
 		pagination.addFilterOption("primaryAnnotations.with.geneSymbol.displayText", basedOnGeneSymbol);
 		pagination.addFilterOption("primaryAnnotations.dataProvider.abbreviation OR primaryAnnotations.secondaryDataProvider.abbreviation", filterSource);
@@ -444,12 +447,12 @@ public class DiseaseController implements DiseaseRESTInterface {
 		String diseaseTerm, String filterSource, String geneticEntity,
 		String geneticEntityType, String associationType, String diseaseQualifier,
 		String evidenceCode, String basedOnGeneSymbol, Boolean includeNegation,
-		Boolean debug, String sortBy, String asc, List<String> geneIDs) {
+		Boolean debug, String sortBy, String asc, String referenceCitation, List<String> geneIDs) {
 
 		LocalDateTime startDate = LocalDateTime.now();
 		Response.ResponseBuilder responseBuilder;
 		try {
-			JsonResultResponse<GeneDiseaseAnnotationDocument> response = getDiseaseAnnotationsRibbonDetails(focusTaxonId, termID, null, filterSpecies, filterGene, filterReference, diseaseTerm, filterSource, geneticEntity, geneticEntityType, associationType, diseaseQualifier, evidenceCode, basedOnGeneSymbol, includeNegation, debug, 150000, 1, sortBy, asc, geneIDs, true);
+			JsonResultResponse<GeneDiseaseAnnotationDocument> response = getDiseaseAnnotationsRibbonDetails(focusTaxonId, termID, null, filterSpecies, filterGene, filterReference, diseaseTerm, filterSource, geneticEntity, geneticEntityType, associationType, diseaseQualifier, evidenceCode, basedOnGeneSymbol, includeNegation, debug, 150000, 1, sortBy, asc, referenceCitation, geneIDs, true);
 			response.setHttpServletRequest(null);
 			response.calculateRequestDuration(startDate);
 			// translate all records

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
@@ -452,7 +452,10 @@ public class DiseaseController implements DiseaseRESTInterface {
 		LocalDateTime startDate = LocalDateTime.now();
 		Response.ResponseBuilder responseBuilder;
 		try {
-			JsonResultResponse<GeneDiseaseAnnotationDocument> response = getDiseaseAnnotationsRibbonDetails(focusTaxonId, termID, null, filterSpecies, filterGene, filterReference, diseaseTerm, filterSource, geneticEntity, geneticEntityType, associationType, diseaseQualifier, evidenceCode, basedOnGeneSymbol, includeNegation, debug, 150000, 1, sortBy, asc, referenceCitation, geneIDs, true);
+			JsonResultResponse<GeneDiseaseAnnotationDocument> response = getDiseaseAnnotationsRibbonDetails(
+				focusTaxonId, termID, null, filterSpecies, filterGene, filterReference, diseaseTerm, filterSource,
+				geneticEntity, geneticEntityType, associationType, diseaseQualifier, evidenceCode, basedOnGeneSymbol,
+				includeNegation, debug, 150000, 1, sortBy, asc, referenceCitation, geneIDs, true);
 			response.setHttpServletRequest(null);
 			response.calculateRequestDuration(startDate);
 			// translate all records

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/DiseaseController.java
@@ -77,7 +77,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 																							String evidenceCode,
 																							String associationType,
 																							String diseaseQualifier,
-																							String asc) {
+																							String asc, String referenceCitation) {
 		long startTime = System.currentTimeMillis();
 		// The @DefaultValue only kicks in if the value is null.
 		// need to handle an empty value manually here.
@@ -91,6 +91,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 		pagination.addFilterOption("generatedRelationString.keyword", associationType);
 		pagination.addFilterOption("diseaseQualifiers.keyword", diseaseQualifier);
 		pagination.addFilterOption("pubmedPublications.referencedCurie", reference);
+		pagination.addFilterOption("references.shortCitation", referenceCitation);
 		pagination.addFilterOption("primaryAnnotations.dataProvider.abbreviation", dataProvider);
 		pagination.addFilterOption("object.name", diseaseName);
 		if (pagination.hasErrors()) {
@@ -129,9 +130,9 @@ public class DiseaseController implements DiseaseRESTInterface {
 		String diseaseQualifier,
 		boolean fullDownload,
 		String downloadFileType,
-		String asc) {
+		String asc, String referenceCitation) {
 		
-		JsonResultResponse<AlleleDiseaseAnnotationDocument> response = getDiseaseAnnotationsByAllele(id, 150000, null, sortBy, geneName, alleleName, disease, species, disease, source, reference, evidenceCode, associationType, diseaseQualifier, asc);
+		JsonResultResponse<AlleleDiseaseAnnotationDocument> response = getDiseaseAnnotationsByAllele(id, 150000, null, sortBy, geneName, alleleName, disease, species, disease, source, reference, evidenceCode, associationType, diseaseQualifier, asc, referenceCitation);
 		Response.ResponseBuilder responseBuilder = null;
 		String allRowsForAlleles = translator.getAllRowsForAlleleDiseaseAnnotations(response.getResults());
 
@@ -186,8 +187,8 @@ public class DiseaseController implements DiseaseRESTInterface {
 														String diseaseQualifier,
 														boolean fullDownload,
 														String downloadFileType,
-														String asc) {
-		JsonResultResponse<GeneDiseaseAnnotationDocument> response = getDiseaseAnnotationsByGene(id, 250000, null, sortBy, geneName, geneID, species, diseaseName, source, reference, evidenceCode, basedOnGeneSymbol, associationType, diseaseQualifier, asc);
+														String asc, String referenceCitation) {
+		JsonResultResponse<GeneDiseaseAnnotationDocument> response = getDiseaseAnnotationsByGene(id, 250000, null, sortBy, geneName, geneID, species, diseaseName, source, reference, evidenceCode, basedOnGeneSymbol, associationType, diseaseQualifier, asc, referenceCitation);
 		Response.ResponseBuilder responseBuilder = null;
 		String allRowsForGenes = translator.getAllRowsForAssociatedGenes(response.getResults());
 		if (fullDownload) {
@@ -240,7 +241,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 																						String basedOnGeneSymbol,
 																						String associationType,
 																						String diseaseQualifier,
-																						String asc) {
+																						String asc, String referenceCitation) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("subject.geneSymbol.displayText", geneName);
@@ -248,6 +249,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 		pagination.addFilterOption("generatedRelationString.keyword", associationType);
 		pagination.addFilterOption("diseaseQualifiers.keyword", diseaseQualifier);
 		pagination.addFilterOption("pubmedPublications.referencedCurie", reference);
+		pagination.addFilterOption("references.shortCitation", referenceCitation);
 		pagination.addFilterOption("primaryAnnotations.dataProvider.abbreviation", source);
 		pagination.addFilterOption("primaryAnnotations.with.geneSymbol.displayText", basedOnGeneSymbol);
 		pagination.addFilterOption("object.name", diseaseName);
@@ -295,7 +297,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 																						String conditionModifier,
 																						String experimentalCondition,
 																						String geneticModifier,
-																						String asc) {
+																						String asc, String referenceCitation) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("subject.agmFullName.displayText", modelName);
@@ -307,6 +309,7 @@ public class DiseaseController implements DiseaseRESTInterface {
 		pagination.addFilterOption("geneticModifierAggregated", geneticModifier);
 		pagination.addFilterOption("diseaseQualifiers.keyword", diseaseQualifier);
 		pagination.addFilterOption("pubmedPublications.referencedCurie", reference);
+		pagination.addFilterOption("references.shortCitation", referenceCitation);
 		pagination.addFilterOption("primaryAnnotations.dataProvider.abbreviation", source);
 		pagination.addFilterOption("object.name", disease);
 
@@ -344,8 +347,8 @@ public class DiseaseController implements DiseaseRESTInterface {
 														String conditionModifier,
 														String experimentalCondition,
 														String geneticModifier,
-														String asc) {
-		JsonResultResponse<AGMDiseaseAnnotationDocument> response = getDiseaseAnnotationsForModel(id, 200000, null, sortBy, modelName, geneName, species, disease, source, reference, evidenceCode, associationType, diseaseQualifier, conditionModifier, experimentalCondition, geneticModifier, asc);
+														String asc, String referenceCitation) {
+		JsonResultResponse<AGMDiseaseAnnotationDocument> response = getDiseaseAnnotationsForModel(id, 200000, null, sortBy, modelName, geneName, species, disease, source, reference, evidenceCode, associationType, diseaseQualifier, conditionModifier, experimentalCondition, geneticModifier, asc, referenceCitation);
 		Response.ResponseBuilder responseBuilder = Response.ok(translator.getAllRowsForModel(response.getResults()));
 		APIServiceHelper.setDownloadHeader(id, EntityType.DISEASE, EntityType.MODEL, responseBuilder);
 		return responseBuilder.build();

--- a/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/controller/GeneController.java
@@ -321,11 +321,12 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public JsonResultResponse<GenePhenotypeAnnotationDocument> getPhenotypeAnnotations(String id, Integer limit, Integer page, String sortBy, String geneticEntity, String geneticEntityType, String phenotype, String reference, String dataProvider, String asc) {
+	public JsonResultResponse<GenePhenotypeAnnotationDocument> getPhenotypeAnnotations(String id, Integer limit, Integer page, String sortBy, String geneticEntity, String geneticEntityType, String phenotype, String reference, String dataProvider, String asc, String referenceCitation) {
 		long startTime = System.currentTimeMillis();
 		Pagination pagination = new Pagination(page, limit, sortBy, asc);
 		pagination.addFilterOption("phenotypeStatement", phenotype);
 		pagination.addFilterOption("pubmedPublications.referencedCurie", reference);
+		pagination.addFilterOption("references.shortCitation", referenceCitation);
 		pagination.addFilterOption("primaryAnnotations.dataProvider.abbreviation", dataProvider);
 		try {
 			JsonResultResponse<GenePhenotypeAnnotationDocument> phenotypes = phenotypeESService.getGenePhenotypeAnnotations(id, pagination, false);
@@ -341,9 +342,9 @@ public class GeneController implements GeneRESTInterface {
 	}
 
 	@Override
-	public Response getPhenotypeAnnotationsDownloadFile(String id, String sortBy, String geneticEntity, String geneticEntityType, String phenotype, String reference, String dataProvider, String asc) {
+	public Response getPhenotypeAnnotationsDownloadFile(String id, String sortBy, String geneticEntity, String geneticEntityType, String phenotype, String reference, String dataProvider, String asc, String referenceCitation) {
 		// retrieve all records
-		JsonResultResponse<GenePhenotypeAnnotationDocument> response = getPhenotypeAnnotations(id, 250000, 1, sortBy, geneticEntity, geneticEntityType, phenotype, reference, dataProvider, asc);
+		JsonResultResponse<GenePhenotypeAnnotationDocument> response = getPhenotypeAnnotations(id, 250000, 1, sortBy, geneticEntity, geneticEntityType, phenotype, reference, dataProvider, asc, referenceCitation);
 		Response.ResponseBuilder responseBuilder = Response.ok(translator.getAllRows(response.getResults()));
 		APIServiceHelper.setDownloadHeader(id, EntityType.GENE, EntityType.PHENOTYPE, responseBuilder);
 		return responseBuilder.build();

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/AlleleRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/AlleleRESTInterface.java
@@ -118,7 +118,8 @@ public interface AlleleRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "debug", description = "debug query", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("false") @QueryParam("debug") Boolean debug,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", description = "Number of rows returned", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
 		@Parameter(in = ParameterIn.QUERY, name = "page", description = "Page number") @DefaultValue("1") @QueryParam("page") Integer page, @Parameter(in = ParameterIn.QUERY, name = "sortBy", description = "Sort by field name") @QueryParam("sortBy") String sortBy,
-		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "ascending or descending", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc);
+		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "ascending or descending", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 	@GET
 	@Path("/{id}/diseases/download")
@@ -138,6 +139,7 @@ public interface AlleleRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "debug", description = "debug query", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("false") @QueryParam("debug") Boolean debug,
 		@Parameter(in = ParameterIn.QUERY, name = "limit", description = "Number of rows returned", schema = @Schema(type = SchemaType.INTEGER)) @DefaultValue("20") @QueryParam("limit") Integer limit,
 		@Parameter(in = ParameterIn.QUERY, name = "page", description = "Page number") @DefaultValue("1") @QueryParam("page") Integer page, @Parameter(in = ParameterIn.QUERY, name = "sortBy", description = "Sort by field name") @QueryParam("sortBy") String sortBy,
-		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "ascending or descending", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc);
+		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "ascending or descending", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/AlleleRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/AlleleRESTInterface.java
@@ -85,7 +85,8 @@ public interface AlleleRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "filter.termName", description = "termName annotation") @QueryParam("filter.termName") String phenotype,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.dataProvider", description = "Source", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.dataProvider") String source,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.reference", description = "Reference number: PUBMED or a Pub ID from the MOD") @QueryParam("filter.reference") String reference,
-		@Parameter(in = ParameterIn.QUERY, name = "sortBy", description = "Field name by which to sort", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("symbol") @QueryParam("sortBy") String sortBy
+		@Parameter(in = ParameterIn.QUERY, name = "sortBy", description = "Field name by which to sort", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("symbol") @QueryParam("sortBy") String sortBy,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation
 
 	);
 
@@ -98,7 +99,8 @@ public interface AlleleRESTInterface {
 		@Parameter(in = ParameterIn.PATH, name = "id", description = "Search for Phenotypes for a given Allele by ID", required = true, schema = @Schema(type = SchemaType.STRING)) @PathParam("id") String id,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.termName", description = "termName annotation") @QueryParam("filter.termName") String phenotype, @Parameter(in = ParameterIn.QUERY, name = "filter.source", description = "Source") @QueryParam("filter.source") String source,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.reference", description = "Reference number: PUBMED or a Pub ID from the MOD") @QueryParam("filter.reference") String reference,
-		@Parameter(in = ParameterIn.QUERY, name = "sortBy", description = "Field name by which to sort", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("symbol") @QueryParam("sortBy") String sortBy);
+		@Parameter(in = ParameterIn.QUERY, name = "sortBy", description = "Field name by which to sort", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("symbol") @QueryParam("sortBy") String sortBy,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 	@GET
 	@Path("/{id}/diseases")

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/DiseaseRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/DiseaseRESTInterface.java
@@ -280,6 +280,8 @@ public interface DiseaseRESTInterface {
 
 		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "ascending or descending", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("true") @QueryParam("asc") String asc,
 
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation,
+
 		@Parameter(in = ParameterIn.QUERY, name = "geneID", description = "Gene by ID", required = true) @RequestBody List<String> geneIDs) throws JsonProcessingException;
 
 	@POST
@@ -303,6 +305,8 @@ public interface DiseaseRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "debug", description = "debug query", schema = @Schema(type = SchemaType.STRING)) @DefaultValue("false") @QueryParam("debug") Boolean debug,
 		@Parameter(in = ParameterIn.QUERY, name = "sortBy", description = "Sort by field name") @QueryParam("sortBy") String sortBy, @Parameter(in = ParameterIn.QUERY, name = "asc", description = "ascending or descending", schema = @Schema(type = SchemaType.STRING))
 //allowedValues = "true,false"
-		@DefaultValue("true") @QueryParam("asc") String asc, @Parameter(in = ParameterIn.QUERY, name = "geneID", description = "Gene by ID", required = true) @RequestBody List<String> geneIDs) throws JsonProcessingException;
+		@DefaultValue("true") @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation,
+		@Parameter(in = ParameterIn.QUERY, name = "geneID", description = "Gene by ID", required = true) @RequestBody List<String> geneIDs) throws JsonProcessingException;
 
 }

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/DiseaseRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/DiseaseRESTInterface.java
@@ -75,7 +75,8 @@ public interface DiseaseRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "filter.diseaseQualifier", description = "diseaseQualifier", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.diseaseQualifier") String diseaseQualifier,
 		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING))
 //,allowedValues = "true,false")
-		@DefaultValue("true") @QueryParam("asc") String asc);
+		@DefaultValue("true") @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 	@GET
 	@Path("/{id}/alleles/download")
@@ -98,7 +99,8 @@ public interface DiseaseRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "filter.associationType", description = "filter by association type", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.associationType") String associationType,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.diseaseQualifier", description = "diseaseQualifier", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.diseaseQualifier") String diseaseQualifier, @QueryParam("fullDownload") boolean fullDownload,
 		// @ApiParam(value = "download file type")
-		@QueryParam("fileType") String downloadFileType, @Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING)) @QueryParam("asc") String asc);
+		@QueryParam("fileType") String downloadFileType, @Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING)) @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 	@GET
 	@Path("/{id}/genes_counts")
@@ -123,7 +125,8 @@ public interface DiseaseRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "filter.basedOnGeneSymbol", description = "filter by based-on-gene", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.basedOnGeneSymbol") String basedOnGeneSymbol,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.associationType", description = "filter by association type") @QueryParam("filter.associationType") String associationType,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.diseaseQualifier", description = "diseaseQualifier", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.diseaseQualifier") String diseaseQualifier,
-		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING)) @QueryParam("asc") String asc);
+		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING)) @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 	@GET
 	@Path("/batch")
@@ -165,7 +168,8 @@ public interface DiseaseRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "filter.associationType", description = "filter by association type") @QueryParam("filter.associationType") String associationType,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.diseaseQualifier", description = "diseaseQualifier", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.diseaseQualifier") String diseaseQualifier, @QueryParam("fullDownload") boolean fullDownload,
 		// @ApiParam(value = "download file type")
-		@QueryParam("fileType") String downloadFileType, @Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING)) @QueryParam("asc") String asc);
+		@QueryParam("fileType") String downloadFileType, @Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING)) @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 	@GET
 	@Path("/{id}/models")
@@ -189,7 +193,8 @@ public interface DiseaseRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "filter.geneticModifier", description = "geneticModifier", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.geneticModifier") String geneticModifier,
 		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING))
 //,allowedValues = "true,false")
-		@DefaultValue("true") @QueryParam("asc") String asc);
+		@DefaultValue("true") @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 	@GET
 	@Path("/{id}/models_counts")
@@ -218,7 +223,8 @@ public interface DiseaseRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "filter.geneticModifier", description = "geneticModifier", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.geneticModifier") String geneticModifier,
 		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING))
 //,allowedValues = "true,false")
-		@DefaultValue("true") @QueryParam("asc") String asc);
+		@DefaultValue("true") @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 	@GET
 	@Path("/{id}/primaryannotations")

--- a/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/GeneRESTInterface.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/rest/interfaces/GeneRESTInterface.java
@@ -267,7 +267,8 @@ public interface GeneRESTInterface {
 		@QueryParam("filter.reference") String reference,
 		@Parameter(in = ParameterIn.QUERY, name = "filter.dataProvider", description = "Source", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.dataProvider") String filterSource,
 		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING))
-		@DefaultValue("true") @QueryParam("asc") String asc);
+		@DefaultValue("true") @QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 	@GET
 	@Path("/{id}/phenotypes/download")
@@ -291,7 +292,8 @@ public interface GeneRESTInterface {
 		@Parameter(in = ParameterIn.QUERY, name = "filter.dataProvider", description = "Source", schema = @Schema(type = SchemaType.STRING)) @QueryParam("filter.dataProvider") String filterSource,
 		@Parameter(in = ParameterIn.QUERY, name = "asc", description = "order to sort by", schema = @Schema(type = SchemaType.STRING))
 		@DefaultValue("true")
-		@QueryParam("asc") String asc);
+		@QueryParam("asc") String asc,
+		@Parameter(in = ParameterIn.QUERY, name = "filter.referenceCitation", description = "filter by reference citation") @QueryParam("filter.referenceCitation") String referenceCitation);
 
 
 	@GET


### PR DESCRIPTION
## Summary

Adds a `filter.referenceCitation` query param to the report-table endpoints backing the new local AGRKB **Reference** column in the UI. It registers `references.shortCitation` as a filter option **without** a `.keyword` suffix, so `ESService` applies a contains (wildcard) match — as opposed to the existing `filter.reference`, which is an exact `.keyword` match on `pubmedPublications.referencedCurie`.

**Paired UI PR: alliance-genome/agr_ui#1836 — these must land together.** The UI sends `filter.referenceCitation`; without this PR, JAX-RS silently drops the unknown query param and the UI's Reference-column filter is ignored (the table returns every row and merely de-emphasizes non-matching citations).

## Endpoints covered

Each also covers its `/download` variant:

| endpoint | commit |
| --- | --- |
| `GET /api/disease/{id}/genes` | `968abffa4` |
| `GET /api/disease/{id}/alleles` | `968abffa4` |
| `GET /api/disease/{id}/models` | `968abffa4` |
| `GET /api/allele/{id}/diseases` | `968abffa4` |
| `GET /api/gene/{id}/phenotypes` | `968abffa4` |
| `GET /api/allele/{id}/phenotypes` | `f1760a211` |
| `POST /api/disease` (gene-page disease ribbon) | `ca17411fe` |

### Note on `/api/allele/{id}/phenotypes` (`f1760a211`)

This one was missed in the first pass and is worth a reviewer's attention. The UI reaches the allele-page Phenotypes table through the *same* shared `phenotypeTable.jsx` component as the gene page, but a *different* controller method (`AlleleController.getPhenotypePerAllele`). Because unknown query params are dropped silently, the filter appeared to work while actually returning unfiltered rows. Lesson for future filter work here: audit by endpoint, not by UI component.

### Note on `POST /api/disease` (`ca17411fe`)

The param is threaded through the public ribbon method into the private overload that carries `includePrimaryAnnotations`, so both the table and its download honor it.

## Verification

Run against a local `agr_api` (`quarkus:dev`) on stage ES.

| request | before | after |
| --- | --- | --- |
| `allele/RGD:7241046/phenotypes?filter.referenceCitation=2014` | 14 (unfiltered) | 11 |
| `allele/RGD:7241046/phenotypes?filter.referenceCitation=<nonsense>` | 14 (unfiltered) | 0 |
| `allele/RGD:7241046/phenotypes/download?filter.referenceCitation=2014` | 14 rows | 11 rows |
| `POST disease?focusTaxonId=NCBITaxon:9606` `["HGNC:11998"]` + `=2014` | 85 (unfiltered) | 8 |
| same + `=Bally` | 85 (unfiltered) | 2 |
| same + `=<nonsense>` | 85 (unfiltered) | 0 |
| `POST disease/download` + `=Bally` | 101 rows | 2 rows |

The five original endpoints were verified in an earlier session: genes 3312→14, alleles 432→23, models 1517→83, allele/diseases 5→3, gene/phenotypes 34→11; downloads honor the filter.

## Known issue (pre-existing, not introduced here)

`filter.reference` regressed from substring to exact matching in this release (SCRUM-6204). Not addressed here: the UI is keeping the PMID "Reference ID" column and its `filter.reference` behavior for now, since some users may want PMID filterability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)