### PR TITLE
SCRUM-6303: Restore curie/name on public ontology-term (interactions) serialization

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/application/OntologyTermAncestorMixIn.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/application/OntologyTermAncestorMixIn.java
@@ -4,15 +4,16 @@ import com.fasterxml.jackson.annotation.JsonView;
 
 import org.alliancegenome.core.view.PublicView;
 
-// MixIn that adds @JsonView(PublicView.DiseaseAncestor.class) to the curie + name
-// accessors on curation_api's OntologyTerm so the disease-ancestors endpoint can
-// serialize just those two fields without owning the source class.
+// MixIn applied globally to curation_api's OntologyTerm. DiseaseAncestor lets the
+// disease-ancestors endpoint serialize just curie + name; Default (the base view all
+// other PublicView views extend) keeps curie + name serializing on every other public
+// endpoint, e.g. gene molecular/genetic interactions.
 public interface OntologyTermAncestorMixIn {
 
-	@JsonView(PublicView.DiseaseAncestor.class)
+	@JsonView({PublicView.Default.class, PublicView.DiseaseAncestor.class})
 	String getCurie();
 
-	@JsonView(PublicView.DiseaseAncestor.class)
+	@JsonView({PublicView.Default.class, PublicView.DiseaseAncestor.class})
 	String getName();
 
 }


### PR DESCRIPTION
## Problem
On gene pages, the **Molecular interactions** and **Genetic interactions** tables were missing values for **interaction type, interactor type, and detection method** on stage (9.1.0) but not production. The API responses returned each ontology term's `definition` but not its `curie` or `name`. Table **downloads were unaffected**.

Example: `/api/gene/SGD:S000002812/molecular-interactions`
- stage: `interactionType: { "definition": "..." }`
- prod:  `interactionType: { "curie": "MI:0915", "name": "physical association", "definition": "..." }`

## Root cause
`RestDefaultObjectMapper` registers `OntologyTermAncestorMixIn` globally on `OntologyTerm` (and `MITerm extends OntologyTerm`). The mixin re-annotated `getCurie()`/`getName()` with `@JsonView(PublicView.DiseaseAncestor.class)` — a **standalone** view. Because a mixin's `@JsonView` **replaces** the source field's annotation (which carried `ForPublic`), and with `DEFAULT_VIEW_INCLUSION = false`, curie/name were emitted **only** under the `DiseaseAncestor` view. Every other view-scoped public endpoint (interactions view `MolecularInteraction → … → ForPublic`) lost them. `definition` was untouched by the mixin, so it still serialized — matching the observed output. This was introduced in KANBAN-1322 (switch from a stub DTO to the global mixin for disease-ancestors).

Downloads use endpoints with **no** `@JsonView`, so view filtering is inactive there → curie/name always included → unaffected.

## Fix
Annotate the mixin's `getCurie()`/`getName()` with `{PublicView.Default.class, PublicView.DiseaseAncestor.class}`:
- `Default` is the base view every other `PublicView.*` view extends (and itself a `ForPublic`), so curie/name serialize again on all normal public endpoints.
- `DiseaseAncestor` keeps the disease-ancestors endpoint narrow — `definition` is still excluded there because it was never given `DiseaseAncestor` and that view is standalone.

## Impact / blast radius
- Change is confined to `agr_api` response serialization; the indexer uses its own mapper, so **ES document contents are unchanged**.
- Strictly additive: it only *adds* curie/name back to the `Default` view family. **No endpoint loses a field.** Restored fields match production.
- Disease-ancestors endpoint behavior is unchanged (still curie + name only).
- Note: two endpoints serialize under `CurationView` document views not under `Default` (`GET /gene/{id}/models`, `GET /gene/{id}/allele-variant-detail`). If they surface ontology terms, they'd still be missing curie/name — same underlying mixin gap, not addressed here. Flagging for a possible follow-up.

## Testing
Verified stage vs production JSON for `/molecular-interactions` to confirm the exact missing fields. Recommend confirming with the existing `InteractionsIT` integration test after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)