### PR TITLE
SCRUM-6274 restructure Disease download TSV to model-centric columns

### DIFF
--- a/agr_file_generator/SCRUM-6274.md
+++ b/agr_file_generator/SCRUM-6274.md
@@ -1,0 +1,268 @@
+# SCRUM-6274 — Disease download TSV: model-centric column layout
+
+## Summary
+
+Rearranges the Disease download **TSV** columns from the legacy FMS subject-agnostic layout
+(`DBobjectType` / `DBObjectID` / `DBObjectSymbol` / `AssociationType`) to the model-centric layout
+Chris Grove proposed in SCRUM-1953 (comment 2026-05-18). The Disease file is the only disease
+download not anchored to a single subject type, so the model, allele and gene levels each get their
+own ID / symbol / association columns and every row names whichever levels its annotation actually
+carries.
+
+JSON_RAW output is untouched — it writes the consolidated ES doc verbatim and never consults the
+field map. Only the TSV layout changes.
+
+## Column layout
+
+35 columns. The 34 from the ticket plus `UniqueID` first, which Chris asked to keep for curator
+verification until the public release (SCRUM-1953 comment 2026-07-15).
+
+| # | Column | Synthetic field | Source |
+|---|---|---|---|
+| 1 | UniqueID | `_uniqueId` | `primaryAnnotations[i].uniqueId` |
+| 2 | Taxon ID | `_taxon` | subject `taxon.curie` |
+| 3 | Species Name | `_speciesName` | subject `taxon.species.fullName` |
+| 4 | Model ID | `_modelId` | AGM annotation subject `primaryExternalId`, else blank |
+| 5 | Model Symbol | `_modelSymbol` | AGM subject `agmFullName.displayText` (fallback `name`) |
+| 6 | Model Type | `_modelType` | AGM subject `subtype.name` |
+| 7 | Model Association | `_modelAssociation` | relation, on AGM annotations only |
+| 8 | Allele IDs | `_alleleIds` | allele subject, else `inferredAllele`, else `assertedAlleles[]` |
+| 9 | Allele Symbols | `_alleleSymbols` | same source, `alleleSymbol.displayText` |
+| 10 | Allele Association | `_alleleAssociation` | relation, on Allele annotations only |
+| 11 | Gene IDs | `_geneIds` | gene subject, else `inferredGene`, else `assertedGenes[]` |
+| 12 | Gene Symbols | `_geneSymbols` | same source, `geneSymbol.displayText` |
+| 13 | Gene Association | `_geneAssociation` | relation, on Gene annotations and via-orthology rows |
+| 14 | Disease Qualifier | `_diseaseQualifier` | `diseaseQualifiers[].name`, `_` → space |
+| 15 | Disease ID | `_doId` | `diseaseAnnotationObject.curie` |
+| 16 | Disease Name | `_doTermName` | `diseaseAnnotationObject.name` |
+| 17 | Evidence Code | `_evidenceCode` | `evidenceCodes[].curie` (ECO term ID) |
+| 18 | Evidence Code Abbreviation | `_evidenceCodeAbbreviation` | `evidenceCodes[].abbreviation` |
+| 19 | Evidence Code Name | `_evidenceCodeName` | `evidenceCodes[].name` |
+| 20 | Experimental Conditions | `_experimentalConditions` | `conditionRelations[]` where type is `has_condition` / `induced_by` |
+| 21 | Condition Modifiers | `_conditionModifiers` | `conditionRelations[]` where type is `ameliorated_by` / `exacerbated_by` |
+| 22 | Genetic Modifier Relation | `_geneticModifierRelation` | `diseaseGeneticModifierRelation.name` |
+| 23 | Genetic Modifier IDs | `_geneticModifierIds` | `diseaseGeneticModifier{Alleles,Genes,Agms}[].primaryExternalId` |
+| 24 | Genetic Modifier Names | `_geneticModifierNames` | same arrays, symbol per entity type |
+| 25 | Strain Background ID | `_strainBackgroundId` | `sgdStrainBackground.primaryExternalId` |
+| 26 | Strain Background Name | `_strainBackgroundName` | `sgdStrainBackground.agmFullName.displayText` |
+| 27 | Genetic Sex | `_geneticSex` | `geneticSex.name` |
+| 28 | Notes | `_notes` | `relatedNotes[]`, labelled `Note: ` / `Summary: ` by note type |
+| 29 | Based On ID | `_basedOnId` | `with[].primaryExternalId` (sorted) |
+| 30 | Based On Symbol | `_basedOnSymbol` | `with[].geneSymbol.displayText` + ` (Abbrev)` |
+| 31 | Source | `_source` | unchanged from SCRUM-1953 |
+| 32 | Source URL | `_sourceUrl` | `dataProviderCrossReference` url template |
+| 33 | Reference | `_reference` | `evidenceItem.referenceID`, fallback `evidenceItem.curie` |
+| 34 | Date | `_date` | `dateUpdated` / `dateCreated` as YYYYMMDD |
+
+Columns dropped: `DBobjectType`, `DBObjectID`, `DBObjectSymbol`, `AssociationType`, `WithOrtholog`,
+`InferredFromID`, `InferredFromSymbol`, `ExperimentalCondition`, `Modifier`. The last four were the
+`_unavailable` placeholders from SCRUM-1953 — all four now have real columns in the new layout, so
+the placeholder mechanism is gone from this generator entirely.
+
+`WithOrtholog` and `InferredFromSymbol` were the same `with[]` data the ticket renames to
+`Based On ID` / `Based On Symbol`; `joinBasedOnSymbols` (SCRUM-1953, with the species abbreviation)
+moved to `Based On Symbol` unchanged, and `joinWithOrthologs` was renamed `joinBasedOnIds`.
+
+## Population rules
+
+Implemented per Chris's spec:
+
+* **Model** — subject of an AGM Disease annotation, otherwise blank. There is no inferred or asserted
+  AGM in the data model, so a gene or allele annotation has no model to name.
+* **Allele(s)** — subject of an Allele Disease annotation, else `inferredAllele`, else
+  `assertedAlleles[]` pipe-joined.
+* **Gene(s)** — subject of a Gene Disease annotation, else `inferredGene`, else `assertedGenes[]`
+  pipe-joined.
+* **Associations** — exactly one of the three association columns is populated per row: the level the
+  annotation was actually curated at. The other two levels are only reached by inference, so
+  asserting a relation for them would invent an annotation that is not in the persistent store.
+* **via_orthology** — gene level only, keyed on the enclosing doc's gene subject (SCRUM-1953
+  behaviour retained). Model and allele columns blank, Gene Association carries the
+  `is_*_via_orthology` relation.
+
+## Semantics borrowed from the gene-page download
+
+`DiseaseAnnotationToTdfTranslator` (agr_api) already builds most of these columns for the gene /
+allele / model page disease downloads, and those are curator-approved. The new columns follow it:
+
+* Genetic modifiers walk `Alleles` → `Genes` → `Agms` so the ID and name columns line up.
+* `Notes` labels `disease_note` as `Note: ` and `disease_summary` as `Summary: `; any other note type
+  is omitted.
+* `Source URL` substitutes the full `referencedCurie` into the resource-descriptor url template,
+  dropping the template's own prefix for MGI / SGD / OMIM whose templates already carry it.
+* `Disease Qualifier` renders `susceptibility_to` as `susceptibility to`.
+
+Two deliberate departures:
+
+1. **Conditions are computed per annotation, not per doc.** The translator overwrites its per-annotation
+   condition values with the doc-level `experimentalConditionsAggregated` /
+   `conditionModifierAggregated` rollups. Those are aggregates across every annotation in the
+   consolidated doc, which would smear conditions across unrelated rows now that each row is one
+   annotation. The generator reads `conditionRelations[]` off the annotation itself and splits it by
+   relation type per the ticket.
+2. **Association is set only at the annotation's own level** (see above). The translator populates both
+   a doc-level and a per-annotation association column because the gene page is anchored to one gene.
+
+## Files changed
+
+* `config/FileGeneratorConfig.java` — `diseaseFieldMap()` replaced with the 35-column layout.
+* `generators/DiseaseFileGenerator.java` — `customizeRows()` emits the new synthetic fields; new
+  helpers `resolveEntityField`, `resolveAgmSymbol`, `joinDiseaseQualifiers`, `joinEvidenceCodes`,
+  `joinConditionSummaries`, `joinGeneticModifiers`, `resolveEntityName`, `joinNotes`,
+  `buildSourceUrl`; `joinWithOrthologs` renamed `joinBasedOnIds`.
+
+No framework changes. `computeSourceIncludes()` still returns null for this generator (JSON_RAW forces
+full `_source`), so no `additionalSourceIncludes()` entries are needed for the new fields.
+
+## Testing
+
+`data` is gitignored; use it as the output folder so generated files can't be committed. The token is
+prepended with `APIToken ` by `ConfigHelper.getCurationApiToken()`, so pass the bare UUID, and note the
+API URL needs the `/api` suffix. `-D` beats the `application.properties` bundled in the jar, which
+carries a stale token that 401s.
+
+```
+java -DALLIANCE_RELEASE=8.4.0 \
+  -DES_HOST=stage.cluster01.alliancegenome.org \
+  -DES_INDEX=site_index \
+  -DCURATION_API_URL=https://alpha-curation.alliancegenome.org/api \
+  -DCURATION_API_TOKEN=<apitoken from person.apitoken> \
+  -DGENERATED_FILES_FOLDER=data \
+  -DSKIP_S3_UPLOAD=true \
+  -jar target/agr_file_generator-jar-with-dependencies.jar Disease
+```
+
+## Verification
+
+Run 2026-07-31 against stage ES (`site_index`, 489,486 docs), 19m08s, 484,442 TSV rows COMBINED.
+
+### Structure
+
+* All 484,442 rows have exactly **35 columns**; header order matches the ticket.
+* Every column is populated on at least some rows — no dead columns, and the four `_unavailable`
+  placeholders from SCRUM-1953 are gone.
+* **Association invariant holds exactly**: every one of the 484,442 rows has exactly one of the three
+  association columns populated. Model 33,024 + Allele 5,663 + Gene 445,755 = 484,442.
+* Per-MOD files stay species-pure (WB 44,670 rows all `NCBITaxon:6239`; SGD 14,303 all
+  `NCBITaxon:559292`, rendered `Saccharomyces cerevisiae` with no `S288C` strain suffix). Both
+  SCRUM-1953 complaints stay fixed.
+
+### Column fill rates (COMBINED)
+
+| Column | Filled | % |
+|---|---|---|
+| UniqueID / Taxon ID / Species Name | 484,442 | 100% |
+| Model ID / Symbol / Type / Association | 33,024 | 6.8% |
+| Allele IDs / Symbols | 32,647 | 6.7% |
+| Allele Association | 5,663 | 1.2% |
+| Gene IDs / Symbols | 472,743 | 97.6% |
+| Gene Association | 445,755 | 92.0% |
+| Disease Qualifier | 89,323 | 18.4% |
+| Disease ID / Name | 484,442 | 100% |
+| Evidence Code / Abbreviation / Name | 484,442 | 100% |
+| Experimental Conditions | 4,145 | 0.9% |
+| Condition Modifiers | 367 | 0.1% |
+| Genetic Modifier Relation / IDs / Names | 9,540 | 2.0% |
+| Strain Background ID / Name | 1,752 | 0.4% |
+| Genetic Sex | 1,592 | 0.3% |
+| Notes | 34,782 | 7.2% |
+| Annotation Type | 35,348 | 7.3% |
+| Based On ID / Symbol | 390,113 | 80.5% |
+| Source / Reference | 484,442 | 100% |
+| Source URL | 95,578 | 19.7% |
+| Date | 461,918 | 95.4% |
+
+The Allele ID (32,647) vs Allele Association (5,663) gap is expected: most allele cells come from an
+AGM annotation's inferred/asserted alleles, which carry no allele-level relation. Based On 80.5% and
+Source URL 19.7% are complements — via-orthology rows have a `with[]` but no data-provider cross
+reference, experimental rows the reverse.
+
+### Association totals vs SCRUM-1953 approved counts
+
+Chris's approved counts (2026-07-15) against this run, summing the three association columns:
+
+| Relation | Approved | This run |
+|---|---|---|
+| is_implicated_via_orthology | 240,711 | 240,711 |
+| is_marker_via_orthology | 148,153 | 148,153 |
+| is_implicated_in | 36,199 | 36,193 |
+| is_marker_for | 25,238 | 25,238 |
+| is_model_of | 23,319 | 23,319 |
+| is_ameliorated_model_of | 5,762 | 5,762 |
+| is_exacerbated_model_of | 3,418 | 3,418 |
+| is_not_implicated_in | 1,095 | 1,095 |
+| does_not_model | 520 | 520 |
+| is_not_marker_for | 28 | 28 |
+| is_not_ameliorated_model_of | 5 | 5 |
+
+Ten of eleven match exactly. `is_implicated_in` is 6 lower (0.017%) — curation data drift over the 16
+days since Chris's run, not a layout change. Negation handling (`does_not_model`, `is_not_*`) is
+carried over untouched.
+
+### wrn-1 acceptance case
+
+SCRUM-1953 comment 2026-05-18 item 3 listed three experimental annotations that had to appear for
+`WB:WBGene00006944`. All three now do, each on its own row at its own level:
+
+| Level | Subject | Association | Reference |
+|---|---|---|---|
+| Gene | `WB:WBGene00006944` wrn-1 | Gene Association `is_implicated_in` | PMID:15115755 |
+| Allele | `WB:WBVar00145506` gk99, wrn-1 as asserted gene | Allele Association `is_implicated_in` | PMID:20062519 |
+| Model | `WB:WBGenotype00000014` (genotype), wrn-1 \| mir-124 asserted | Model Association `is_model_of` | PMID:23075628 |
+
+Plus 8 via-orthology rows, all gene-level with model and allele columns blank — including the
+`wrn-1 is_implicated_via_orthology breast cancer` row based on `HGNC:12791` / `WRN (Hsa)` that Chris
+asked for. Alleles are never the subject of a via_orthology row.
+
+Both wrn-1 rows for `senile cataract` are genuinely distinct annotations (their UniqueIDs differ by a
+`susceptibility_to` qualifier), not a dedup failure.
+
+### Source URL
+
+0 malformed URLs out of 95,578 — no unsubstituted `[%s]`, no doubled prefix from the MGI / SGD / OMIM
+exception. Per-MOD shapes:
+
+```
+MGI     http://www.informatics.jax.org/allele/genoview/MGI:2166570
+SGD     https://www.yeastgenome.org/locus/SGD:S000000027/disease
+WB      https://www.wormbase.org/resources/disease/DOID:0050425
+FB      https://flybase.org/cgi-bin/cvreport.html?id=DOID:0014667
+ZFIN    https://zfin.org/DOID:0014667
+RGD     https://rgd.mcw.edu/rgdweb/ontology/annot.html?species=Rat&x=1&acc_id=DOID:0014667#annot
+HUMAN   https://rgd.mcw.edu/rgdweb/ontology/annot.html?species=Human&x=1&acc_id=DOID:0001816#annot
+```
+
+MGI and SGD resolve to an entity-specific page; the others resolve to the MOD's page for the disease
+term, because that is what their `dataProviderCrossReference` points at. Human annotations get RGD
+URLs because RGD provides them. Same behaviour as the gene-page download.
+
+### Other spot checks
+
+* Genetic Modifier IDs and Names: 9,540 rows, **0 misaligned** element counts.
+* Strain Background populated for SGD only (`SGD:S000203450` / `Sigma1278b`), as expected for a field
+  declared on `GeneDiseaseAnnotation` alone.
+* Notes: 34,091 `Note: ` + 691 `Summary: ` = 34,782, matching the column fill count exactly, so every
+  populated cell is labelled.
+* Experimental Conditions and Condition Modifiers split by relation type as specified; the 37 rows with
+  both populated are annotations that genuinely carry both kinds of condition relation.
+
+## Open questions for Chris
+
+1. **Symbol columns carry HTML markup.** Model Symbol, Allele Symbols and Gene Symbols use
+   `displayText`, which renders superscripts as markup — e.g. `Apc2<sup>g10</sup> Apc<sup>Q8</sup>`.
+   This matches both the pre-existing Disease TSV and the gene-page download, so it is left as-is, but
+   the plain-text `formatText` variant (`Apc2[g10]`) may read better in a TSV. Easy swap if wanted.
+2. **Source URL granularity.** For most MODs the cross reference points at the disease term page rather
+   than the annotation, so that is what the column contains (see above). If an annotation-level URL is
+   wanted, the cross reference would have to change upstream in curation.
+3. **UniqueID** is still the first column per the 2026-07-15 request; drop it before the public release.
+4. **Association placement** — confirm that putting the relation only at the annotation's own level
+   (exactly one of the three columns per row) is what you intended, rather than repeating it on every
+   level the row names.
+
+## Not addressed here
+
+`Date` is blank on 4.6% of rows. `primaryAnnotations[i]` carries no `dateUpdated`, only a sometimes-absent
+`dateCreated`; the generator falls back to the file-generation date for via-orthology rows only. This is
+inherited from SCRUM-1953 and is a curation-side indexing gap, not a column-layout issue.
+

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/config/FileGeneratorConfig.java
@@ -230,30 +230,52 @@ public enum FileGeneratorConfig {
 	 * DiseaseFileGenerator.customizeRows() expands each ES hit into N flattened
 	 * rows (one per primaryAnnotations element) for TSV; JSON_RAW writes the
 	 * consolidated doc verbatim. Every column is synthetic (`_*`) and populated
-	 * per-row from primaryAnnotations[i]. Columns whose ES source is not currently
-	 * indexed map to "_unavailable" (rendered as an empty cell).
+	 * per-row from primaryAnnotations[i]. The model, allele and gene columns each
+	 * name their own level of the annotation: the level matching the annotation's
+	 * type comes from its subject, the other levels from the inferred entity or the
+	 * asserted entities, and any level the annotation does not carry is left blank.
+	 * The three association columns follow the same rule, so exactly one of them is
+	 * populated per row — the level the annotation was curated at. UniqueID is not
+	 * part of the published layout; it is retained for curator verification and
+	 * comes out before the public release (SCRUM-1953).
 	 */
 	private static Map<String, String> diseaseFieldMap() {
 		Map<String, String> m = new LinkedHashMap<>();
 		m.put("UniqueID", "_uniqueId");
-		m.put("Taxon", "_taxon");
-		m.put("SpeciesName", "_speciesName");
-		m.put("DBobjectType", "_dbObjectType");
-		m.put("DBObjectID", "_dbObjectId");
-		m.put("DBObjectSymbol", "_dbObjectSymbol");
-		m.put("AssociationType", "_associationType");
-		m.put("DOID", "_doId");
-		m.put("DOtermName", "_doTermName");
-		m.put("WithOrtholog", "_withOrtholog");
-		m.put("InferredFromID", "_unavailable");
-		m.put("InferredFromSymbol", "_inferredFromSymbol");
-		m.put("ExperimentalCondition", "_unavailable");
-		m.put("Modifier", "_unavailable");
-		m.put("EvidenceCode", "_evidenceCode");
-		m.put("EvidenceCodeName", "_evidenceCodeName");
+		m.put("Taxon ID", "_taxon");
+		m.put("Species Name", "_speciesName");
+		m.put("Model ID", "_modelId");
+		m.put("Model Symbol", "_modelSymbol");
+		m.put("Model Type", "_modelType");
+		m.put("Model Association", "_modelAssociation");
+		m.put("Allele IDs", "_alleleIds");
+		m.put("Allele Symbols", "_alleleSymbols");
+		m.put("Allele Association", "_alleleAssociation");
+		m.put("Gene IDs", "_geneIds");
+		m.put("Gene Symbols", "_geneSymbols");
+		m.put("Gene Association", "_geneAssociation");
+		m.put("Disease Qualifier", "_diseaseQualifier");
+		m.put("Disease ID", "_doId");
+		m.put("Disease Name", "_doTermName");
+		m.put("Evidence Code", "_evidenceCode");
+		m.put("Evidence Code Abbreviation", "_evidenceCodeAbbreviation");
+		m.put("Evidence Code Name", "_evidenceCodeName");
+		m.put("Experimental Conditions", "_experimentalConditions");
+		m.put("Condition Modifiers", "_conditionModifiers");
+		m.put("Genetic Modifier Relation", "_geneticModifierRelation");
+		m.put("Genetic Modifier IDs", "_geneticModifierIds");
+		m.put("Genetic Modifier Names", "_geneticModifierNames");
+		m.put("Strain Background ID", "_strainBackgroundId");
+		m.put("Strain Background Name", "_strainBackgroundName");
+		m.put("Genetic Sex", "_geneticSex");
+		m.put("Notes", "_notes");
+		m.put("Annotation Type", "_annotationType");
+		m.put("Based On ID", "_basedOnId");
+		m.put("Based On Symbol", "_basedOnSymbol");
+		m.put("Source", "_source");
+		m.put("Source URL", "_sourceUrl");
 		m.put("Reference", "_reference");
 		m.put("Date", "_date");
-		m.put("Source", "_source");
 		return m;
 	}
 

--- a/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
+++ b/agr_file_generator/src/main/java/org/alliancegenome/filegenerator/generators/DiseaseFileGenerator.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -25,6 +26,17 @@ public class DiseaseFileGenerator extends FileGenerator {
 			LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE); // YYYYMMDD
 
 	private static final String LINKML_README_URL = "https://alliance-genome.github.io/agr_curation_schema/DiseaseAnnotation/";
+
+	// has_condition and induced_by establish the setup the disease phenotype was observed under; ameliorated_by and exacerbated_by qualify an already-established annotation. The two sets are reported in separate columns per Chris Grove's SCRUM-6274 spec, and any other relation type is reported in neither.
+	private static final Set<String> EXPERIMENTAL_CONDITION_RELATIONS = Set.of("has_condition", "induced_by");
+
+	private static final Set<String> CONDITION_MODIFIER_RELATIONS = Set.of("ameliorated_by", "exacerbated_by");
+
+	// MGI, SGD and OMIM url templates already carry the prefix (e.g. ".../allele/MGI:[%s]") while their referencedCurie is prefixed too, so the template's copy is dropped before substitution to avoid doubling it. Mirrors DiseaseAnnotationToTdfTranslator, which builds the same Source URL column for the gene-page disease download.
+	private static final Set<String> URL_PREFIX_IN_TEMPLATE = Set.of("MGI", "SGD", "OMIM");
+
+	// Note types the download reports, each with the label the curators expect in the Notes column. Any other note type is omitted rather than emitted unlabelled.
+	private static final Map<String, String> NOTE_TYPE_LABELS = Map.of("disease_note", "Note: ", "disease_summary", "Summary: ");
 
 	// Same primaryAnnotation appears across many consolidated docs (gene/allele/agm rollups + via_orthology fan-out). Dedup by the canonical Annotation.uniqueId so each annotation is emitted once per run. dispatch() runs from the parallel scroll pool, so this must be a concurrent set.
 	private final Set<String> seenUniqueIds = ConcurrentHashMap.newKeySet();
@@ -97,73 +109,77 @@ public class DiseaseFileGenerator extends FileGenerator {
 
 			row.put("_uniqueId", uniqueId);
 
+			// Exactly one of the three association columns is populated per row — the one naming the level the annotation was actually curated at. The other two levels are only ever reached by inference (inferred/asserted entities), so asserting a relation for them would invent an annotation that is not in the persistent store.
+			String associationType = resolveAssociationType(pa);
+
 			if (isViaOrthology) {
 				// A via_orthology annotation lives inside the ortholog GENE's consolidated doc, but its diseaseAnnotationSubject still points at the source entity (allele/AGM/source gene). The row must be keyed on the enclosing doc's gene subject, so source every subject column from the top-level subject.
+				// Per SCRUM-6274 these predicted annotations exist at the gene level only, so the model and allele columns stay blank.
 				row.put("_taxon", JsonPath.resolveString(customizedHit, "subject.taxon.curie"));
 				row.put("_speciesName", JsonPath.resolveString(customizedHit, "subject.taxon.species.fullName"));
-				row.put("_dbObjectType", "gene");
-				row.put("_dbObjectId", JsonPath.resolveString(customizedHit, "subject.primaryExternalId"));
-				row.put("_dbObjectSymbol", JsonPath.resolveString(customizedHit, "subject.geneSymbol.displayText"));
+
+				row.put("_modelId", "");
+				row.put("_modelSymbol", "");
+				row.put("_modelType", "");
+				row.put("_modelAssociation", "");
+
+				row.put("_alleleIds", "");
+				row.put("_alleleSymbols", "");
+				row.put("_alleleAssociation", "");
+
+				row.put("_geneIds", JsonPath.resolveString(customizedHit, "subject.primaryExternalId"));
+				row.put("_geneSymbols", JsonPath.resolveString(customizedHit, "subject.geneSymbol.displayText"));
+				row.put("_geneAssociation", associationType);
 			} else {
 				row.put("_taxon", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.curie"));
 				row.put("_speciesName", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.species.fullName"));
 
+				// DiseaseAnnotation declares no generic subject field, so the Jackson type discriminator is the only way to tell whether diseaseAnnotationSubject is a gene, an allele or a model.
 				String paType = JsonPath.resolveString(pa, "type");
-				String dbObjectType;
-				if ("GeneDiseaseAnnotation".equals(paType)) {
-					dbObjectType = "gene";
-				} else if ("AlleleDiseaseAnnotation".equals(paType)) {
-					dbObjectType = "allele";
-				} else if ("AGMDiseaseAnnotation".equals(paType)) {
-					dbObjectType = "affected_genomic_model";
-				} else {
-					dbObjectType = paType.replace("DiseaseAnnotation", "").toLowerCase();
-				}
-				row.put("_dbObjectType", dbObjectType);
 
-				row.put("_dbObjectId", JsonPath.resolveString(pa, "diseaseAnnotationSubject.primaryExternalId"));
+				// Only an AGM annotation names a model at all — there is no inferred or asserted AGM to fall back on — so a gene or allele annotation leaves the model columns blank instead of repeating the subject under the wrong heading.
+				boolean subjectIsModel = "AGMDiseaseAnnotation".equals(paType);
+				row.put("_modelId", subjectIsModel ? JsonPath.resolveString(pa, "diseaseAnnotationSubject.primaryExternalId") : "");
+				row.put("_modelSymbol", subjectIsModel ? resolveAgmSymbol(pa, "diseaseAnnotationSubject") : "");
+				row.put("_modelType", subjectIsModel ? JsonPath.resolveString(pa, "diseaseAnnotationSubject.subtype.name") : "");
+				row.put("_modelAssociation", subjectIsModel ? associationType : "");
 
-				String subjectType = JsonPath.resolveString(pa, "diseaseAnnotationSubject.type");
-				String symbol;
-				if ("Gene".equals(subjectType)) {
-					symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.geneSymbol.displayText");
-				} else if ("Allele".equals(subjectType)) {
-					symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.alleleSymbol.displayText");
-				} else if ("AffectedGenomicModel".equals(subjectType)) {
-					symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.agmFullName.displayText");
-					if (symbol.isEmpty()) {
-						symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.name");
-					}
-				} else {
-					symbol = JsonPath.resolveString(pa, "diseaseAnnotationSubject.name");
-				}
-				row.put("_dbObjectSymbol", symbol);
+				boolean subjectIsAllele = "AlleleDiseaseAnnotation".equals(paType);
+				row.put("_alleleIds", resolveEntityField(pa, subjectIsAllele, "inferredAllele", "assertedAlleles", "primaryExternalId"));
+				row.put("_alleleSymbols", resolveEntityField(pa, subjectIsAllele, "inferredAllele", "assertedAlleles", "alleleSymbol.displayText"));
+				row.put("_alleleAssociation", subjectIsAllele ? associationType : "");
+
+				boolean subjectIsGene = "GeneDiseaseAnnotation".equals(paType);
+				row.put("_geneIds", resolveEntityField(pa, subjectIsGene, "inferredGene", "assertedGenes", "primaryExternalId"));
+				row.put("_geneSymbols", resolveEntityField(pa, subjectIsGene, "inferredGene", "assertedGenes", "geneSymbol.displayText"));
+				row.put("_geneAssociation", subjectIsGene ? associationType : "");
 			}
 
-			row.put("_associationType", resolveAssociationType(pa));
+			row.put("_diseaseQualifier", joinDiseaseQualifiers(pa));
 			row.put("_doId", JsonPath.resolveString(pa, "diseaseAnnotationObject.curie"));
 			row.put("_doTermName", JsonPath.resolveString(pa, "diseaseAnnotationObject.name"));
 
-			row.put("_withOrtholog", joinWithOrthologs(pa));
-			row.put("_inferredFromSymbol", joinBasedOnSymbols(pa));
+			row.put("_evidenceCode", joinEvidenceCodes(pa, "curie"));
+			row.put("_evidenceCodeAbbreviation", joinEvidenceCodes(pa, "abbreviation"));
+			row.put("_evidenceCodeName", joinEvidenceCodes(pa, "name"));
 
-			JsonNode evCodes = pa.path("evidenceCodes");
-			List<String> curies = new ArrayList<>();
-			List<String> names = new ArrayList<>();
-			if (evCodes.isArray()) {
-				for (JsonNode ec : evCodes) {
-					String c = ec.path("curie").asText("");
-					String n = ec.path("name").asText("");
-					if (!c.isEmpty()) {
-						curies.add(c);
-					}
-					if (!n.isEmpty()) {
-						names.add(n);
-					}
-				}
-			}
-			row.put("_evidenceCode", String.join("|", curies));
-			row.put("_evidenceCodeName", String.join("|", names));
+			row.put("_experimentalConditions", joinConditionSummaries(pa, EXPERIMENTAL_CONDITION_RELATIONS));
+			row.put("_conditionModifiers", joinConditionSummaries(pa, CONDITION_MODIFIER_RELATIONS));
+
+			row.put("_geneticModifierRelation", JsonPath.resolveString(pa, "diseaseGeneticModifierRelation.name"));
+			row.put("_geneticModifierIds", joinGeneticModifiers(pa, false));
+			row.put("_geneticModifierNames", joinGeneticModifiers(pa, true));
+
+			// sgdStrainBackground is declared on GeneDiseaseAnnotation only, so allele and AGM rows leave these columns blank.
+			row.put("_strainBackgroundId", JsonPath.resolveString(pa, "sgdStrainBackground.primaryExternalId"));
+			row.put("_strainBackgroundName", resolveAgmSymbol(pa, "sgdStrainBackground"));
+
+			row.put("_geneticSex", JsonPath.resolveString(pa, "geneticSex.name"));
+			row.put("_notes", joinNotes(pa));
+			row.put("_annotationType", JsonPath.resolveString(pa, "annotationType.name"));
+
+			row.put("_basedOnId", joinBasedOnIds(pa));
+			row.put("_basedOnSymbol", joinBasedOnSymbols(pa));
 
 			// Per-annotation reference is a single evidenceItem (not a references[] array). Prefer the PMID-style referenceID over the AGRKB curie, matching how the parent-rooted code used to choose references[0].referenceID first.
 			String reference = JsonPath.resolveString(pa, "evidenceItem.referenceID");
@@ -191,6 +207,7 @@ public class DiseaseFileGenerator extends FileGenerator {
 			} else {
 				row.put("_source", JsonPath.resolveString(pa, "diseaseAnnotationSubject.taxon.species.displayName"));
 			}
+			row.put("_sourceUrl", buildSourceUrl(pa));
 
 			rows.add(row);
 		}
@@ -208,7 +225,163 @@ public class DiseaseFileGenerator extends FileGenerator {
 		return relationName.replaceFirst("_", "_not_");
 	}
 
-	private static String joinWithOrthologs(JsonNode pa) {
+	/**
+	 * Resolves one field of the allele or gene column pair. The annotation's own subject wins when the annotation is of that entity's type — a GeneDiseaseAnnotation names its gene directly — then the curated inferred entity, then the asserted entities pipe-joined.
+	 * Which of the three sources wins is decided on primaryExternalId alone, so the IDs and the symbols always describe the same entities in the same order.
+	 */
+	private static String resolveEntityField(JsonNode pa, boolean subjectIsEntity, String inferredPath, String assertedPath, String field) {
+		if (subjectIsEntity) {
+			return JsonPath.resolveString(pa, "diseaseAnnotationSubject." + field);
+		}
+		if (!JsonPath.resolveString(pa, inferredPath + ".primaryExternalId").isEmpty()) {
+			return JsonPath.resolveString(pa, inferredPath + "." + field);
+		}
+		JsonNode asserted = pa.path(assertedPath);
+		if (!asserted.isArray()) {
+			return "";
+		}
+		LinkedHashSet<String> values = new LinkedHashSet<>();
+		for (JsonNode entity : asserted) {
+			String value = JsonPath.resolveString(entity, field);
+			if (!value.isEmpty()) {
+				values.add(value);
+			}
+		}
+		return String.join("|", values);
+	}
+
+	/** agmFullName is an optional slot, so fall back to the model's name before giving up and leaving the cell blank. */
+	private static String resolveAgmSymbol(JsonNode pa, String agmPath) {
+		String symbol = JsonPath.resolveString(pa, agmPath + ".agmFullName.displayText");
+		if (symbol.isEmpty()) {
+			symbol = JsonPath.resolveString(pa, agmPath + ".name");
+		}
+		return symbol;
+	}
+
+	private static String joinDiseaseQualifiers(JsonNode pa) {
+		JsonNode qualifiers = pa.path("diseaseQualifiers");
+		if (!qualifiers.isArray()) {
+			return "";
+		}
+		LinkedHashSet<String> names = new LinkedHashSet<>();
+		for (JsonNode qualifier : qualifiers) {
+			String name = qualifier.path("name").asText("");
+			if (!name.isEmpty()) {
+				names.add(name.replace("_", " "));
+			}
+		}
+		return String.join("|", names);
+	}
+
+	private static String joinEvidenceCodes(JsonNode pa, String field) {
+		JsonNode evidenceCodes = pa.path("evidenceCodes");
+		if (!evidenceCodes.isArray()) {
+			return "";
+		}
+		List<String> values = new ArrayList<>();
+		for (JsonNode ec : evidenceCodes) {
+			String value = ec.path(field).asText("");
+			if (!value.isEmpty()) {
+				values.add(value);
+			}
+		}
+		return String.join("|", values);
+	}
+
+	private static String joinConditionSummaries(JsonNode pa, Set<String> relationTypes) {
+		JsonNode relations = pa.path("conditionRelations");
+		if (!relations.isArray()) {
+			return "";
+		}
+		LinkedHashSet<String> summaries = new LinkedHashSet<>();
+		for (JsonNode relation : relations) {
+			if (!relationTypes.contains(relation.path("conditionRelationType").path("name").asText(""))) {
+				continue;
+			}
+			JsonNode conditions = relation.path("conditions");
+			if (!conditions.isArray()) {
+				continue;
+			}
+			for (JsonNode condition : conditions) {
+				String summary = condition.path("conditionSummary").asText("");
+				if (!summary.isEmpty()) {
+					summaries.add(summary);
+				}
+			}
+		}
+		return String.join("|", summaries);
+	}
+
+	/**
+	 * Genetic modifiers are split across three typed arrays in the annotation. They are walked alleles-then-genes-then-AGMs so the IDs and the names line up position for position, matching the order DiseaseAnnotationToTdfTranslator uses for the same two columns on the gene page download.
+	 */
+	private static String joinGeneticModifiers(JsonNode pa, boolean wantName) {
+		List<String> values = new ArrayList<>();
+		for (String arrayPath : List.of("diseaseGeneticModifierAlleles", "diseaseGeneticModifierGenes", "diseaseGeneticModifierAgms")) {
+			JsonNode modifiers = pa.path(arrayPath);
+			if (!modifiers.isArray()) {
+				continue;
+			}
+			for (JsonNode modifier : modifiers) {
+				String value = wantName ? resolveEntityName(modifier) : modifier.path("primaryExternalId").asText("");
+				if (!value.isEmpty()) {
+					values.add(value);
+				}
+			}
+		}
+		return String.join("|", values);
+	}
+
+	/** Names a modifier entity by whichever symbol slot its type carries — the modifier arrays hold alleles, genes and models side by side. */
+	private static String resolveEntityName(JsonNode entity) {
+		String name = JsonPath.resolveString(entity, "alleleSymbol.displayText");
+		if (name.isEmpty()) {
+			name = JsonPath.resolveString(entity, "geneSymbol.displayText");
+		}
+		if (name.isEmpty()) {
+			name = JsonPath.resolveString(entity, "agmFullName.displayText");
+		}
+		if (name.isEmpty()) {
+			name = JsonPath.resolveString(entity, "name");
+		}
+		return name;
+	}
+
+	private static String joinNotes(JsonNode pa) {
+		JsonNode notes = pa.path("relatedNotes");
+		if (!notes.isArray()) {
+			return "";
+		}
+		LinkedHashSet<String> rendered = new LinkedHashSet<>();
+		for (JsonNode note : notes) {
+			String label = NOTE_TYPE_LABELS.get(note.path("noteType").path("name").asText(""));
+			String freeText = note.path("freeText").asText("");
+			if (label == null || freeText.isEmpty()) {
+				continue;
+			}
+			rendered.add(label + freeText);
+		}
+		return String.join("|", rendered);
+	}
+
+	/**
+	 * The source MOD's own page for this annotation, built from the annotation's data-provider cross reference. Blank when the annotation carries no cross reference (every via_orthology annotation, whose provider is the Alliance itself).
+	 */
+	private static String buildSourceUrl(JsonNode pa) {
+		String curie = JsonPath.resolveString(pa, "dataProviderCrossReference.referencedCurie");
+		String urlTemplate = JsonPath.resolveString(pa, "dataProviderCrossReference.resourceDescriptorPage.urlTemplate");
+		if (curie.isEmpty() || urlTemplate.isEmpty()) {
+			return "";
+		}
+		String provider = JsonPath.resolveString(pa, "dataProvider.abbreviation");
+		if (URL_PREFIX_IN_TEMPLATE.contains(provider)) {
+			urlTemplate = urlTemplate.replace(provider + ":", "");
+		}
+		return urlTemplate.replace("[%s]", curie);
+	}
+
+	private static String joinBasedOnIds(JsonNode pa) {
 		JsonNode with = pa.path("with");
 		if (!with.isArray()) {
 			return "";


### PR DESCRIPTION
Rearranges the Disease download **TSV** columns from the legacy FMS subject-agnostic layout (`DBobjectType` / `DBObjectID` / `DBObjectSymbol` / `AssociationType`) to the model-centric layout Chris Grove proposed in SCRUM-1953 (comment 2026-05-18). The Disease file is the only disease download not anchored to a single subject type, so the model, allele and gene levels each get their own ID / symbol / association columns.

JSON_RAW output is untouched — it writes the consolidated ES doc verbatim and never consults the field map.

Jira: https://agr-jira.atlassian.net/browse/SCRUM-6274

## Changes

- `config/FileGeneratorConfig.java` — `diseaseFieldMap()` replaced with the 35-column layout (the ticket's 34 plus `UniqueID` first, kept for curator verification per SCRUM-1953 comment 2026-07-15).
- `generators/DiseaseFileGenerator.java` — `customizeRows()` emits the new synthetic fields, plus helpers for disease qualifiers, the evidence-code triple, condition splitting, genetic modifiers, notes and source URL. `joinWithOrthologs` renamed `joinBasedOnIds`; `joinBasedOnSymbols` (with species abbreviation, SCRUM-1953) moves to its own `Based On Symbol` column.
- `SCRUM-6274.md` — column mapping, population rules, verification results, open questions.

The four `_unavailable` placeholders from SCRUM-1953 (`InferredFromID`, `InferredFromSymbol`, `ExperimentalCondition`, `Modifier`) all become real populated columns, so the placeholder mechanism is gone from this generator.

## Notable decisions

New columns follow `DiseaseAnnotationToTdfTranslator` (agr_api), which already builds these same columns for the curator-approved gene / allele / model page downloads. Two deliberate departures:

1. **Conditions are computed per annotation, not per doc.** The translator overwrites its per-annotation values with the doc-level `experimentalConditionsAggregated` / `conditionModifierAggregated` rollups. Those aggregate across every annotation in a consolidated doc, which would smear conditions across unrelated rows now that each row is one annotation.
2. **Association sits only at the annotation's own level**, so exactly one of the three association columns is populated per row. The other two levels are only reached by inference, so asserting a relation for them would invent an annotation that is not in the persistent store.

## Verification

Full run against stage ES (`site_index`, 489,486 docs) → 484,442 TSV rows COMBINED, 19m08s. Checkstyle and compile clean.

- All rows have exactly **35 columns**; header order matches the ticket; every column populated on some rows.
- **Association invariant holds exactly**: Model 33,024 + Allele 5,663 + Gene 445,755 = 484,442.
- **Association totals match Chris's approved SCRUM-1953 counts** on 10 of 11 relations exactly (`is_implicated_via_orthology` 240,711; `is_marker_via_orthology` 148,153; `is_model_of` 23,319; `does_not_model` 520; …). `is_implicated_in` is 6 lower (0.017%) from 16 days of curation drift.
- **wrn-1 acceptance case passes.** All three experimental annotations Chris listed as missing now appear, each at its own level:

  | Level | Subject | Association | Reference |
  |---|---|---|---|
  | Gene | `WB:WBGene00006944` wrn-1 | Gene Association `is_implicated_in` | PMID:15115755 |
  | Allele | `WB:WBVar00145506` gk99, wrn-1 asserted | Allele Association `is_implicated_in` | PMID:20062519 |
  | Model | `WB:WBGenotype00000014` genotype, wrn-1 \| mir-124 asserted | Model Association `is_model_of` | PMID:23075628 |

  Plus 8 via-orthology rows, all gene-level with model and allele blank, including `wrn-1 is_implicated_via_orthology breast cancer` based on `HGNC:12791` / `WRN (Hsa)`. Alleles are never the subject of a via_orthology row.
- Source URL: 0 malformed of 95,578 — no unsubstituted `[%s]`, no doubled prefix from the MGI / SGD / OMIM exception.
- Genetic Modifier IDs vs Names: 9,540 rows, 0 misaligned element counts.
- Per-MOD files stay species-pure (WB all `NCBITaxon:6239`, SGD all `NCBITaxon:559292` with no `S288C` suffix).
- Strain Background populates for SGD only, as expected for a field declared on `GeneDiseaseAnnotation` alone.

## Open questions for curators

Written up in `SCRUM-6274.md`:

1. **Symbol columns carry HTML markup** — `displayText` renders superscripts as `Apc2<sup>g10</sup>`. Matches both the previous Disease TSV and the gene-page download, so left as-is, but `formatText` (`Apc2[g10]`) may read better in a TSV.
2. **Source URL granularity** — for most MODs the cross reference points at the disease term page, not the annotation, so that is what the column holds. An annotation-level URL would need an upstream curation change.
3. **UniqueID** is still the first column; drop before public release.
4. **Association placement** — confirm one-column-per-row is intended rather than repeating the relation on every level the row names.

`Date` is blank on 4.6% of rows — inherited from SCRUM-1953 (`primaryAnnotations[i]` carries no `dateUpdated`), a curation-side indexing gap, not a layout issue.