### PR TITLE
KANBAN-1322 autocomplete: match on curie and secondaryIds

### DIFF
--- a/agr_api/src/main/java/org/alliancegenome/api/service/AutoCompleteService.java
+++ b/agr_api/src/main/java/org/alliancegenome/api/service/AutoCompleteService.java
@@ -47,6 +47,8 @@ public class AutoCompleteService {
 		multi.field("name.autocomplete");
 		multi.field("synonyms.keyword", 2.0F);
 		multi.field("synonyms.autocomplete");
+		multi.field("curie", 10.0F);
+		multi.field("secondaryIds", 6.0F);
 
 		bool.must(multi);
 


### PR DESCRIPTION
## Summary
Adds `curie` and `secondaryIds` to the `search_autocomplete` multi-match so ontology IDs are searchable directly.

Motivation: in the ontology browser (and any other autocomplete consumer), typing an ID like `DOID:10927` currently returns nothing because the multi-match only queries `symbol`, `nameKey`, `name`, and `synonyms`. Users have to know the term name to find it.

- `curie` weight **10** — an exact ID paste should outrank a fuzzy name match on any other field
- `secondaryIds` weight **6** — supports deprecated / merged IDs that have been folded into a current term

Both fields are already indexed as keywords, so this is a pure query-side change. No mapping change, no reindex.

## Test plan
- [ ] `GET /api/search_autocomplete?q=DOID:10927&category=disease_search_result` returns exactly the `gastrojejunal ulcer` hit
- [ ] `GET /api/search_autocomplete?q=DOID:9999999&category=disease_search_result` returns 0 hits (no phantoms)
- [ ] `GET /api/search_autocomplete?q=gastrojejunal&category=disease_search_result` still returns the same term (name search unaffected)
- [ ] `GET /api/search_autocomplete?q=Parkinson&category=disease_search_result` still returns the numbered subtypes plus the parent (existing name-based flow unaffected)
- [ ] Typing a `DOID:` ID in the ontology browser search box (paired with agr_ui PR #1839) surfaces the term
